### PR TITLE
Fix import name.

### DIFF
--- a/src/bin/csp.rs
+++ b/src/bin/csp.rs
@@ -3,7 +3,7 @@
 //
 // Author: Atsushi Sakai(@Atsushi_twi)
 //         Ryohei Sasaki(@rsasaki0109)
-use RustRobotics::cubic_spline_planner;
+use rust_robotics::cubic_spline_planner;
 
 use plotlib::page::Page;
 use plotlib::repr::Plot;

--- a/src/bin/lqr_steer_control.rs
+++ b/src/bin/lqr_steer_control.rs
@@ -6,7 +6,7 @@
 //
 extern crate nalgebra;
 
-use RustRobotics::cubic_spline_planner;
+use rust_robotics::cubic_spline_planner;
 
 use plotlib::page::Page;
 use plotlib::repr::Plot;

--- a/src/bin/stanley_controller.rs
+++ b/src/bin/stanley_controller.rs
@@ -7,7 +7,7 @@
 //     - [Stanley: The robot that won the DARPA grand challenge](http://isl.ecst.csuchico.edu/DOCS/darpa2005/DARPA%202005%20Stanley.pdf)
 //    - [Autonomous Automobile Path Tracking](https://www.ri.cmu.edu/pub_files/2009/2/Automatic_Steering_Methods_for_Autonomous_Automobile_Path_Tracking.pdf)
 
-use RustRobotics::cubic_spline_planner;
+use rust_robotics::cubic_spline_planner;
 
 use plotlib::page::Page;
 use plotlib::repr::Plot;


### PR DESCRIPTION
Hi there,

Thanks for creating this amazing repo. I found the repo failed to compile on `use RustRobotics::cubic_spline_planner;`. I suggest this issue is due to the change of repo name recently. I just replaced the above line with `use rust_robotics::cubic_spline_planner;` and it is all good now.

Best,
Levi