### PR TITLE
Stabilize all-targets integration and add planning modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, feat/* ]
+    branches: [ main, dev/*, feat/*, task/* ]
   pull_request:
     branches: [ main ]
 
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  all-targets:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -29,18 +29,18 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}
 
-    - name: Build
-      run: cargo build --lib --verbose
+    - name: Build all targets
+      run: cargo build --all-targets --verbose
 
-    - name: Run tests
-      run: cargo test --lib -- --skip slam
+    - name: Run tests for all targets
+      run: cargo test --all-targets
 
     - name: Clippy (warnings only)
-      run: cargo clippy --lib -- -W clippy::all
+      run: cargo clippy --all-targets -- -W clippy::all
       continue-on-error: true
 
     - name: Check formatting
-      run: cargo fmt -- --check
+      run: cargo fmt --all -- --check
       continue-on-error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ path = "src/bin/stanley_controller.rs"
 
 [[bin]]
 name = "move_to_pose"
-path = "src/path_tracking/move_to_pose.rs"
+path = "src/bin/move_to_pose.rs"
 
 [[bin]]
 name = "model_predictive_trajectory_generator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,15 +32,31 @@ path = "examples/path_planning/jps.rs"
 name = "state_lattice"
 path = "examples/path_planning/state_lattice.rs"
 
+[[bin]]
+name = "ekf"
+path = "src/bin/ekf.rs"
+
+[[bin]]
+name = "dwa"
+path = "src/bin/dwa.rs"
+
 # Legacy binaries (will be migrated to examples)
 
 [[bin]]
+name = "ndt"
+path = "src/mapping/ndt.rs"
+
+[[bin]]
 name = "rrt"
-path = "src/path_planning/rrt.rs"
+path = "src/bin/rrt.rs"
+
+[[bin]]
+name = "dijkstra"
+path = "src/path_planning/dijkstra.rs"
 
 [[bin]]
 name = "particle_filter"
-path = "src/localization/particle_filter.rs"
+path = "src/bin/particle_filter.rs"
 
 [[bin]]
 name = "rrt_star"
@@ -59,6 +75,10 @@ name = "quintic_polynomials"
 path = "src/path_planning/quintic_polynomials.rs"
 
 [[bin]]
+name = "csp"
+path = "src/path_planning/csp.rs"
+
+[[bin]]
 name = "cubic_spline"
 path = "src/path_planning/cubic_spline_planner.rs"
 
@@ -75,20 +95,28 @@ name = "bezier_planning"
 path = "src/path_planning/bezier_path_planning.rs"
 
 [[bin]]
+name = "bezier_path"
+path = "src/path_planning/bezier_path.rs"
+
+[[bin]]
 name = "lqr_steer_control"
-path = "src/path_tracking/lqr_steer_control.rs"
+path = "src/bin/lqr_steer_control.rs"
 
 [[bin]]
 name = "pure_pursuit"
-path = "src/path_tracking/pure_pursuit.rs"
+path = "src/bin/pure_pursuit.rs"
 
 [[bin]]
 name = "stanley_controller"
-path = "src/path_tracking/stanley_controller.rs"
+path = "src/bin/stanley_controller.rs"
 
 [[bin]]
 name = "move_to_pose"
 path = "src/path_tracking/move_to_pose.rs"
+
+[[bin]]
+name = "model_predictive_trajectory_generator"
+path = "src/path_tracking/model_predictive_trajectory_generator.rs"
 
 [[bin]]
 name = "inverted_pendulum_lqr"
@@ -112,7 +140,7 @@ path = "src/mission_planning/state_machine.rs"
 
 [[bin]]
 name = "unscented_kalman_filter"
-path = "src/localization/unscented_kalman_filter.rs"
+path = "src/bin/unscented_kalman_filter.rs"
 
 [[bin]]
 name = "histogram_filter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ path = "src/slam/icp_matching.rs"
 
 [[bin]]
 name = "state_machine"
-path = "src/mission_planning/state_machine.rs"
+path = "src/bin/state_machine.rs"
 
 [[bin]]
 name = "unscented_kalman_filter"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cargo build
 
 Run (Example)
 ```
-cargo run --bin a_star
+cargo run --example a_star
 cargo run --bin rrt
 cargo run --bin inverted_pendulum_lqr
 cargo run --bin two_joint_arm_control
@@ -73,7 +73,7 @@ cargo run --bin two_joint_arm_control
 
 Red:GPS, Brue:Ground Truth, Green:EKF, Yellow:Dead Reckoning
 
-- [src](https://github.com/rsasaki0109/RustRobotics/blob/master/src/bin/ekf.rs)
+- [src](./src/bin/ekf.rs)
 
 ```
 cargo run --bin ekf
@@ -251,7 +251,7 @@ Blue: Start, Red: Goal, Green: Path
 - [src](./src/path_planning/bezier_path_planning.rs)
 
 ```
-cargo run --bin bezier_path_planning
+cargo run --bin bezier_planning
 ```
 
 ## Cubic Spline
@@ -387,7 +387,7 @@ Blue: Start, Red: Goal, Green: Path
 - [src](./src/path_planning/reeds_shepp_path.rs)
 
 ```
-cargo run --bin reeds_shepp_path
+cargo run --bin reeds_shepp
 ```
 
 ## PRM (Probabilistic Road-Map)
@@ -565,5 +565,4 @@ Finite state machine for robot behavior management with states, transitions, gua
 ```
 cargo run --bin state_machine
 ```
-
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ cargo run --bin two_joint_arm_control
    * [Aerial Navigation](#aerial-navigation)
       * [3D Grid A*](#3d-grid-a)
    * [Mission Planning](#mission-planning)
+      * [Behavior Tree](#behavior-tree)
       * [State Machine](#state-machine)
 
 # Localization
@@ -569,6 +570,16 @@ cargo run --bin grid_a_star_3d
 ```
 
 # Mission Planning
+
+## Behavior Tree
+
+Behavior tree runtime for mission-level decision making with sequence, selector, condition, and action nodes backed by a shared blackboard.
+
+- [src](./src/mission_planning/behavior_tree.rs)
+
+```
+cargo run --bin behavior_tree
+```
 
 ## State Machine
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ cargo run --bin two_joint_arm_control
       * [LQR Control](#lqr-control)
    * [Arm Navigation](#arm-navigation)
       * [Two Joint Arm Control](#two-joint-arm-control)
+   * [Aerial Navigation](#aerial-navigation)
+      * [3D Grid A*](#3d-grid-a)
+   * [Mission Planning](#mission-planning)
+      * [State Machine](#state-machine)
 
 # Localization
 ## Extended Kalman Filter Localization
@@ -552,6 +556,18 @@ Black: Arm links, Red: Joints (shoulder, elbow, end effector), Green: Target pos
 cargo run --bin two_joint_arm_control
 ```
 
+# Aerial Navigation
+
+## 3D Grid A*
+
+Bounded 3D voxel-grid planning for aerial robots. The planner supports 6-connected or 26-connected motion and returns a collision-free waypoint sequence.
+
+- [src](./src/aerial_navigation/grid_a_star_3d.rs)
+
+```
+cargo run --bin grid_a_star_3d
+```
+
 # Mission Planning
 
 ## State Machine
@@ -565,4 +581,3 @@ Finite state machine for robot behavior management with states, transitions, gua
 ```
 cargo run --bin state_machine
 ```
-

--- a/examples/path_planning/a_star.rs
+++ b/examples/path_planning/a_star.rs
@@ -4,7 +4,7 @@
 
 use rust_robotics::common::{PathPlanner, Point2D};
 use rust_robotics::path_planning::a_star::{AStarConfig, AStarPlanner};
-use rust_robotics::utils::{colors, PathStyle, PointStyle, Visualizer};
+use rust_robotics::utils::{PathStyle, Visualizer};
 
 fn main() {
     println!("A* path planning start!!");

--- a/examples/path_planning/a_star.rs
+++ b/examples/path_planning/a_star.rs
@@ -2,9 +2,9 @@
 //!
 //! Demonstrates the A* path planning algorithm on a simple grid with obstacles.
 
-use rust_robotics::path_planning::a_star::{AStarPlanner, AStarConfig};
-use rust_robotics::common::{Point2D, PathPlanner};
-use rust_robotics::utils::{Visualizer, PathStyle, PointStyle, colors};
+use rust_robotics::common::{PathPlanner, Point2D};
+use rust_robotics::path_planning::a_star::{AStarConfig, AStarPlanner};
+use rust_robotics::utils::{colors, PathStyle, PointStyle, Visualizer};
 
 fn main() {
     println!("A* path planning start!!");
@@ -22,10 +22,14 @@ fn main() {
     let mut oy = Vec::new();
 
     for i in 0..11 {
-        ox.push(i as f64); oy.push(0.0);
-        ox.push(i as f64); oy.push(10.0);
-        ox.push(0.0); oy.push(i as f64);
-        ox.push(10.0); oy.push(i as f64);
+        ox.push(i as f64);
+        oy.push(0.0);
+        ox.push(i as f64);
+        oy.push(10.0);
+        ox.push(0.0);
+        oy.push(i as f64);
+        ox.push(10.0);
+        oy.push(i as f64);
     }
 
     // Add internal obstacle

--- a/examples/path_planning/jps.rs
+++ b/examples/path_planning/jps.rs
@@ -155,7 +155,8 @@ fn generate_svg(
     ));
     svg.push_str(&format!(
         "<text x=\"{:.1}\" y=\"{:.1}\" class=\"legend\">JPS Path</text>\n",
-        legend_x + 50.0, legend_y + 22.0
+        legend_x + 50.0,
+        legend_y + 22.0
     ));
     svg.push_str(&format!(
         "<line x1=\"{:.1}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" stroke=\"#0066CC\" stroke-width=\"2\" stroke-opacity=\"0.5\"/>\n",
@@ -163,7 +164,8 @@ fn generate_svg(
     ));
     svg.push_str(&format!(
         "<text x=\"{:.1}\" y=\"{:.1}\" class=\"legend\">A* Path</text>\n",
-        legend_x + 50.0, legend_y + 42.0
+        legend_x + 50.0,
+        legend_y + 42.0
     ));
 
     svg.push_str("</svg>\n");

--- a/examples/path_planning/jps.rs
+++ b/examples/path_planning/jps.rs
@@ -265,7 +265,9 @@ fn main() {
             let svg = generate_svg(&ox, &oy, jps_path, a_star_path, start, goal);
 
             // Use absolute path from CARGO_MANIFEST_DIR
-            let abs_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            let abs_path = std::env::var_os("CARGO_MANIFEST_DIR")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| std::path::PathBuf::from("."))
                 .join("img/path_planning/jps_result.svg");
 
             match File::create(&abs_path) {

--- a/examples/path_planning/state_lattice.rs
+++ b/examples/path_planning/state_lattice.rs
@@ -136,11 +136,13 @@ fn test_lane_sampling() {
     println!("Test 3: Lane-based Sampling");
     println!("----------------------------");
 
-    let mut config = StateLatticeConfig::default();
-    config.lane_width = 3.5;
-    config.vehicle_width = 1.8;
-    config.lane_heading = 0.0;
-    config.d = 30.0;
+    let config = StateLatticeConfig {
+        lane_width: 3.5,
+        vehicle_width: 1.8,
+        lane_heading: 0.0,
+        d: 30.0,
+        ..StateLatticeConfig::default()
+    };
 
     let planner = StateLattice::new(config);
     let states = planner.calc_lane_states();

--- a/examples/path_planning/state_lattice.rs
+++ b/examples/path_planning/state_lattice.rs
@@ -6,11 +6,9 @@
 //! 2. Biased polar sampling (toward a goal direction)
 //! 3. Lane-based sampling (for structured environments)
 
-use rust_robotics::path_planning::state_lattice::{
-    StateLattice, StateLatticeConfig,
-};
 use rust_robotics::common::Point2D;
-use rust_robotics::utils::{Visualizer, PathStyle, PointStyle, colors};
+use rust_robotics::path_planning::state_lattice::{StateLattice, StateLatticeConfig};
+use rust_robotics::utils::{colors, PathStyle, PointStyle, Visualizer};
 
 fn main() {
     println!("State Lattice Path Planning Example");
@@ -58,7 +56,9 @@ fn test_uniform_polar_sampling() {
     for state in &states {
         vis.plot_point(
             Point2D::new(state.x, state.y),
-            &PointStyle::new(colors::BLUE, "").with_size(1.0).with_symbol('x'),
+            &PointStyle::new(colors::BLUE, "")
+                .with_size(1.0)
+                .with_symbol('x'),
         );
     }
 
@@ -113,13 +113,18 @@ fn test_biased_polar_sampling() {
     let goal_y = goal_dist * goal_angle.sin();
     vis.plot_point(
         Point2D::new(goal_x, goal_y),
-        &PointStyle::new(colors::BLUE, "Goal Dir").with_size(2.0).with_symbol('*'),
+        &PointStyle::new(colors::BLUE, "Goal Dir")
+            .with_size(2.0)
+            .with_symbol('*'),
     );
 
     // Plot generated paths
     for path in &paths {
         let path2d = path.to_path();
-        vis.plot_path(&path2d, &PathStyle::new(colors::RED, "").with_line_width(1.0));
+        vis.plot_path(
+            &path2d,
+            &PathStyle::new(colors::RED, "").with_line_width(1.0),
+        );
     }
 
     let _ = vis.save_svg("img/path_planning/state_lattice_biased.svg", 800, 600);
@@ -159,7 +164,10 @@ fn test_lane_sampling() {
             Point2D::new(lane_length, y_offset),
         ];
         let lane_path = rust_robotics::common::Path2D::from_points(lane_points);
-        vis.plot_path(&lane_path, &PathStyle::new(colors::GRAY, "Lane").with_line_width(2.0));
+        vis.plot_path(
+            &lane_path,
+            &PathStyle::new(colors::GRAY, "Lane").with_line_width(2.0),
+        );
     }
 
     // Plot origin
@@ -172,14 +180,19 @@ fn test_lane_sampling() {
     for state in &states {
         vis.plot_point(
             Point2D::new(state.x, state.y),
-            &PointStyle::new(colors::BLUE, "").with_size(1.0).with_symbol('x'),
+            &PointStyle::new(colors::BLUE, "")
+                .with_size(1.0)
+                .with_symbol('x'),
         );
     }
 
     // Plot generated paths
     for path in &paths {
         let path2d = path.to_path();
-        vis.plot_path(&path2d, &PathStyle::new(colors::RED, "").with_line_width(1.0));
+        vis.plot_path(
+            &path2d,
+            &PathStyle::new(colors::RED, "").with_line_width(1.0),
+        );
     }
 
     let _ = vis.save_svg("img/path_planning/state_lattice_lane.svg", 800, 600);
@@ -196,7 +209,10 @@ fn test_full_planning() {
     let start = Point2D::new(0.0, 0.0);
     let goal = Point2D::new(30.0, 10.0);
 
-    println!("Planning from ({}, {}) to ({}, {})", start.x, start.y, goal.x, goal.y);
+    println!(
+        "Planning from ({}, {}) to ({}, {})",
+        start.x, start.y, goal.x, goal.y
+    );
 
     match planner.plan(start, goal) {
         Ok(path) => {
@@ -211,7 +227,10 @@ fn test_full_planning() {
 
             vis.plot_start(start);
             vis.plot_goal(goal);
-            vis.plot_path(&path, &PathStyle::new(colors::RED, "Path").with_line_width(2.0));
+            vis.plot_path(
+                &path,
+                &PathStyle::new(colors::RED, "Path").with_line_width(2.0),
+            );
 
             let _ = vis.save_svg("img/path_planning/state_lattice_plan.svg", 800, 600);
             println!("Plot saved to: img/path_planning/state_lattice_plan.svg");

--- a/examples/path_planning/theta_star.rs
+++ b/examples/path_planning/theta_star.rs
@@ -6,9 +6,9 @@
 //! Theta* extends A* by allowing paths to connect any two visible nodes,
 //! resulting in shorter, more natural paths compared to standard A*.
 
-use rust_robotics::path_planning::theta_star::{ThetaStarPlanner, ThetaStarConfig};
-use rust_robotics::path_planning::a_star::{AStarPlanner, AStarConfig};
-use rust_robotics::common::{Point2D, Path2D, PathPlanner};
+use rust_robotics::common::{Path2D, PathPlanner, Point2D};
+use rust_robotics::path_planning::a_star::{AStarConfig, AStarPlanner};
+use rust_robotics::path_planning::theta_star::{ThetaStarConfig, ThetaStarPlanner};
 use std::fs::File;
 use std::io::Write;
 
@@ -68,11 +68,17 @@ fn generate_svg(
         let y = transform_y(i as f64);
         svg.push_str(&format!(
             "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\"/>\n",
-            x, margin, x, height as f64 - margin
+            x,
+            margin,
+            x,
+            height as f64 - margin
         ));
         svg.push_str(&format!(
             "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\"/>\n",
-            margin, y, width as f64 - margin, y
+            margin,
+            y,
+            width as f64 - margin,
+            y
         ));
     }
     svg.push_str("</g>\n");
@@ -84,7 +90,8 @@ fn generate_svg(
         let cy = transform_y(y);
         svg.push_str(&format!(
             "<rect x=\"{}\" y=\"{}\" width=\"8\" height=\"8\" rx=\"1\"/>\n",
-            cx - 4.0, cy - 4.0
+            cx - 4.0,
+            cy - 4.0
         ));
     }
     svg.push_str("</g>\n");
@@ -102,7 +109,8 @@ fn generate_svg(
         for p in &a_star_path.points {
             svg.push_str(&format!(
                 "<circle cx=\"{}\" cy=\"{}\" r=\"3\"/>\n",
-                transform_x(p.x), transform_y(p.y)
+                transform_x(p.x),
+                transform_y(p.y)
             ));
         }
         svg.push_str("</g>\n");
@@ -121,7 +129,8 @@ fn generate_svg(
         for p in &theta_path.points {
             svg.push_str(&format!(
                 "<circle cx=\"{}\" cy=\"{}\" r=\"5\"/>\n",
-                transform_x(p.x), transform_y(p.y)
+                transform_x(p.x),
+                transform_y(p.y)
             ));
         }
         svg.push_str("</g>\n");
@@ -134,7 +143,8 @@ fn generate_svg(
     ));
     svg.push_str(&format!(
         "<text x=\"{}\" y=\"{}\" class=\"axis-label\" fill=\"#00AA00\">S</text>\n",
-        transform_x(start.x) + 12.0, transform_y(start.y) + 4.0
+        transform_x(start.x) + 12.0,
+        transform_y(start.y) + 4.0
     ));
 
     // Draw goal point (blue)
@@ -144,7 +154,8 @@ fn generate_svg(
     ));
     svg.push_str(&format!(
         "<text x=\"{}\" y=\"{}\" class=\"axis-label\" fill=\"#0000AA\">G</text>\n",
-        transform_x(goal.x) + 12.0, transform_y(goal.y) + 4.0
+        transform_x(goal.x) + 12.0,
+        transform_y(goal.y) + 4.0
     ));
 
     // Legend
@@ -157,20 +168,30 @@ fn generate_svg(
     // A* legend
     svg.push_str(&format!(
         "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" stroke=\"#0066CC\" stroke-width=\"2\"/>\n",
-        legend_x + 10.0, legend_y + 25.0, legend_x + 40.0, legend_y + 25.0
+        legend_x + 10.0,
+        legend_y + 25.0,
+        legend_x + 40.0,
+        legend_y + 25.0
     ));
     svg.push_str(&format!(
         "<text x=\"{}\" y=\"{}\" class=\"legend\">A* ({} pts)</text>\n",
-        legend_x + 50.0, legend_y + 29.0, a_star_path.len()
+        legend_x + 50.0,
+        legend_y + 29.0,
+        a_star_path.len()
     ));
     // Theta* legend
     svg.push_str(&format!(
         "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" stroke=\"#CC0000\" stroke-width=\"3\"/>\n",
-        legend_x + 10.0, legend_y + 50.0, legend_x + 40.0, legend_y + 50.0
+        legend_x + 10.0,
+        legend_y + 50.0,
+        legend_x + 40.0,
+        legend_y + 50.0
     ));
     svg.push_str(&format!(
         "<text x=\"{}\" y=\"{}\" class=\"legend\">Theta* ({} pts)</text>\n",
-        legend_x + 50.0, legend_y + 54.0, theta_path.len()
+        legend_x + 50.0,
+        legend_y + 54.0,
+        theta_path.len()
     ));
 
     svg.push_str("</svg>\n");
@@ -193,10 +214,14 @@ fn main() {
     let mut oy = Vec::new();
 
     for i in 0..21 {
-        ox.push(i as f64); oy.push(0.0);
-        ox.push(i as f64); oy.push(20.0);
-        ox.push(0.0); oy.push(i as f64);
-        ox.push(20.0); oy.push(i as f64);
+        ox.push(i as f64);
+        oy.push(0.0);
+        ox.push(i as f64);
+        oy.push(20.0);
+        ox.push(0.0);
+        oy.push(i as f64);
+        ox.push(20.0);
+        oy.push(i as f64);
     }
 
     // Add internal obstacles (L-shaped wall)
@@ -234,12 +259,20 @@ fn main() {
     match (theta_result, a_star_result) {
         (Ok(theta_path), Ok(a_star_path)) => {
             println!("\n=== Results ===");
-            println!("Theta* path: {} waypoints, length: {:.2}",
-                theta_path.len(), theta_path.total_length());
-            println!("A* path: {} waypoints, length: {:.2}",
-                a_star_path.len(), a_star_path.total_length());
-            println!("Theta* improvement: {:.1}% shorter path",
-                (1.0 - theta_path.total_length() / a_star_path.total_length()) * 100.0);
+            println!(
+                "Theta* path: {} waypoints, length: {:.2}",
+                theta_path.len(),
+                theta_path.total_length()
+            );
+            println!(
+                "A* path: {} waypoints, length: {:.2}",
+                a_star_path.len(),
+                a_star_path.total_length()
+            );
+            println!(
+                "Theta* improvement: {:.1}% shorter path",
+                (1.0 - theta_path.total_length() / a_star_path.total_length()) * 100.0
+            );
 
             // Generate and save SVG
             let base_path = std::env::current_dir()

--- a/examples/path_tracking/rear_wheel_feedback.rs
+++ b/examples/path_tracking/rear_wheel_feedback.rs
@@ -9,7 +9,6 @@ use rust_robotics::common::{Path2D, Point2D};
 use rust_robotics::path_tracking::rear_wheel_feedback::{
     RearWheelFeedbackConfig, RearWheelFeedbackController, VehicleState,
 };
-use std::f64::consts::PI;
 
 // Cubic spline helper for path generation
 struct CubicSpline {
@@ -33,9 +32,7 @@ impl CubicSpline {
         let mut c = vec![0.0; n];
         let mut d = vec![0.0; n];
 
-        for i in 0..n {
-            a[i] = y[i];
-        }
+        a[..n].copy_from_slice(&y[..n]);
 
         let mut alpha = vec![0.0; n - 1];
         for i in 1..n - 1 {
@@ -202,7 +199,7 @@ fn main() {
     println!("Starting Rear Wheel Feedback Control simulation...");
 
     // Define waypoints for a curved path
-    let waypoints = vec![
+    let waypoints = [
         (0.0, 0.0),
         (10.0, -6.0),
         (20.5, 5.0),
@@ -307,13 +304,13 @@ fn main() {
 
         // Plot start and goal
         axes.points(
-            &[trajectory_x[0]],
-            &[trajectory_y[0]],
+            [trajectory_x[0]],
+            [trajectory_y[0]],
             &[Caption("Start"), Color("cyan"), PointSymbol('o')],
         );
         axes.points(
-            &[*trajectory_x.last().unwrap()],
-            &[*trajectory_y.last().unwrap()],
+            [*trajectory_x.last().unwrap()],
+            [*trajectory_y.last().unwrap()],
             &[Caption("End"), Color("magenta"), PointSymbol('x')],
         );
     }

--- a/examples/path_tracking/rear_wheel_feedback.rs
+++ b/examples/path_tracking/rear_wheel_feedback.rs
@@ -4,11 +4,11 @@
 //!
 //! Run with: cargo run --example rear_wheel_feedback
 
-use gnuplot::{Figure, Caption, Color, AxesCommon, PointSymbol};
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSymbol};
+use rust_robotics::common::{Path2D, Point2D};
 use rust_robotics::path_tracking::rear_wheel_feedback::{
-    RearWheelFeedbackController, RearWheelFeedbackConfig, VehicleState,
+    RearWheelFeedbackConfig, RearWheelFeedbackController, VehicleState,
 };
-use rust_robotics::common::{Point2D, Path2D};
 use std::f64::consts::PI;
 
 // Cubic spline helper for path generation
@@ -58,7 +58,13 @@ impl CubicSpline {
             d[j] = (c[j + 1] - c[j]) / (3.0 * h[j]);
         }
 
-        CubicSpline { a, b, c, d, x: x.to_vec() }
+        CubicSpline {
+            a,
+            b,
+            c,
+            d,
+            x: x.to_vec(),
+        }
     }
 
     fn calc(&self, t: f64) -> f64 {
@@ -226,7 +232,10 @@ fn main() {
 
     // Set path
     let path = Path2D::from_points(
-        cx.iter().zip(cy.iter()).map(|(&x, &y)| Point2D::new(x, y)).collect()
+        cx.iter()
+            .zip(cy.iter())
+            .map(|(&x, &y)| Point2D::new(x, y))
+            .collect(),
     );
     controller.set_path_with_info(path, cyaw.clone(), ck);
 
@@ -262,12 +271,16 @@ fn main() {
         }
     }
 
-    println!("Simulation finished. Trajectory points: {}", trajectory_x.len());
+    println!(
+        "Simulation finished. Trajectory points: {}",
+        trajectory_x.len()
+    );
 
     // Plot results
     let mut fg = Figure::new();
     {
-        let axes = fg.axes2d()
+        let axes = fg
+            .axes2d()
             .set_title("Rear Wheel Feedback Control", &[])
             .set_x_label("x [m]", &[])
             .set_y_label("y [m]", &[])
@@ -277,17 +290,32 @@ fn main() {
         axes.lines(&cx, &cy, &[Caption("Reference Path"), Color("blue")]);
 
         // Plot vehicle trajectory
-        axes.lines(&trajectory_x, &trajectory_y, &[Caption("Vehicle Trajectory"), Color("red")]);
+        axes.lines(
+            &trajectory_x,
+            &trajectory_y,
+            &[Caption("Vehicle Trajectory"), Color("red")],
+        );
 
         // Plot waypoints
         let wp_x: Vec<f64> = waypoints.iter().map(|p| p.0).collect();
         let wp_y: Vec<f64> = waypoints.iter().map(|p| p.1).collect();
-        axes.points(&wp_x, &wp_y, &[Caption("Waypoints"), Color("green"), PointSymbol('O')]);
+        axes.points(
+            &wp_x,
+            &wp_y,
+            &[Caption("Waypoints"), Color("green"), PointSymbol('O')],
+        );
 
         // Plot start and goal
-        axes.points(&[trajectory_x[0]], &[trajectory_y[0]], &[Caption("Start"), Color("cyan"), PointSymbol('o')]);
-        axes.points(&[*trajectory_x.last().unwrap()], &[*trajectory_y.last().unwrap()],
-                   &[Caption("End"), Color("magenta"), PointSymbol('x')]);
+        axes.points(
+            &[trajectory_x[0]],
+            &[trajectory_y[0]],
+            &[Caption("Start"), Color("cyan"), PointSymbol('o')],
+        );
+        axes.points(
+            &[*trajectory_x.last().unwrap()],
+            &[*trajectory_y.last().unwrap()],
+            &[Caption("End"), Color("magenta"), PointSymbol('x')],
+        );
     }
 
     // Save as SVG

--- a/src/aerial_navigation/grid_a_star_3d.rs
+++ b/src/aerial_navigation/grid_a_star_3d.rs
@@ -365,6 +365,18 @@ mod tests {
     }
 
     #[test]
+    fn test_grid_a_star_3d_uses_diagonal_shortcut_when_enabled() {
+        let planner = planner_with_config(true, vec![]);
+
+        let path = planner
+            .plan(Point3D::new(0.0, 0.0, 0.0), Point3D::new(2.0, 2.0, 2.0))
+            .expect("path should exist");
+
+        assert_eq!(path.len(), 3);
+        assert_eq!(path.points[1], Point3D::new(1.0, 1.0, 1.0));
+    }
+
+    #[test]
     fn test_grid_a_star_3d_avoids_obstacles() {
         let obstacles = vec![
             Point3D::new(1.0, 0.0, 0.0),

--- a/src/aerial_navigation/grid_a_star_3d.rs
+++ b/src/aerial_navigation/grid_a_star_3d.rs
@@ -325,10 +325,7 @@ pub fn demo_grid_a_star_3d() {
 mod tests {
     use super::*;
 
-    fn planner_with_config(
-        allow_diagonal: bool,
-        obstacles: Vec<Point3D>,
-    ) -> GridAStar3DPlanner {
+    fn planner_with_config(allow_diagonal: bool, obstacles: Vec<Point3D>) -> GridAStar3DPlanner {
         GridAStar3DPlanner::new(
             GridAStar3DConfig {
                 resolution: 1.0,
@@ -374,10 +371,7 @@ mod tests {
             Point3D::new(1.0, 1.0, 0.0),
             Point3D::new(1.0, 2.0, 0.0),
         ];
-        let planner = planner_with_config(
-            false,
-            obstacles.clone(),
-        );
+        let planner = planner_with_config(false, obstacles.clone());
 
         let path = planner
             .plan(Point3D::new(0.0, 0.0, 0.0), Point3D::new(2.0, 2.0, 0.0))

--- a/src/aerial_navigation/grid_a_star_3d.rs
+++ b/src/aerial_navigation/grid_a_star_3d.rs
@@ -1,0 +1,409 @@
+//! 3D grid-based A* path planning for aerial robots.
+//!
+//! The planner operates on a voxel grid and returns a collision-free path
+//! between two 3D points inside a bounded workspace.
+
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap, HashSet};
+
+use crate::common::{Point3D, RoboticsError, RoboticsResult};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct GridPoint3D {
+    x: i32,
+    y: i32,
+    z: i32,
+}
+
+impl GridPoint3D {
+    fn new(x: i32, y: i32, z: i32) -> Self {
+        Self { x, y, z }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Path3D {
+    pub points: Vec<Point3D>,
+}
+
+impl Path3D {
+    pub fn new(points: Vec<Point3D>) -> Self {
+        Self { points }
+    }
+
+    pub fn len(&self) -> usize {
+        self.points.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.points.is_empty()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GridAStar3DConfig {
+    pub resolution: f64,
+    pub bounds_min: Point3D,
+    pub bounds_max: Point3D,
+    pub allow_diagonal: bool,
+}
+
+impl Default for GridAStar3DConfig {
+    fn default() -> Self {
+        Self {
+            resolution: 1.0,
+            bounds_min: Point3D::new(0.0, 0.0, 0.0),
+            bounds_max: Point3D::new(10.0, 10.0, 5.0),
+            allow_diagonal: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PriorityNode {
+    point: GridPoint3D,
+    cost: f64,
+    priority: f64,
+}
+
+impl Eq for PriorityNode {}
+
+impl PartialEq for PriorityNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.priority == other.priority
+    }
+}
+
+impl Ord for PriorityNode {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .priority
+            .partial_cmp(&self.priority)
+            .unwrap_or(Ordering::Equal)
+    }
+}
+
+impl PartialOrd for PriorityNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub struct GridAStar3DPlanner {
+    config: GridAStar3DConfig,
+    max_index: GridPoint3D,
+    obstacles: HashSet<GridPoint3D>,
+    motions: Vec<(i32, i32, i32, f64)>,
+}
+
+impl GridAStar3DPlanner {
+    pub fn new(config: GridAStar3DConfig, obstacles: &[Point3D]) -> RoboticsResult<Self> {
+        validate_config(&config)?;
+
+        let max_index = GridPoint3D::new(
+            ((config.bounds_max.x - config.bounds_min.x) / config.resolution).round() as i32,
+            ((config.bounds_max.y - config.bounds_min.y) / config.resolution).round() as i32,
+            ((config.bounds_max.z - config.bounds_min.z) / config.resolution).round() as i32,
+        );
+
+        let planner = Self {
+            max_index,
+            obstacles: obstacles
+                .iter()
+                .map(|point| quantize(point, &config))
+                .collect(),
+            motions: build_motion_model(config.allow_diagonal),
+            config,
+        };
+
+        Ok(planner)
+    }
+
+    pub fn plan(&self, start: Point3D, goal: Point3D) -> RoboticsResult<Path3D> {
+        let start_grid = quantize(&start, &self.config);
+        let goal_grid = quantize(&goal, &self.config);
+
+        if !self.is_valid(start_grid) {
+            return Err(RoboticsError::PlanningError(
+                "Start point is out of bounds or occupied".to_string(),
+            ));
+        }
+
+        if !self.is_valid(goal_grid) {
+            return Err(RoboticsError::PlanningError(
+                "Goal point is out of bounds or occupied".to_string(),
+            ));
+        }
+
+        let mut open_set = BinaryHeap::new();
+        let mut came_from = HashMap::new();
+        let mut best_cost = HashMap::new();
+
+        open_set.push(PriorityNode {
+            point: start_grid,
+            cost: 0.0,
+            priority: heuristic(start_grid, goal_grid),
+        });
+        best_cost.insert(start_grid, 0.0);
+
+        while let Some(current) = open_set.pop() {
+            if current.point == goal_grid {
+                return Ok(self.reconstruct_path(goal_grid, start_grid, &came_from));
+            }
+
+            let Some(known_cost) = best_cost.get(&current.point).copied() else {
+                continue;
+            };
+            if current.cost > known_cost {
+                continue;
+            }
+
+            for (dx, dy, dz, move_cost) in &self.motions {
+                let next = GridPoint3D::new(
+                    current.point.x + dx,
+                    current.point.y + dy,
+                    current.point.z + dz,
+                );
+                if !self.is_valid(next) {
+                    continue;
+                }
+
+                let tentative_cost = current.cost + move_cost;
+                let current_best = best_cost.get(&next).copied().unwrap_or(f64::INFINITY);
+                if tentative_cost >= current_best {
+                    continue;
+                }
+
+                came_from.insert(next, current.point);
+                best_cost.insert(next, tentative_cost);
+                open_set.push(PriorityNode {
+                    point: next,
+                    cost: tentative_cost,
+                    priority: tentative_cost + heuristic(next, goal_grid),
+                });
+            }
+        }
+
+        Err(RoboticsError::PlanningError("No 3D path found".to_string()))
+    }
+
+    fn is_valid(&self, point: GridPoint3D) -> bool {
+        point.x >= 0
+            && point.y >= 0
+            && point.z >= 0
+            && point.x <= self.max_index.x
+            && point.y <= self.max_index.y
+            && point.z <= self.max_index.z
+            && !self.obstacles.contains(&point)
+    }
+
+    fn reconstruct_path(
+        &self,
+        goal: GridPoint3D,
+        start: GridPoint3D,
+        came_from: &HashMap<GridPoint3D, GridPoint3D>,
+    ) -> Path3D {
+        let mut points = vec![goal];
+        let mut current = goal;
+
+        while current != start {
+            current = came_from[&current];
+            points.push(current);
+        }
+
+        points.reverse();
+        Path3D::new(
+            points
+                .into_iter()
+                .map(|point| dequantize(point, &self.config))
+                .collect(),
+        )
+    }
+}
+
+fn validate_config(config: &GridAStar3DConfig) -> RoboticsResult<()> {
+    if config.resolution <= 0.0 {
+        return Err(RoboticsError::InvalidParameter(
+            "resolution must be positive".to_string(),
+        ));
+    }
+
+    if config.bounds_min.x > config.bounds_max.x
+        || config.bounds_min.y > config.bounds_max.y
+        || config.bounds_min.z > config.bounds_max.z
+    {
+        return Err(RoboticsError::InvalidParameter(
+            "bounds_min must not exceed bounds_max".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn quantize(point: &Point3D, config: &GridAStar3DConfig) -> GridPoint3D {
+    GridPoint3D::new(
+        ((point.x - config.bounds_min.x) / config.resolution).round() as i32,
+        ((point.y - config.bounds_min.y) / config.resolution).round() as i32,
+        ((point.z - config.bounds_min.z) / config.resolution).round() as i32,
+    )
+}
+
+fn dequantize(point: GridPoint3D, config: &GridAStar3DConfig) -> Point3D {
+    Point3D::new(
+        config.bounds_min.x + point.x as f64 * config.resolution,
+        config.bounds_min.y + point.y as f64 * config.resolution,
+        config.bounds_min.z + point.z as f64 * config.resolution,
+    )
+}
+
+fn heuristic(a: GridPoint3D, b: GridPoint3D) -> f64 {
+    let dx = (a.x - b.x) as f64;
+    let dy = (a.y - b.y) as f64;
+    let dz = (a.z - b.z) as f64;
+    (dx * dx + dy * dy + dz * dz).sqrt()
+}
+
+fn build_motion_model(allow_diagonal: bool) -> Vec<(i32, i32, i32, f64)> {
+    let mut motions = vec![
+        (1, 0, 0, 1.0),
+        (-1, 0, 0, 1.0),
+        (0, 1, 0, 1.0),
+        (0, -1, 0, 1.0),
+        (0, 0, 1, 1.0),
+        (0, 0, -1, 1.0),
+    ];
+
+    if allow_diagonal {
+        for dx in -1_i32..=1 {
+            for dy in -1_i32..=1 {
+                for dz in -1_i32..=1 {
+                    if dx == 0 && dy == 0 && dz == 0 {
+                        continue;
+                    }
+                    if dx.abs() + dy.abs() + dz.abs() <= 1 {
+                        continue;
+                    }
+                    let cost = ((dx * dx + dy * dy + dz * dz) as f64).sqrt();
+                    motions.push((dx, dy, dz, cost));
+                }
+            }
+        }
+    }
+
+    motions
+}
+
+pub fn demo_grid_a_star_3d() {
+    let config = GridAStar3DConfig {
+        bounds_min: Point3D::new(0.0, 0.0, 0.0),
+        bounds_max: Point3D::new(6.0, 6.0, 4.0),
+        ..Default::default()
+    };
+    let obstacles = vec![
+        Point3D::new(2.0, 2.0, 0.0),
+        Point3D::new(2.0, 2.0, 1.0),
+        Point3D::new(2.0, 2.0, 2.0),
+        Point3D::new(3.0, 2.0, 2.0),
+    ];
+
+    let planner = GridAStar3DPlanner::new(config, &obstacles).expect("planner should build");
+    let start = Point3D::new(0.0, 0.0, 0.0);
+    let goal = Point3D::new(5.0, 5.0, 3.0);
+
+    match planner.plan(start, goal) {
+        Ok(path) => {
+            println!("3D path found with {} waypoints:", path.len());
+            for point in path.points {
+                println!("({:.1}, {:.1}, {:.1})", point.x, point.y, point.z);
+            }
+        }
+        Err(error) => eprintln!("Planning failed: {}", error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn planner_with_config(
+        allow_diagonal: bool,
+        obstacles: Vec<Point3D>,
+    ) -> GridAStar3DPlanner {
+        GridAStar3DPlanner::new(
+            GridAStar3DConfig {
+                resolution: 1.0,
+                bounds_min: Point3D::new(0.0, 0.0, 0.0),
+                bounds_max: Point3D::new(4.0, 4.0, 4.0),
+                allow_diagonal,
+            },
+            &obstacles,
+        )
+        .expect("planner should be created")
+    }
+
+    #[test]
+    fn test_invalid_config_is_rejected() {
+        let result = GridAStar3DPlanner::new(
+            GridAStar3DConfig {
+                resolution: 0.0,
+                ..Default::default()
+            },
+            &[],
+        );
+
+        assert!(matches!(result, Err(RoboticsError::InvalidParameter(_))));
+    }
+
+    #[test]
+    fn test_grid_a_star_3d_finds_path() {
+        let planner = planner_with_config(true, vec![]);
+        let start = Point3D::new(0.0, 0.0, 0.0);
+        let goal = Point3D::new(3.0, 2.0, 1.0);
+
+        let path = planner.plan(start, goal).expect("path should exist");
+
+        assert!(!path.is_empty());
+        assert_eq!(path.points.first().copied(), Some(start));
+        assert_eq!(path.points.last().copied(), Some(goal));
+    }
+
+    #[test]
+    fn test_grid_a_star_3d_avoids_obstacles() {
+        let obstacles = vec![
+            Point3D::new(1.0, 0.0, 0.0),
+            Point3D::new(1.0, 1.0, 0.0),
+            Point3D::new(1.0, 2.0, 0.0),
+        ];
+        let planner = planner_with_config(
+            false,
+            obstacles.clone(),
+        );
+
+        let path = planner
+            .plan(Point3D::new(0.0, 0.0, 0.0), Point3D::new(2.0, 2.0, 0.0))
+            .expect("path should route around the wall");
+
+        assert!(path.points.iter().all(|point| !obstacles.contains(point)));
+        assert!(path.points.iter().any(|point| point.z > 0.0));
+        assert!(path.len() > 4);
+    }
+
+    #[test]
+    fn test_grid_a_star_3d_reports_no_path() {
+        let planner = planner_with_config(
+            false,
+            vec![
+                Point3D::new(0.0, 1.0, 1.0),
+                Point3D::new(2.0, 1.0, 1.0),
+                Point3D::new(1.0, 0.0, 1.0),
+                Point3D::new(1.0, 2.0, 1.0),
+                Point3D::new(1.0, 1.0, 0.0),
+                Point3D::new(1.0, 1.0, 2.0),
+            ],
+        );
+
+        let result = planner.plan(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 1.0, 1.0));
+
+        assert!(matches!(result, Err(RoboticsError::PlanningError(_))));
+    }
+}

--- a/src/aerial_navigation/mod.rs
+++ b/src/aerial_navigation/mod.rs
@@ -1,3 +1,5 @@
 // Aerial Navigation algorithms module
 
-// TODO: Add aerial navigation implementations
+pub mod grid_a_star_3d;
+
+pub use grid_a_star_3d::{GridAStar3DConfig, GridAStar3DPlanner, Path3D};

--- a/src/arm_navigation/two_joint_arm_control.rs
+++ b/src/arm_navigation/two_joint_arm_control.rs
@@ -5,7 +5,7 @@
 // Ported to Rust by: rust_robotics team
 //
 
-use gnuplot::{Figure, Caption, Color, AxesCommon, PointSymbol};
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSymbol};
 use std::f64::consts::PI;
 
 // Simulation parameters
@@ -43,73 +43,75 @@ impl TwoJointArm {
     pub fn solve_inverse_kinematics(&mut self, goal_threshold: f64) -> bool {
         let mut iterations = 0;
         const MAX_ITERATIONS: usize = 1000;
-        
+
         self.trajectory.clear();
-        
+
         while iterations < MAX_ITERATIONS {
             let (end_x, end_y) = self.forward_kinematics();
-            self.trajectory.push((self.theta1, self.theta2, end_x, end_y));
-            
+            self.trajectory
+                .push((self.theta1, self.theta2, end_x, end_y));
+
             // Check if goal is reached
-            let distance_to_goal = ((end_x - self.target_x).powi(2) + (end_y - self.target_y).powi(2)).sqrt();
+            let distance_to_goal =
+                ((end_x - self.target_x).powi(2) + (end_y - self.target_y).powi(2)).sqrt();
             if distance_to_goal < goal_threshold {
                 return true;
             }
-            
+
             // Calculate target joint angles using inverse kinematics
             let (theta1_goal, theta2_goal) = match self.calculate_target_angles() {
                 Some(angles) => angles,
                 None => continue, // Target unreachable, skip this iteration
             };
-            
+
             // Update joint angles with proportional control
             self.theta1 += KP * self.angle_diff(theta1_goal, self.theta1) * DT;
             self.theta2 += KP * self.angle_diff(theta2_goal, self.theta2) * DT;
-            
+
             iterations += 1;
         }
-        
+
         false // Failed to reach target within max iterations
     }
 
     fn calculate_target_angles(&self) -> Option<(f64, f64)> {
         let x = self.target_x;
         let y = self.target_y;
-        
+
         // Check if target is reachable
         let distance = (x.powi(2) + y.powi(2)).sqrt();
         if distance > (L1 + L2) {
             return None; // Target too far
         }
-        
+
         // Calculate theta2 using law of cosines
         let cos_theta2 = (x.powi(2) + y.powi(2) - L1.powi(2) - L2.powi(2)) / (2.0 * L1 * L2);
-        
+
         // Clamp to valid range to avoid numerical errors
         let cos_theta2 = cos_theta2.clamp(-1.0, 1.0);
         let mut theta2_goal = cos_theta2.acos();
-        
+
         // Calculate theta1
         let tmp = (L2 * theta2_goal.sin()).atan2(L1 + L2 * theta2_goal.cos());
         let mut theta1_goal = y.atan2(x) - tmp;
-        
+
         // Try the other solution if theta1 is negative
         if theta1_goal < 0.0 {
             theta2_goal = -theta2_goal;
             let tmp = (L2 * theta2_goal.sin()).atan2(L1 + L2 * theta2_goal.cos());
             theta1_goal = y.atan2(x) - tmp;
         }
-        
+
         Some((theta1_goal, theta2_goal))
     }
 
     fn forward_kinematics(&self) -> (f64, f64) {
         let elbow_x = L1 * self.theta1.cos();
         let elbow_y = L1 * self.theta1.sin();
-        
+
         let end_x = elbow_x + L2 * (self.theta1 + self.theta2).cos();
         let end_y = elbow_y + L2 * (self.theta1 + self.theta2).sin();
-        
+
         (end_x, end_y)
     }
 
@@ -127,22 +129,38 @@ impl TwoJointArm {
     pub fn save_animation_frames(&self, target_name: &str) {
         let output_dir = format!("img/arm_navigation/{}", target_name);
         std::fs::create_dir_all(&output_dir).unwrap();
-        
+
         for (frame, &(theta1, theta2, end_x, end_y)) in self.trajectory.iter().enumerate() {
-            if frame % 5 == 0 { // Save every 5th frame
+            if frame % 5 == 0 {
+                // Save every 5th frame
                 self.save_frame(frame / 5, theta1, theta2, end_x, end_y, &output_dir);
             }
         }
-        
+
         println!("Animation frames saved in {}/frame_*.png", output_dir);
         println!("Create video with: ffmpeg -r 10 -i {}/frame_%04d.png -c:v libx264 -pix_fmt yuv420p {}_animation.mp4", output_dir, target_name);
     }
 
-    fn save_frame(&self, frame: usize, theta1: f64, theta2: f64, end_x: f64, end_y: f64, output_dir: &str) {
+    fn save_frame(
+        &self,
+        frame: usize,
+        theta1: f64,
+        theta2: f64,
+        end_x: f64,
+        end_y: f64,
+        output_dir: &str,
+    ) {
         let mut fg = Figure::new();
         {
-            let axes = fg.axes2d()
-                .set_title(&format!("Two Joint Arm Control - Frame {} (Target: {:.2}, {:.2})", frame, self.target_x, self.target_y), &[])
+            let axes = fg
+                .axes2d()
+                .set_title(
+                    &format!(
+                        "Two Joint Arm Control - Frame {} (Target: {:.2}, {:.2})",
+                        frame, self.target_x, self.target_y
+                    ),
+                    &[],
+                )
                 .set_x_label("X [m]", &[])
                 .set_y_label("Y [m]", &[])
                 .set_x_range(gnuplot::Fix(-2.5), gnuplot::Fix(2.5))
@@ -155,27 +173,33 @@ impl TwoJointArm {
             let wrist = (end_x, end_y);
 
             // Draw arm links (black lines like Python version)
-            axes.lines(&[shoulder.0, elbow.0], &[shoulder.1, elbow.1], &[
-                Color("black")
-            ]);
-            axes.lines(&[elbow.0, wrist.0], &[elbow.1, wrist.1], &[
-                Color("black")
-            ]);
+            axes.lines(
+                &[shoulder.0, elbow.0],
+                &[shoulder.1, elbow.1],
+                &[Color("black")],
+            );
+            axes.lines(&[elbow.0, wrist.0], &[elbow.1, wrist.1], &[Color("black")]);
 
             // Draw joints (red circles like Python version)
-            axes.points(&[shoulder.0, elbow.0, wrist.0], &[shoulder.1, elbow.1, wrist.1], &[
-                Color("red"), PointSymbol('O')
-            ]);
+            axes.points(
+                &[shoulder.0, elbow.0, wrist.0],
+                &[shoulder.1, elbow.1, wrist.1],
+                &[Color("red"), PointSymbol('O')],
+            );
 
             // Draw target (green star like Python version)
-            axes.points(&[self.target_x], &[self.target_y], &[
-                Color("green"), PointSymbol('*')
-            ]);
+            axes.points(
+                &[self.target_x],
+                &[self.target_y],
+                &[Color("green"), PointSymbol('*')],
+            );
 
             // Draw line to target (green dashed line like Python version)
-            axes.lines(&[wrist.0, self.target_x], &[wrist.1, self.target_y], &[
-                Color("green")
-            ]);
+            axes.lines(
+                &[wrist.0, self.target_x],
+                &[wrist.1, self.target_y],
+                &[Color("green")],
+            );
         }
 
         let output_path = format!("{}/frame_{:04}.png", output_dir, frame);
@@ -189,7 +213,8 @@ impl TwoJointArm {
 
         let mut fg = Figure::new();
         {
-            let axes = fg.axes2d()
+            let axes = fg
+                .axes2d()
                 .set_title("Two Joint Arm to Point Control", &[])
                 .set_x_label("X [m]", &[])
                 .set_y_label("Y [m]", &[])
@@ -203,27 +228,33 @@ impl TwoJointArm {
             let wrist = (end_x, end_y);
 
             // Draw arm links (black lines like Python version)
-            axes.lines(&[shoulder.0, elbow.0], &[shoulder.1, elbow.1], &[
-                Color("black")
-            ]);
-            axes.lines(&[elbow.0, wrist.0], &[elbow.1, wrist.1], &[
-                Color("black")
-            ]);
+            axes.lines(
+                &[shoulder.0, elbow.0],
+                &[shoulder.1, elbow.1],
+                &[Color("black")],
+            );
+            axes.lines(&[elbow.0, wrist.0], &[elbow.1, wrist.1], &[Color("black")]);
 
             // Draw joints (red circles like Python version)
-            axes.points(&[shoulder.0, elbow.0, wrist.0], &[shoulder.1, elbow.1, wrist.1], &[
-                Color("red"), PointSymbol('O')
-            ]);
+            axes.points(
+                &[shoulder.0, elbow.0, wrist.0],
+                &[shoulder.1, elbow.1, wrist.1],
+                &[Color("red"), PointSymbol('O')],
+            );
 
             // Draw target (green star like Python version)
-            axes.points(&[self.target_x], &[self.target_y], &[
-                Color("green"), PointSymbol('*')
-            ]);
+            axes.points(
+                &[self.target_x],
+                &[self.target_y],
+                &[Color("green"), PointSymbol('*')],
+            );
 
             // Draw line to target (green dashed line like Python version)
-            axes.lines(&[wrist.0, self.target_x], &[wrist.1, self.target_y], &[
-                Color("green")
-            ]);
+            axes.lines(
+                &[wrist.0, self.target_x],
+                &[wrist.1, self.target_y],
+                &[Color("green")],
+            );
         }
 
         fg.set_terminal("pngcairo", output_path);
@@ -234,7 +265,8 @@ impl TwoJointArm {
     pub fn create_summary_plot(&self, target_name: &str) {
         let mut fg = Figure::new();
         {
-            let axes = fg.axes2d()
+            let axes = fg
+                .axes2d()
                 .set_title("Two Joint Arm - Joint Angles vs Time", &[])
                 .set_x_label("Iteration", &[])
                 .set_y_label("Angle [rad]", &[]);
@@ -242,9 +274,17 @@ impl TwoJointArm {
             let iterations: Vec<f64> = (0..self.trajectory.len()).map(|i| i as f64).collect();
             let theta1_data: Vec<f64> = self.trajectory.iter().map(|(t1, _, _, _)| *t1).collect();
             let theta2_data: Vec<f64> = self.trajectory.iter().map(|(_, t2, _, _)| *t2).collect();
-            
-            axes.lines(&iterations, &theta1_data, &[Caption("Theta1 [rad]"), Color("blue")]);
-            axes.lines(&iterations, &theta2_data, &[Caption("Theta2 [rad]"), Color("red")]);
+
+            axes.lines(
+                &iterations,
+                &theta1_data,
+                &[Caption("Theta1 [rad]"), Color("blue")],
+            );
+            axes.lines(
+                &iterations,
+                &theta2_data,
+                &[Caption("Theta2 [rad]"), Color("red")],
+            );
         }
 
         let output_path = format!("img/arm_navigation/{}_summary.png", target_name);
@@ -257,20 +297,20 @@ impl TwoJointArm {
     pub fn run_random_targets_demo(&mut self, num_targets: usize) {
         use rand::Rng;
         let mut rng = rand::thread_rng();
-        
+
         println!("Starting Two Joint Arm random targets demo...");
-        
+
         for i in 0..num_targets {
             // Generate random target within workspace
             let angle = rng.gen::<f64>() * 2.0 * PI;
             let radius = rng.gen::<f64>() * (L1 + L2 - 0.1); // Slightly inside workspace
             let target_x = radius * angle.cos();
             let target_y = radius * angle.sin();
-            
+
             self.set_target(target_x, target_y);
-            
+
             println!("Target {}: ({:.2}, {:.2})", i + 1, target_x, target_y);
-            
+
             if self.solve_inverse_kinematics(0.01) {
                 println!("  ✓ Reached target in {} iterations", self.trajectory.len());
                 let target_name = format!("target_{:02}", i + 1);
@@ -279,7 +319,7 @@ impl TwoJointArm {
                 println!("  ✗ Failed to reach target");
             }
         }
-        
+
         self.create_summary_plot("random_demo");
         println!("Two Joint Arm demo complete!");
     }

--- a/src/arm_navigation/two_joint_arm_control.rs
+++ b/src/arm_navigation/two_joint_arm_control.rs
@@ -1,3 +1,9 @@
+#![allow(
+    dead_code,
+    clippy::needless_borrows_for_generic_args,
+    clippy::new_without_default
+)]
+
 //
 // Inverse kinematics of a two-joint arm
 // Author: Daniel Ingram (daniel-s-ingram)
@@ -6,6 +12,7 @@
 //
 
 use gnuplot::{AxesCommon, Caption, Color, Figure, PointSymbol};
+
 use std::f64::consts::PI;
 
 // Simulation parameters
@@ -145,7 +152,7 @@ impl TwoJointArm {
         &self,
         frame: usize,
         theta1: f64,
-        theta2: f64,
+        _theta2: f64,
         end_x: f64,
         end_y: f64,
         output_dir: &str,

--- a/src/bin/behavior_tree.rs
+++ b/src/bin/behavior_tree.rs
@@ -1,0 +1,3 @@
+fn main() {
+    rust_robotics::mission_planning::behavior_tree::demo_behavior_tree();
+}

--- a/src/bin/dwa.rs
+++ b/src/bin/dwa.rs
@@ -36,18 +36,33 @@ fn main() {
         axes.points(
             &obs_x,
             &obs_y,
-            &[Caption("Obstacles"), Color("black"), PointSymbol('O'), PointSize(1.5)],
+            &[
+                Caption("Obstacles"),
+                Color("black"),
+                PointSymbol('O'),
+                PointSize(1.5),
+            ],
         );
         axes.lines(&path_x, &path_y, &[Caption("Trajectory"), Color("green")]);
         axes.points(
             &[0.0],
             &[0.0],
-            &[Caption("Start"), Color("blue"), PointSymbol('O'), PointSize(2.0)],
+            &[
+                Caption("Start"),
+                Color("blue"),
+                PointSymbol('O'),
+                PointSize(2.0),
+            ],
         );
         axes.points(
             &[10.0],
             &[10.0],
-            &[Caption("Goal"), Color("red"), PointSymbol('O'), PointSize(2.0)],
+            &[
+                Caption("Goal"),
+                Color("red"),
+                PointSymbol('O'),
+                PointSize(2.0),
+            ],
         );
         axes.set_title("Dynamic Window Approach", &[])
             .set_x_label("X [m]", &[])

--- a/src/bin/dwa.rs
+++ b/src/bin/dwa.rs
@@ -1,0 +1,61 @@
+use std::fs;
+
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
+use rust_robotics::path_planning::{DWAPlanner, DWAState};
+use rust_robotics::Point2D;
+
+fn main() {
+    println!("DWA demo start");
+
+    fs::create_dir_all("img/path_planning").unwrap();
+
+    let mut planner = DWAPlanner::with_defaults();
+    planner.set_state(DWAState::new(0.0, 0.0, 0.0, 0.0, 0.0));
+    planner.set_goal(Point2D::new(10.0, 10.0));
+
+    let obstacles = vec![
+        Point2D::new(2.5, 2.0),
+        Point2D::new(3.0, 4.0),
+        Point2D::new(4.5, 4.0),
+        Point2D::new(5.0, 6.0),
+        Point2D::new(6.5, 6.0),
+        Point2D::new(7.0, 8.0),
+        Point2D::new(8.5, 8.0),
+    ];
+    planner.set_obstacles(obstacles.clone());
+
+    let states = planner.navigate_to_goal(250);
+    let path_x: Vec<f64> = states.iter().map(|s| s[0]).collect();
+    let path_y: Vec<f64> = states.iter().map(|s| s[1]).collect();
+    let obs_x: Vec<f64> = obstacles.iter().map(|p| p.x).collect();
+    let obs_y: Vec<f64> = obstacles.iter().map(|p| p.y).collect();
+
+    let mut fig = Figure::new();
+    {
+        let axes = fig.axes2d();
+        axes.points(
+            &obs_x,
+            &obs_y,
+            &[Caption("Obstacles"), Color("black"), PointSymbol('O'), PointSize(1.5)],
+        );
+        axes.lines(&path_x, &path_y, &[Caption("Trajectory"), Color("green")]);
+        axes.points(
+            &[0.0],
+            &[0.0],
+            &[Caption("Start"), Color("blue"), PointSymbol('O'), PointSize(2.0)],
+        );
+        axes.points(
+            &[10.0],
+            &[10.0],
+            &[Caption("Goal"), Color("red"), PointSymbol('O'), PointSize(2.0)],
+        );
+        axes.set_title("Dynamic Window Approach", &[])
+            .set_x_label("X [m]", &[])
+            .set_y_label("Y [m]", &[])
+            .set_aspect_ratio(gnuplot::Fix(1.0));
+    }
+
+    fig.save_to_svg("./img/path_planning/dwa.svg", 640, 480)
+        .unwrap();
+    println!("Saved plot to ./img/path_planning/dwa.svg");
+}

--- a/src/bin/dwa.rs
+++ b/src/bin/dwa.rs
@@ -45,8 +45,8 @@ fn main() {
         );
         axes.lines(&path_x, &path_y, &[Caption("Trajectory"), Color("green")]);
         axes.points(
-            &[0.0],
-            &[0.0],
+            [0.0],
+            [0.0],
             &[
                 Caption("Start"),
                 Color("blue"),
@@ -55,8 +55,8 @@ fn main() {
             ],
         );
         axes.points(
-            &[10.0],
-            &[10.0],
+            [10.0],
+            [10.0],
             &[
                 Caption("Goal"),
                 Color("red"),

--- a/src/bin/ekf.rs
+++ b/src/bin/ekf.rs
@@ -77,8 +77,8 @@ fn main() {
         axes.lines(&est_x, &est_y, &[Caption("EKF"), Color("green")]);
         axes.lines(&dr_x, &dr_y, &[Caption("Dead Reckoning"), Color("yellow")]);
         axes.points(
-            &[true_x[0]],
-            &[true_y[0]],
+            [true_x[0]],
+            [true_y[0]],
             &[Caption("Start"), Color("black"), PointSymbol('O')],
         );
         axes.set_title("Extended Kalman Filter Localization", &[])

--- a/src/bin/ekf.rs
+++ b/src/bin/ekf.rs
@@ -1,0 +1,93 @@
+use std::fs;
+
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSymbol};
+use rust_robotics::localization::{EKFControl, EKFLocalizer, EKFMeasurement, EKFState};
+use rust_robotics::StateEstimator;
+
+fn propagate(state: &mut EKFState, control: &EKFControl, dt: f64) {
+    let yaw = state[2];
+    state[0] += control[0] * yaw.cos() * dt;
+    state[1] += control[0] * yaw.sin() * dt;
+    state[2] += control[1] * dt;
+    state[3] = control[0];
+}
+
+fn main() {
+    println!("EKF localization demo start");
+
+    fs::create_dir_all("img/localization").unwrap();
+
+    let dt = 0.1;
+    let n_steps = 100;
+    let control = EKFControl::new(1.0, 0.1);
+
+    let mut ekf = EKFLocalizer::with_defaults();
+    let mut true_state = EKFState::zeros();
+    let mut dead_reckoning = EKFState::zeros();
+
+    let mut true_x = Vec::with_capacity(n_steps + 1);
+    let mut true_y = Vec::with_capacity(n_steps + 1);
+    let mut est_x = Vec::with_capacity(n_steps + 1);
+    let mut est_y = Vec::with_capacity(n_steps + 1);
+    let mut gps_x = Vec::with_capacity(n_steps + 1);
+    let mut gps_y = Vec::with_capacity(n_steps + 1);
+    let mut dr_x = Vec::with_capacity(n_steps + 1);
+    let mut dr_y = Vec::with_capacity(n_steps + 1);
+
+    true_x.push(true_state[0]);
+    true_y.push(true_state[1]);
+    est_x.push(ekf.get_state()[0]);
+    est_y.push(ekf.get_state()[1]);
+    gps_x.push(true_state[0]);
+    gps_y.push(true_state[1]);
+    dr_x.push(dead_reckoning[0]);
+    dr_y.push(dead_reckoning[1]);
+
+    for step in 0..n_steps {
+        propagate(&mut true_state, &control, dt);
+
+        let gps_noise_x = ((step % 9) as f64 - 4.0) * 0.05;
+        let gps_noise_y = (((step * 2) % 11) as f64 - 5.0) * 0.04;
+        let measurement =
+            EKFMeasurement::new(true_state[0] + gps_noise_x, true_state[1] + gps_noise_y);
+
+        let dr_control = EKFControl::new(
+            control[0] + (((step * 3) % 7) as f64 - 3.0) * 0.01,
+            control[1] + (((step * 5) % 9) as f64 - 4.0) * 0.002,
+        );
+        propagate(&mut dead_reckoning, &dr_control, dt);
+
+        ekf.estimate(&measurement, &control, dt).unwrap();
+
+        true_x.push(true_state[0]);
+        true_y.push(true_state[1]);
+        est_x.push(ekf.get_state()[0]);
+        est_y.push(ekf.get_state()[1]);
+        gps_x.push(measurement[0]);
+        gps_y.push(measurement[1]);
+        dr_x.push(dead_reckoning[0]);
+        dr_y.push(dead_reckoning[1]);
+    }
+
+    let mut fig = Figure::new();
+    {
+        let axes = fig.axes2d();
+        axes.lines(&gps_x, &gps_y, &[Caption("GPS"), Color("red")]);
+        axes.lines(&true_x, &true_y, &[Caption("Ground Truth"), Color("blue")]);
+        axes.lines(&est_x, &est_y, &[Caption("EKF"), Color("green")]);
+        axes.lines(&dr_x, &dr_y, &[Caption("Dead Reckoning"), Color("yellow")]);
+        axes.points(
+            &[true_x[0]],
+            &[true_y[0]],
+            &[Caption("Start"), Color("black"), PointSymbol('O')],
+        );
+        axes.set_title("Extended Kalman Filter Localization", &[])
+            .set_x_label("X [m]", &[])
+            .set_y_label("Y [m]", &[])
+            .set_aspect_ratio(gnuplot::Fix(1.0));
+    }
+
+    fig.save_to_svg("./img/localization/ekf.svg", 640, 480)
+        .unwrap();
+    println!("Saved plot to ./img/localization/ekf.svg");
+}

--- a/src/bin/grid_a_star_3d.rs
+++ b/src/bin/grid_a_star_3d.rs
@@ -1,0 +1,3 @@
+fn main() {
+    rust_robotics::aerial_navigation::grid_a_star_3d::demo_grid_a_star_3d();
+}

--- a/src/bin/lqr_steer_control.rs
+++ b/src/bin/lqr_steer_control.rs
@@ -1,0 +1,29 @@
+use rust_robotics::path_tracking::LQRSteerController;
+
+fn main() {
+    let waypoints = vec![
+        (0.0, 0.0),
+        (5.0, 0.0),
+        (10.0, 2.0),
+        (15.0, 0.0),
+        (20.0, -2.0),
+        (25.0, 0.0),
+    ];
+
+    let mut controller = LQRSteerController::with_defaults();
+    match controller.planning(waypoints, 2.0, 0.5) {
+        Some(trajectory) => {
+            let end = trajectory.last().copied().unwrap_or((0.0, 0.0));
+            println!(
+                "LQR steer trajectory points={}, end=({:.3}, {:.3})",
+                trajectory.len(),
+                end.0,
+                end.1
+            );
+        }
+        None => {
+            eprintln!("LQR steer control failed");
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/bin/move_to_pose.rs
+++ b/src/bin/move_to_pose.rs
@@ -1,0 +1,3 @@
+fn main() {
+    rust_robotics::path_tracking::move_to_pose::demo_move_to_pose();
+}

--- a/src/bin/particle_filter.rs
+++ b/src/bin/particle_filter.rs
@@ -1,0 +1,21 @@
+use rust_robotics::localization::{PFControl, PFMeasurement, PFState, ParticleFilterConfig, ParticleFilterLocalizer};
+
+fn main() {
+    let initial = PFState::new(0.0, 0.0, 0.0, 0.0);
+    let mut pf = ParticleFilterLocalizer::with_initial_state(initial, ParticleFilterConfig::default());
+    let control = PFControl::new(1.0, 0.05);
+    let observations: PFMeasurement = vec![
+        (7.0, 5.0, 0.0),
+        (6.0, 0.0, 5.0),
+    ];
+
+    for _ in 0..20 {
+        let _ = pf.step(&control, &observations);
+    }
+
+    let estimate = pf.estimate();
+    println!(
+        "Particle filter estimate: x={:.3}, y={:.3}, yaw={:.3}, v={:.3}",
+        estimate[0], estimate[1], estimate[2], estimate[3]
+    );
+}

--- a/src/bin/particle_filter.rs
+++ b/src/bin/particle_filter.rs
@@ -1,13 +1,13 @@
-use rust_robotics::localization::{PFControl, PFMeasurement, PFState, ParticleFilterConfig, ParticleFilterLocalizer};
+use rust_robotics::localization::{
+    PFControl, PFMeasurement, PFState, ParticleFilterConfig, ParticleFilterLocalizer,
+};
 
 fn main() {
     let initial = PFState::new(0.0, 0.0, 0.0, 0.0);
-    let mut pf = ParticleFilterLocalizer::with_initial_state(initial, ParticleFilterConfig::default());
+    let mut pf =
+        ParticleFilterLocalizer::with_initial_state(initial, ParticleFilterConfig::default());
     let control = PFControl::new(1.0, 0.05);
-    let observations: PFMeasurement = vec![
-        (7.0, 5.0, 0.0),
-        (6.0, 0.0, 5.0),
-    ];
+    let observations: PFMeasurement = vec![(7.0, 5.0, 0.0), (6.0, 0.0, 5.0)];
 
     for _ in 0..20 {
         let _ = pf.step(&control, &observations);

--- a/src/bin/pure_pursuit.rs
+++ b/src/bin/pure_pursuit.rs
@@ -1,0 +1,24 @@
+use rust_robotics::path_tracking::PurePursuitController;
+
+fn main() {
+    let waypoints: Vec<(f64, f64)> = (0..20)
+        .map(|i| (i as f64, (i as f64 / 3.0).sin() * 2.0))
+        .collect();
+
+    let mut controller = PurePursuitController::with_params(0.1, 2.0, 2.9);
+    match controller.planning(waypoints, 5.0) {
+        Some(trajectory) => {
+            let end = trajectory.last().copied().unwrap_or((0.0, 0.0));
+            println!(
+                "Pure pursuit trajectory points={}, end=({:.3}, {:.3})",
+                trajectory.len(),
+                end.0,
+                end.1
+            );
+        }
+        None => {
+            eprintln!("Pure pursuit failed");
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/bin/rrt.rs
+++ b/src/bin/rrt.rs
@@ -1,0 +1,21 @@
+use rust_robotics::path_planning::{AreaBounds, CircleObstacle, RRTConfig, RRTPlanner};
+
+fn main() {
+    let obstacles = vec![
+        CircleObstacle::new(5.0, 5.0, 1.0),
+        CircleObstacle::new(3.0, 6.0, 2.0),
+        CircleObstacle::new(7.0, 8.0, 1.5),
+    ];
+    let rand_area = AreaBounds::new(-2.0, 15.0, -2.0, 15.0);
+    let mut planner = RRTPlanner::new(obstacles, rand_area, None, RRTConfig::default());
+
+    match planner.planning([0.0, 0.0], [10.0, 10.0]) {
+        Some(path) => {
+            println!("RRT path found with {} points", path.len());
+        }
+        None => {
+            eprintln!("RRT failed to find a path");
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/bin/stanley_controller.rs
+++ b/src/bin/stanley_controller.rs
@@ -1,0 +1,24 @@
+use rust_robotics::path_tracking::{StanleyConfig, StanleyController};
+
+fn main() {
+    let waypoints: Vec<(f64, f64)> = (0..20)
+        .map(|i| (i as f64, (i as f64 / 4.0).cos() * 2.0))
+        .collect();
+
+    let mut controller = StanleyController::new(StanleyConfig::default());
+    match controller.planning(waypoints, 5.0, 0.5) {
+        Some(trajectory) => {
+            let end = trajectory.last().copied().unwrap_or((0.0, 0.0));
+            println!(
+                "Stanley trajectory points={}, end=({:.3}, {:.3})",
+                trajectory.len(),
+                end.0,
+                end.1
+            );
+        }
+        None => {
+            eprintln!("Stanley controller failed");
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/bin/state_machine.rs
+++ b/src/bin/state_machine.rs
@@ -1,0 +1,3 @@
+fn main() {
+    rust_robotics::mission_planning::state_machine::demo_state_machine();
+}

--- a/src/bin/unscented_kalman_filter.rs
+++ b/src/bin/unscented_kalman_filter.rs
@@ -1,5 +1,5 @@
-use rust_robotics::localization::{UKFLocalizer, UKFState};
 use rust_robotics::localization::unscented_kalman_filter::{calc_input, observation};
+use rust_robotics::localization::{UKFLocalizer, UKFState};
 use rust_robotics::StateEstimator;
 
 fn main() {

--- a/src/bin/unscented_kalman_filter.rs
+++ b/src/bin/unscented_kalman_filter.rs
@@ -1,0 +1,22 @@
+use rust_robotics::localization::{UKFLocalizer, UKFState};
+use rust_robotics::localization::unscented_kalman_filter::{calc_input, observation};
+use rust_robotics::StateEstimator;
+
+fn main() {
+    let mut ukf = UKFLocalizer::with_defaults();
+    let mut x_true = UKFState::zeros();
+    let mut x_dr = UKFState::zeros();
+
+    for _ in 0..50 {
+        let u = calc_input();
+        let (z, u_noisy) = observation(&mut x_true, &mut x_dr, &u);
+        ukf.predict(&u_noisy, 0.1);
+        ukf.update(&z);
+    }
+
+    let estimate = ukf.estimate();
+    println!(
+        "UKF estimate: x={:.3}, y={:.3}, yaw={:.3}, v={:.3}",
+        estimate[0], estimate[1], estimate[2], estimate[3]
+    );
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -3,10 +3,10 @@
 //! This module provides the foundational building blocks used across
 //! all robotics algorithms in this crate.
 
-pub mod types;
-pub mod traits;
 pub mod error;
+pub mod traits;
+pub mod types;
 
-pub use types::*;
-pub use traits::*;
 pub use error::*;
+pub use traits::*;
+pub use types::*;

--- a/src/common/traits.rs
+++ b/src/common/traits.rs
@@ -1,7 +1,7 @@
 //! Common traits defining interfaces for robotics algorithms
 
-use crate::common::types::*;
 use crate::common::error::RoboticsError;
+use crate::common::types::*;
 
 /// Trait for path planning algorithms
 pub trait PathPlanner {
@@ -92,8 +92,12 @@ pub trait MotionModel {
     fn propagate(&self, state: &Self::State, control: &Self::Control, dt: f64) -> Self::State;
 
     /// Compute Jacobian with respect to state (for EKF)
-    fn jacobian_state(&self, state: &Self::State, control: &Self::Control, dt: f64)
-        -> nalgebra::DMatrix<f64>;
+    fn jacobian_state(
+        &self,
+        state: &Self::State,
+        control: &Self::Control,
+        dt: f64,
+    ) -> nalgebra::DMatrix<f64>;
 }
 
 /// Trait for observation/measurement models

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1,6 +1,6 @@
 //! Common types used throughout rust_robotics
 
-use nalgebra::{Vector2, Vector3, Vector4, Matrix2, Matrix4};
+use nalgebra::{Matrix2, Matrix4, Vector2, Vector3, Vector4};
 
 /// 2D point representation
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -29,7 +29,10 @@ impl Point2D {
 
 impl From<(f64, f64)> for Point2D {
     fn from(tuple: (f64, f64)) -> Self {
-        Self { x: tuple.0, y: tuple.1 }
+        Self {
+            x: tuple.0,
+            y: tuple.1,
+        }
     }
 }
 
@@ -53,11 +56,16 @@ impl Point3D {
     }
 
     pub fn origin() -> Self {
-        Self { x: 0.0, y: 0.0, z: 0.0 }
+        Self {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        }
     }
 
     pub fn distance(&self, other: &Point3D) -> f64 {
-        ((self.x - other.x).powi(2) + (self.y - other.y).powi(2) + (self.z - other.z).powi(2)).sqrt()
+        ((self.x - other.x).powi(2) + (self.y - other.y).powi(2) + (self.z - other.z).powi(2))
+            .sqrt()
     }
 
     pub fn to_vector(&self) -> Vector3<f64> {
@@ -79,7 +87,11 @@ impl Pose2D {
     }
 
     pub fn origin() -> Self {
-        Self { x: 0.0, y: 0.0, yaw: 0.0 }
+        Self {
+            x: 0.0,
+            y: 0.0,
+            yaw: 0.0,
+        }
     }
 
     pub fn position(&self) -> Point2D {
@@ -103,7 +115,11 @@ impl Pose2D {
 
 impl From<Vector3<f64>> for Pose2D {
     fn from(v: Vector3<f64>) -> Self {
-        Self { x: v[0], y: v[1], yaw: v[2] }
+        Self {
+            x: v[0],
+            y: v[1],
+            yaw: v[2],
+        }
     }
 }
 
@@ -122,7 +138,12 @@ impl State2D {
     }
 
     pub fn origin() -> Self {
-        Self { x: 0.0, y: 0.0, yaw: 0.0, v: 0.0 }
+        Self {
+            x: 0.0,
+            y: 0.0,
+            yaw: 0.0,
+            v: 0.0,
+        }
     }
 
     pub fn pose(&self) -> Pose2D {
@@ -140,15 +161,20 @@ impl State2D {
 
 impl From<Vector4<f64>> for State2D {
     fn from(v: Vector4<f64>) -> Self {
-        Self { x: v[0], y: v[1], yaw: v[2], v: v[3] }
+        Self {
+            x: v[0],
+            y: v[1],
+            yaw: v[2],
+            v: v[3],
+        }
     }
 }
 
 /// Control input for differential drive robot
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ControlInput {
-    pub v: f64,      // linear velocity
-    pub omega: f64,  // angular velocity
+    pub v: f64,     // linear velocity
+    pub omega: f64, // angular velocity
 }
 
 impl ControlInput {
@@ -167,7 +193,10 @@ impl ControlInput {
 
 impl From<Vector2<f64>> for ControlInput {
     fn from(v: Vector2<f64>) -> Self {
-        Self { v: v[0], omega: v[1] }
+        Self {
+            v: v[0],
+            omega: v[1],
+        }
     }
 }
 
@@ -188,7 +217,9 @@ impl Path2D {
 
     pub fn from_xy(x: &[f64], y: &[f64]) -> Self {
         assert_eq!(x.len(), y.len());
-        let points = x.iter().zip(y.iter())
+        let points = x
+            .iter()
+            .zip(y.iter())
             .map(|(&x, &y)| Point2D::new(x, y))
             .collect();
         Self { points }
@@ -218,9 +249,7 @@ impl Path2D {
         if self.points.len() < 2 {
             return 0.0;
         }
-        self.points.windows(2)
-            .map(|w| w[0].distance(&w[1]))
-            .sum()
+        self.points.windows(2).map(|w| w[0].distance(&w[1])).sum()
     }
 }
 
@@ -260,7 +289,9 @@ impl Obstacles {
 
     pub fn from_xy(x: &[f64], y: &[f64]) -> Self {
         assert_eq!(x.len(), y.len());
-        let points = x.iter().zip(y.iter())
+        let points = x
+            .iter()
+            .zip(y.iter())
             .map(|(&x, &y)| Point2D::new(x, y))
             .collect();
         Self { points }

--- a/src/control/lqr_control.rs
+++ b/src/control/lqr_control.rs
@@ -6,14 +6,14 @@
 // Visualization style based on PythonRobotics by AtsushiSakai
 //
 
-use gnuplot::{Figure, AxesCommon, PlotOption, Coordinate};
-use nalgebra::{Matrix4, Matrix1, Vector4, Matrix1x4};
+use gnuplot::{AxesCommon, Coordinate, Figure, PlotOption};
+use nalgebra::{Matrix1, Matrix1x4, Matrix4, Vector4};
 
 // Model parameters
-const L_BAR: f64 = 2.0;  // length of bar
-const M: f64 = 1.0;      // [kg] cart mass
-const MASS: f64 = 0.3;   // [kg] pendulum mass
-const G: f64 = 9.8;      // [m/s^2] gravity
+const L_BAR: f64 = 2.0; // length of bar
+const M: f64 = 1.0; // [kg] cart mass
+const MASS: f64 = 0.3; // [kg] pendulum mass
+const G: f64 = 9.8; // [m/s^2] gravity
 
 const DELTA_T: f64 = 0.1; // time tick [s]
 const SIM_TIME: f64 = 5.0; // simulation time [s]
@@ -24,16 +24,16 @@ const CART_HEIGHT: f64 = 0.5;
 const WHEEL_RADIUS: f64 = 0.1;
 
 pub struct InvertedPendulumLQR {
-    pub q: Matrix4<f64>,     // state cost matrix
-    pub r: Matrix1<f64>,     // input cost matrix
+    pub q: Matrix4<f64>,                      // state cost matrix
+    pub r: Matrix1<f64>,                      // input cost matrix
     pub trajectory: Vec<(f64, Vector4<f64>)>, // time, state history
 }
 
 impl InvertedPendulumLQR {
     pub fn new() -> Self {
         let mut q = Matrix4::<f64>::zeros();
-        q[(1, 1)] = 1.0;  // velocity cost
-        q[(2, 2)] = 1.0;  // angle cost
+        q[(1, 1)] = 1.0; // velocity cost
+        q[(2, 2)] = 1.0; // angle cost
 
         let r = Matrix1::<f64>::from_element(0.01); // input cost
 
@@ -64,8 +64,11 @@ impl InvertedPendulumLQR {
         }
 
         println!("Simulation finished");
-        println!("Final state: x={:.2} [m], theta={:.2} [deg]",
-                x[0], x[2].to_degrees());
+        println!(
+            "Final state: x={:.2} [m], theta={:.2} [deg]",
+            x[0],
+            x[2].to_degrees()
+        );
 
         true
     }
@@ -83,24 +86,37 @@ impl InvertedPendulumLQR {
 
     fn get_model_matrix(&self) -> (Matrix4<f64>, Vector4<f64>) {
         let mut a = Matrix4::<f64>::new(
-            0.0, 1.0, 0.0, 0.0,
-            0.0, 0.0, MASS * G / M, 0.0,
-            0.0, 0.0, 0.0, 1.0,
-            0.0, 0.0, G * (M + MASS) / (L_BAR * M), 0.0
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            MASS * G / M,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            G * (M + MASS) / (L_BAR * M),
+            0.0,
         );
         a = Matrix4::<f64>::identity() + DELTA_T * a;
 
-        let b = Vector4::new(
-            0.0,
-            1.0 / M,
-            0.0,
-            1.0 / (L_BAR * M)
-        ) * DELTA_T;
+        let b = Vector4::new(0.0, 1.0 / M, 0.0, 1.0 / (L_BAR * M)) * DELTA_T;
 
         (a, b)
     }
 
-    fn solve_dare(&self, a: &Matrix4<f64>, b: &Vector4<f64>, q: &Matrix4<f64>, r: &Matrix1<f64>) -> Matrix4<f64> {
+    fn solve_dare(
+        &self,
+        a: &Matrix4<f64>,
+        b: &Vector4<f64>,
+        q: &Matrix4<f64>,
+        r: &Matrix1<f64>,
+    ) -> Matrix4<f64> {
         let mut p = *q;
         let max_iter = 150;
         let eps = 0.01;
@@ -112,8 +128,9 @@ impl InvertedPendulumLQR {
                 break;
             }
 
-            let pn = a.transpose() * p * a -
-                     a.transpose() * p * b * (1.0 / denominator[0]) * bt_p * a + q;
+            let pn = a.transpose() * p * a
+                - a.transpose() * p * b * (1.0 / denominator[0]) * bt_p * a
+                + q;
 
             if (pn - p).abs().max() < eps {
                 break;
@@ -123,7 +140,13 @@ impl InvertedPendulumLQR {
         p
     }
 
-    fn dlqr(&self, a: &Matrix4<f64>, b: &Vector4<f64>, q: &Matrix4<f64>, r: &Matrix1<f64>) -> (Matrix1x4<f64>, Matrix4<f64>, Vector4<f64>) {
+    fn dlqr(
+        &self,
+        a: &Matrix4<f64>,
+        b: &Vector4<f64>,
+        q: &Matrix4<f64>,
+        r: &Matrix1<f64>,
+    ) -> (Matrix1x4<f64>, Matrix4<f64>, Vector4<f64>) {
         let p = self.solve_dare(a, b, q, r);
 
         let bt_p = b.transpose() * p;
@@ -142,11 +165,13 @@ impl InvertedPendulumLQR {
         let half_w = CART_WIDTH / 2.0;
 
         // Rectangle corners (closed polygon)
-        let xs = vec![
-            x - half_w, x + half_w, x + half_w, x - half_w, x - half_w
-        ];
+        let xs = vec![x - half_w, x + half_w, x + half_w, x - half_w, x - half_w];
         let ys = vec![
-            y_offset, y_offset, y_offset + CART_HEIGHT, y_offset + CART_HEIGHT, y_offset
+            y_offset,
+            y_offset,
+            y_offset + CART_HEIGHT,
+            y_offset + CART_HEIGHT,
+            y_offset,
         ];
         (xs, ys)
     }
@@ -181,20 +206,35 @@ impl InvertedPendulumLQR {
 
         let mut fg = Figure::new();
         {
-            let axes = fg.axes2d()
+            let axes = fg
+                .axes2d()
                 .set_title("Inverted Pendulum LQR Control", &[])
                 .set_x_label("x [m]", &[])
                 .set_y_label("y [m]", &[])
                 .set_aspect_ratio(gnuplot::AutoOption::Fix(1.0))
-                .set_x_range(gnuplot::AutoOption::Fix(-3.0), gnuplot::AutoOption::Fix(3.0))
-                .set_y_range(gnuplot::AutoOption::Fix(-1.0), gnuplot::AutoOption::Fix(4.0));
+                .set_x_range(
+                    gnuplot::AutoOption::Fix(-3.0),
+                    gnuplot::AutoOption::Fix(3.0),
+                )
+                .set_y_range(
+                    gnuplot::AutoOption::Fix(-1.0),
+                    gnuplot::AutoOption::Fix(4.0),
+                );
 
             // Draw ground line
-            axes.lines(&[-4.0, 4.0], &[0.0, 0.0], &[PlotOption::Color("gray"), PlotOption::LineWidth(2.0)]);
+            axes.lines(
+                &[-4.0, 4.0],
+                &[0.0, 0.0],
+                &[PlotOption::Color("gray"), PlotOption::LineWidth(2.0)],
+            );
 
             // Draw multiple frames with transparency effect (lighter colors for older frames)
-            let colors = ["#CCCCFF", "#AAAAFF", "#8888FF", "#6666FF", "#4444FF", "#0000FF"];
-            let pendulum_colors = ["#CCCCCC", "#AAAAAA", "#888888", "#666666", "#444444", "#000000"];
+            let colors = [
+                "#CCCCFF", "#AAAAFF", "#8888FF", "#6666FF", "#4444FF", "#0000FF",
+            ];
+            let pendulum_colors = [
+                "#CCCCCC", "#AAAAAA", "#888888", "#666666", "#444444", "#000000",
+            ];
 
             for (frame_idx, color_idx) in (0..num_frames).zip(0..num_frames) {
                 let step = if frame_idx == num_frames - 1 {
@@ -209,22 +249,57 @@ impl InvertedPendulumLQR {
 
                 // Draw cart
                 let (cart_x, cart_y) = self.get_cart_polygon(x_pos);
-                axes.lines(&cart_x, &cart_y, &[PlotOption::Color(colors[color_idx]), PlotOption::LineWidth(2.0)]);
+                axes.lines(
+                    &cart_x,
+                    &cart_y,
+                    &[
+                        PlotOption::Color(colors[color_idx]),
+                        PlotOption::LineWidth(2.0),
+                    ],
+                );
 
                 // Draw wheels
                 let y_offset = WHEEL_RADIUS;
                 let (w1x, w1y) = self.get_wheel_points(x_pos - CART_WIDTH / 4.0, y_offset);
                 let (w2x, w2y) = self.get_wheel_points(x_pos + CART_WIDTH / 4.0, y_offset);
-                axes.lines(&w1x, &w1y, &[PlotOption::Color(pendulum_colors[color_idx]), PlotOption::LineWidth(1.5)]);
-                axes.lines(&w2x, &w2y, &[PlotOption::Color(pendulum_colors[color_idx]), PlotOption::LineWidth(1.5)]);
+                axes.lines(
+                    &w1x,
+                    &w1y,
+                    &[
+                        PlotOption::Color(pendulum_colors[color_idx]),
+                        PlotOption::LineWidth(1.5),
+                    ],
+                );
+                axes.lines(
+                    &w2x,
+                    &w2y,
+                    &[
+                        PlotOption::Color(pendulum_colors[color_idx]),
+                        PlotOption::LineWidth(1.5),
+                    ],
+                );
 
                 // Draw pendulum
                 let (pend_x, pend_y) = self.get_pendulum_points(x_pos, theta);
-                axes.lines(&pend_x, &pend_y, &[PlotOption::Color(pendulum_colors[color_idx]), PlotOption::LineWidth(3.0)]);
+                axes.lines(
+                    &pend_x,
+                    &pend_y,
+                    &[
+                        PlotOption::Color(pendulum_colors[color_idx]),
+                        PlotOption::LineWidth(3.0),
+                    ],
+                );
 
                 // Draw pendulum mass (circle at the end)
                 let (mass_x, mass_y) = self.get_wheel_points(pend_x[1], pend_y[1]);
-                axes.lines(&mass_x, &mass_y, &[PlotOption::Color(pendulum_colors[color_idx]), PlotOption::LineWidth(2.0)]);
+                axes.lines(
+                    &mass_x,
+                    &mass_y,
+                    &[
+                        PlotOption::Color(pendulum_colors[color_idx]),
+                        PlotOption::LineWidth(2.0),
+                    ],
+                );
 
                 // Add time label for the last frame
                 if frame_idx == num_frames - 1 {
@@ -232,7 +307,7 @@ impl InvertedPendulumLQR {
                         &format!("t={:.1}s", time),
                         Coordinate::Graph(0.02),
                         Coordinate::Graph(0.95),
-                        &[]
+                        &[],
                     );
                 }
             }
@@ -243,7 +318,7 @@ impl InvertedPendulumLQR {
                 &format!("Initial angle: {:.1} deg", initial_state[2].to_degrees()),
                 Coordinate::Graph(0.02),
                 Coordinate::Graph(0.88),
-                &[]
+                &[],
             );
         }
 
@@ -266,42 +341,76 @@ impl InvertedPendulumLQR {
 
         let mut fg = Figure::new();
         {
-            let axes = fg.axes2d()
-                .set_title(&format!("Inverted Pendulum LQR Control  t={:.2}s", time), &[])
+            let axes = fg
+                .axes2d()
+                .set_title(
+                    &format!("Inverted Pendulum LQR Control  t={:.2}s", time),
+                    &[],
+                )
                 .set_x_label("x [m]", &[])
                 .set_y_label("y [m]", &[])
                 .set_aspect_ratio(gnuplot::AutoOption::Fix(1.0))
-                .set_x_range(gnuplot::AutoOption::Fix(-3.0), gnuplot::AutoOption::Fix(3.0))
-                .set_y_range(gnuplot::AutoOption::Fix(-1.0), gnuplot::AutoOption::Fix(4.0));
+                .set_x_range(
+                    gnuplot::AutoOption::Fix(-3.0),
+                    gnuplot::AutoOption::Fix(3.0),
+                )
+                .set_y_range(
+                    gnuplot::AutoOption::Fix(-1.0),
+                    gnuplot::AutoOption::Fix(4.0),
+                );
 
             // Draw ground line
-            axes.lines(&[-4.0, 4.0], &[0.0, 0.0], &[PlotOption::Color("gray"), PlotOption::LineWidth(2.0)]);
+            axes.lines(
+                &[-4.0, 4.0],
+                &[0.0, 0.0],
+                &[PlotOption::Color("gray"), PlotOption::LineWidth(2.0)],
+            );
 
             // Draw cart (blue, matching PythonRobotics)
             let (cart_x, cart_y) = self.get_cart_polygon(x_pos);
-            axes.lines(&cart_x, &cart_y, &[PlotOption::Color("blue"), PlotOption::LineWidth(2.0)]);
+            axes.lines(
+                &cart_x,
+                &cart_y,
+                &[PlotOption::Color("blue"), PlotOption::LineWidth(2.0)],
+            );
 
             // Draw wheels (black)
             let y_offset = WHEEL_RADIUS;
             let (w1x, w1y) = self.get_wheel_points(x_pos - CART_WIDTH / 4.0, y_offset);
             let (w2x, w2y) = self.get_wheel_points(x_pos + CART_WIDTH / 4.0, y_offset);
-            axes.lines(&w1x, &w1y, &[PlotOption::Color("black"), PlotOption::LineWidth(1.5)]);
-            axes.lines(&w2x, &w2y, &[PlotOption::Color("black"), PlotOption::LineWidth(1.5)]);
+            axes.lines(
+                &w1x,
+                &w1y,
+                &[PlotOption::Color("black"), PlotOption::LineWidth(1.5)],
+            );
+            axes.lines(
+                &w2x,
+                &w2y,
+                &[PlotOption::Color("black"), PlotOption::LineWidth(1.5)],
+            );
 
             // Draw pendulum (black, matching PythonRobotics)
             let (pend_x, pend_y) = self.get_pendulum_points(x_pos, theta);
-            axes.lines(&pend_x, &pend_y, &[PlotOption::Color("black"), PlotOption::LineWidth(3.0)]);
+            axes.lines(
+                &pend_x,
+                &pend_y,
+                &[PlotOption::Color("black"), PlotOption::LineWidth(3.0)],
+            );
 
             // Draw pendulum mass
             let (mass_x, mass_y) = self.get_wheel_points(pend_x[1], pend_y[1]);
-            axes.lines(&mass_x, &mass_y, &[PlotOption::Color("black"), PlotOption::LineWidth(2.0)]);
+            axes.lines(
+                &mass_x,
+                &mass_y,
+                &[PlotOption::Color("black"), PlotOption::LineWidth(2.0)],
+            );
 
             // Add state info
             axes.label(
                 &format!("x={:.2}m, θ={:.1}°", x_pos, theta.to_degrees()),
                 Coordinate::Graph(0.02),
                 Coordinate::Graph(0.95),
-                &[]
+                &[],
             );
         }
 

--- a/src/control/lqr_control.rs
+++ b/src/control/lqr_control.rs
@@ -1,3 +1,9 @@
+#![allow(
+    dead_code,
+    clippy::needless_borrows_for_generic_args,
+    clippy::new_without_default
+)]
+
 //
 // Inverted Pendulum LQR control
 // author: Trung Kien - letrungkien.k53.hut@gmail.com

--- a/src/control/mpc_control.rs
+++ b/src/control/mpc_control.rs
@@ -4,35 +4,35 @@
 // Ported to Rust by: rust_robotics team
 //
 
-use gnuplot::{Figure, Caption, Color, AxesCommon, PointSymbol};
-use nalgebra::{Matrix4, Matrix1, Vector4, DMatrix, DVector};
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSymbol};
+use nalgebra::{DMatrix, DVector, Matrix1, Matrix4, Vector4};
 use std::f64::consts::PI;
 
 // Model parameters
-const L_BAR: f64 = 2.0;  // length of bar
-const M: f64 = 1.0;      // [kg] cart mass
-const MASS: f64 = 0.3;   // [kg] pendulum mass
-const G: f64 = 9.8;      // [m/s^2] gravity
+const L_BAR: f64 = 2.0; // length of bar
+const M: f64 = 1.0; // [kg] cart mass
+const MASS: f64 = 0.3; // [kg] pendulum mass
+const G: f64 = 9.8; // [m/s^2] gravity
 
-const T: usize = 30;     // Horizon length
+const T: usize = 30; // Horizon length
 const DELTA_T: f64 = 0.1; // time tick [s]
 const SIM_TIME: f64 = 5.0; // simulation time [s]
 
 pub struct InvertedPendulumMPC {
-    pub q: Matrix4<f64>,     // state cost matrix
-    pub r: Matrix1<f64>,     // input cost matrix
-    pub trajectory: Vec<(f64, Vector4<f64>)>, // time, state history
+    pub q: Matrix4<f64>,                            // state cost matrix
+    pub r: Matrix1<f64>,                            // input cost matrix
+    pub trajectory: Vec<(f64, Vector4<f64>)>,       // time, state history
     pub prediction_history: Vec<Vec<Vector4<f64>>>, // predicted trajectories for animation
 }
 
 impl InvertedPendulumMPC {
     pub fn new() -> Self {
         let mut q = Matrix4::<f64>::zeros();
-        q[(1, 1)] = 1.0;  // velocity cost
-        q[(2, 2)] = 1.0;  // angle cost
-        
+        q[(1, 1)] = 1.0; // velocity cost
+        q[(2, 2)] = 1.0; // angle cost
+
         let r = Matrix1::<f64>::from_element(0.01); // input cost
-        
+
         InvertedPendulumMPC {
             q,
             r,
@@ -44,7 +44,7 @@ impl InvertedPendulumMPC {
     pub fn simulate(&mut self, x0: Vector4<f64>) -> bool {
         let mut x = x0;
         let mut time = 0.0;
-        
+
         self.trajectory.clear();
         self.prediction_history.clear();
         self.trajectory.push((time, x));
@@ -55,26 +55,35 @@ impl InvertedPendulumMPC {
 
             // Calculate MPC control input and predicted trajectory
             let (predicted_states, u) = self.mpc_control(&x);
-            
+
             // Store prediction for animation
             self.prediction_history.push(predicted_states);
 
             // Simulate inverted pendulum cart
             x = self.simulation_step(&x, u);
-            
+
             self.trajectory.push((time, x));
 
             // Generate frame for animation
-            if frame_count % 5 == 0 { // Every 5th frame to reduce file count
-                self.save_animation_frame(frame_count / 5, time, &x, &self.prediction_history.last().unwrap());
+            if frame_count % 5 == 0 {
+                // Every 5th frame to reduce file count
+                self.save_animation_frame(
+                    frame_count / 5,
+                    time,
+                    &x,
+                    &self.prediction_history.last().unwrap(),
+                );
             }
             frame_count += 1;
         }
 
         println!("MPC simulation finished");
-        println!("Final state: x={:.2} [m], theta={:.2} [deg]", 
-                x[0], x[2].to_degrees());
-        
+        println!(
+            "Final state: x={:.2} [m], theta={:.2} [deg]",
+            x[0],
+            x[2].to_degrees()
+        );
+
         true
     }
 
@@ -86,89 +95,115 @@ impl InvertedPendulumMPC {
     fn mpc_control(&self, x0: &Vector4<f64>) -> (Vec<Vector4<f64>>, Matrix1<f64>) {
         // Simplified MPC using iterative LQR approach (since we don't have cvxpy)
         let (a, b) = self.get_model_matrix();
-        
+
         // Initialize control sequence
         let mut u_seq = vec![0.0; T];
         let mut best_cost = f64::INFINITY;
         let mut best_u_seq = u_seq.clone();
-        
+
         // Simple gradient descent optimization
         for _iter in 0..50 {
             let (states, cost) = self.simulate_prediction(x0, &u_seq, &a, &b);
-            
+
             if cost < best_cost {
                 best_cost = cost;
                 best_u_seq = u_seq.clone();
             }
-            
+
             // Update control sequence using simple gradient
             for t in 0..T {
                 let mut u_plus = u_seq.clone();
                 let mut u_minus = u_seq.clone();
                 let delta = 0.01;
-                
+
                 u_plus[t] += delta;
                 u_minus[t] -= delta;
-                
+
                 let (_, cost_plus) = self.simulate_prediction(x0, &u_plus, &a, &b);
                 let (_, cost_minus) = self.simulate_prediction(x0, &u_minus, &a, &b);
-                
+
                 let gradient = (cost_plus - cost_minus) / (2.0 * delta);
                 u_seq[t] -= 0.1 * gradient; // Learning rate
-                
+
                 // Clamp control input
                 u_seq[t] = u_seq[t].clamp(-10.0, 10.0);
             }
         }
-        
+
         let (predicted_states, _) = self.simulate_prediction(x0, &best_u_seq, &a, &b);
         (predicted_states, Matrix1::from_element(best_u_seq[0]))
     }
 
-    fn simulate_prediction(&self, x0: &Vector4<f64>, u_seq: &[f64], a: &Matrix4<f64>, b: &Vector4<f64>) -> (Vec<Vector4<f64>>, f64) {
+    fn simulate_prediction(
+        &self,
+        x0: &Vector4<f64>,
+        u_seq: &[f64],
+        a: &Matrix4<f64>,
+        b: &Vector4<f64>,
+    ) -> (Vec<Vector4<f64>>, f64) {
         let mut x = *x0;
         let mut states = vec![x];
         let mut cost = 0.0;
-        
+
         for t in 0..T {
             // State cost
             cost += (x.transpose() * self.q * x)[0];
-            
+
             // Control cost
             cost += u_seq[t] * self.r[0] * u_seq[t];
-            
+
             // Update state
             x = a * x + b * u_seq[t];
             states.push(x);
         }
-        
+
         (states, cost)
     }
 
     fn get_model_matrix(&self) -> (Matrix4<f64>, Vector4<f64>) {
         let mut a = Matrix4::<f64>::new(
-            0.0, 1.0, 0.0, 0.0,
-            0.0, 0.0, MASS * G / M, 0.0,
-            0.0, 0.0, 0.0, 1.0,
-            0.0, 0.0, G * (M + MASS) / (L_BAR * M), 0.0
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            MASS * G / M,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            G * (M + MASS) / (L_BAR * M),
+            0.0,
         );
         a = Matrix4::<f64>::identity() + DELTA_T * a;
 
-        let b = Vector4::new(
-            0.0,
-            1.0 / M,
-            0.0,
-            1.0 / (L_BAR * M)
-        ) * DELTA_T;
+        let b = Vector4::new(0.0, 1.0 / M, 0.0, 1.0 / (L_BAR * M)) * DELTA_T;
 
         (a, b)
     }
 
-    fn save_animation_frame(&self, frame: usize, time: f64, current_state: &Vector4<f64>, predicted_states: &[Vector4<f64>]) {
+    fn save_animation_frame(
+        &self,
+        frame: usize,
+        time: f64,
+        current_state: &Vector4<f64>,
+        predicted_states: &[Vector4<f64>],
+    ) {
         let mut fg = Figure::new();
         {
-            let mut axes = fg.axes2d()
-                .set_title(&format!("Inverted Pendulum MPC Control - Frame {} (t={:.1}s)", frame, time), &[])
+            let mut axes = fg
+                .axes2d()
+                .set_title(
+                    &format!(
+                        "Inverted Pendulum MPC Control - Frame {} (t={:.1}s)",
+                        frame, time
+                    ),
+                    &[],
+                )
                 .set_x_label("Position [m]", &[])
                 .set_y_label("Height [m]", &[])
                 .set_x_range(gnuplot::Fix(-6.0), gnuplot::Fix(3.0))
@@ -177,30 +212,38 @@ impl InvertedPendulumMPC {
 
             // Draw cart and pendulum
             self.draw_cart_pendulum(&mut axes, current_state[0], current_state[2]);
-            
+
             // Draw predicted trajectory
             if predicted_states.len() > 1 {
                 let pred_x: Vec<f64> = predicted_states.iter().map(|s| s[0]).collect();
                 let pred_angles: Vec<f64> = predicted_states.iter().map(|s| s[2]).collect();
-                
+
                 // Draw predicted cart positions
-                axes.points(&pred_x, &vec![0.2; pred_x.len()], &[
-                    Caption("Predicted Path"), 
-                    Color("red"), 
-                    PointSymbol('.')
-                ]);
-                
+                axes.points(
+                    &pred_x,
+                    &vec![0.2; pred_x.len()],
+                    &[Caption("Predicted Path"), Color("red"), PointSymbol('.')],
+                );
+
                 // Draw predicted pendulum tips
-                let pred_tip_x: Vec<f64> = predicted_states.iter()
-                    .map(|s| s[0] + L_BAR * s[2].sin()).collect();
-                let pred_tip_y: Vec<f64> = predicted_states.iter()
-                    .map(|s| 0.5 + L_BAR * s[2].cos()).collect();
-                    
-                axes.points(&pred_tip_x, &pred_tip_y, &[
-                    Caption("Predicted Pendulum"), 
-                    Color("orange"), 
-                    PointSymbol('x')
-                ]);
+                let pred_tip_x: Vec<f64> = predicted_states
+                    .iter()
+                    .map(|s| s[0] + L_BAR * s[2].sin())
+                    .collect();
+                let pred_tip_y: Vec<f64> = predicted_states
+                    .iter()
+                    .map(|s| 0.5 + L_BAR * s[2].cos())
+                    .collect();
+
+                axes.points(
+                    &pred_tip_x,
+                    &pred_tip_y,
+                    &[
+                        Caption("Predicted Pendulum"),
+                        Color("orange"),
+                        PointSymbol('x'),
+                    ],
+                );
             }
         }
 
@@ -216,22 +259,43 @@ impl InvertedPendulumMPC {
         let radius = 0.1;
 
         // Cart body
-        let cx = vec![x - cart_w/2.0, x + cart_w/2.0, x + cart_w/2.0, x - cart_w/2.0, x - cart_w/2.0];
-        let cy = vec![radius*2.0, radius*2.0, cart_h + radius*2.0, cart_h + radius*2.0, radius*2.0];
+        let cx = vec![
+            x - cart_w / 2.0,
+            x + cart_w / 2.0,
+            x + cart_w / 2.0,
+            x - cart_w / 2.0,
+            x - cart_w / 2.0,
+        ];
+        let cy = vec![
+            radius * 2.0,
+            radius * 2.0,
+            cart_h + radius * 2.0,
+            cart_h + radius * 2.0,
+            radius * 2.0,
+        ];
         axes.lines(&cx, &cy, &[Caption("Cart"), Color("blue")]);
 
         // Pendulum rod
         let bx = vec![x, x + L_BAR * theta.sin()];
-        let by = vec![cart_h + radius*2.0, cart_h + radius*2.0 + L_BAR * theta.cos()];
+        let by = vec![
+            cart_h + radius * 2.0,
+            cart_h + radius * 2.0 + L_BAR * theta.cos(),
+        ];
         axes.lines(&bx, &by, &[Caption("Pendulum"), Color("black")]);
 
         // Wheels
         let angles: Vec<f64> = (0..120).map(|i| i as f64 * PI / 60.0).collect();
-        let wheel_x: Vec<f64> = angles.iter().map(|a| x - cart_w/4.0 + radius * a.cos()).collect();
+        let wheel_x: Vec<f64> = angles
+            .iter()
+            .map(|a| x - cart_w / 4.0 + radius * a.cos())
+            .collect();
         let wheel_y: Vec<f64> = angles.iter().map(|a| radius + radius * a.sin()).collect();
         axes.lines(&wheel_x, &wheel_y, &[Color("black")]);
 
-        let wheel_x2: Vec<f64> = angles.iter().map(|a| x + cart_w/4.0 + radius * a.cos()).collect();
+        let wheel_x2: Vec<f64> = angles
+            .iter()
+            .map(|a| x + cart_w / 4.0 + radius * a.cos())
+            .collect();
         axes.lines(&wheel_x2, &wheel_y, &[Color("black")]);
 
         // Pendulum mass
@@ -243,15 +307,20 @@ impl InvertedPendulumMPC {
     pub fn create_summary_plot(&self) {
         let mut fg = Figure::new();
         {
-            let axes = fg.axes2d()
+            let axes = fg
+                .axes2d()
                 .set_title("Inverted Pendulum MPC Control - Summary", &[])
                 .set_x_label("Time [s]", &[])
                 .set_y_label("State", &[]);
 
             let time: Vec<f64> = self.trajectory.iter().map(|(t, _)| *t).collect();
             let position: Vec<f64> = self.trajectory.iter().map(|(_, x)| x[0]).collect();
-            let angle: Vec<f64> = self.trajectory.iter().map(|(_, x)| x[2].to_degrees()).collect();
-            
+            let angle: Vec<f64> = self
+                .trajectory
+                .iter()
+                .map(|(_, x)| x[2].to_degrees())
+                .collect();
+
             axes.lines(&time, &position, &[Caption("Position [m]"), Color("blue")]);
             axes.lines(&time, &angle, &[Caption("Angle [deg]"), Color("red")]);
         }
@@ -268,12 +337,12 @@ fn main() {
     std::fs::create_dir_all("img/inverted_pendulum").unwrap();
 
     let mut controller = InvertedPendulumMPC::new();
-    
+
     // Initial state: [position, velocity, angle, angular_velocity]
     let x0 = Vector4::new(0.0, 0.0, 0.3, 0.0); // 0.3 rad initial angle
-    
+
     println!("Starting Inverted Pendulum MPC Control simulation...");
-    
+
     if controller.simulate(x0) {
         controller.create_summary_plot();
         println!("MPC Control simulation complete!");

--- a/src/control/mpc_control.rs
+++ b/src/control/mpc_control.rs
@@ -73,7 +73,7 @@ impl InvertedPendulumMPC {
                     frame_count / 5,
                     time,
                     &x,
-                    &self.prediction_history.last().unwrap(),
+                    self.prediction_history.last().unwrap(),
                 );
             }
             frame_count += 1;
@@ -147,15 +147,15 @@ impl InvertedPendulumMPC {
         let mut states = vec![x];
         let mut cost = 0.0;
 
-        for t in 0..T {
+        for &u_t in u_seq.iter().take(T) {
             // State cost
             cost += (x.transpose() * self.q * x)[0];
 
             // Control cost
-            cost += u_seq[t] * self.r[0] * u_seq[t];
+            cost += u_t * self.r[0] * u_t;
 
             // Update state
-            x = a * x + b * u_seq[t];
+            x = a * x + b * u_t;
             states.push(x);
         }
 
@@ -197,7 +197,7 @@ impl InvertedPendulumMPC {
     ) {
         let mut fg = Figure::new();
         {
-            let mut axes = fg
+            let axes = fg
                 .axes2d()
                 .set_title(
                     &format!(
@@ -213,7 +213,7 @@ impl InvertedPendulumMPC {
                 .set_aspect_ratio(gnuplot::Fix(1.0));
 
             // Draw cart and pendulum
-            self.draw_cart_pendulum(&mut axes, current_state[0], current_state[2]);
+            self.draw_cart_pendulum(axes, current_state[0], current_state[2]);
 
             // Draw predicted trajectory
             if predicted_states.len() > 1 {

--- a/src/control/mpc_control.rs
+++ b/src/control/mpc_control.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::needless_borrows_for_generic_args)]
+
 //
 // Inverted Pendulum MPC control
 // author: Atsushi Sakai
@@ -5,7 +7,7 @@
 //
 
 use gnuplot::{AxesCommon, Caption, Color, Figure, PointSymbol};
-use nalgebra::{DMatrix, DVector, Matrix1, Matrix4, Vector4};
+use nalgebra::{Matrix1, Matrix4, Vector4};
 use std::f64::consts::PI;
 
 // Model parameters
@@ -103,7 +105,7 @@ impl InvertedPendulumMPC {
 
         // Simple gradient descent optimization
         for _iter in 0..50 {
-            let (states, cost) = self.simulate_prediction(x0, &u_seq, &a, &b);
+            let (_states, cost) = self.simulate_prediction(x0, &u_seq, &a, &b);
 
             if cost < best_cost {
                 best_cost = cost;
@@ -216,12 +218,10 @@ impl InvertedPendulumMPC {
             // Draw predicted trajectory
             if predicted_states.len() > 1 {
                 let pred_x: Vec<f64> = predicted_states.iter().map(|s| s[0]).collect();
-                let pred_angles: Vec<f64> = predicted_states.iter().map(|s| s[2]).collect();
-
                 // Draw predicted cart positions
                 axes.points(
                     &pred_x,
-                    &vec![0.2; pred_x.len()],
+                    vec![0.2; pred_x.len()],
                     &[Caption("Predicted Path"), Color("red"), PointSymbol('.')],
                 );
 
@@ -329,6 +329,12 @@ impl InvertedPendulumMPC {
         fg.set_terminal("pngcairo", output_path);
         fg.show().unwrap();
         println!("MPC summary plot saved to: {}", output_path);
+    }
+}
+
+impl Default for InvertedPendulumMPC {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,17 +10,17 @@ pub mod common;
 pub mod utils;
 
 // Algorithm modules
+pub mod aerial_navigation;
+pub mod arm_navigation;
+pub mod control;
 pub mod localization;
 pub mod mapping;
-pub mod slam;
+pub mod mission_planning;
 pub mod path_planning;
 pub mod path_tracking;
-pub mod control;
-pub mod arm_navigation;
-pub mod aerial_navigation;
-pub mod mission_planning;
+pub mod slam;
 
 // Re-export common types for convenience
-pub use common::{Point2D, Pose2D, State2D, Path2D, ControlInput, Obstacles};
-pub use common::{PathPlanner, StateEstimator, PathTracker};
+pub use common::{ControlInput, Obstacles, Path2D, Point2D, Pose2D, State2D};
+pub use common::{PathPlanner, PathTracker, StateEstimator};
 pub use common::{RoboticsError, RoboticsResult};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate provides implementations of common robotics algorithms
 //! for localization, mapping, path planning, path tracking, and control.
 
+extern crate self as rust_robotics;
+
 // Core modules
 pub mod common;
 pub mod utils;

--- a/src/localization/ekf.rs
+++ b/src/localization/ekf.rs
@@ -3,8 +3,8 @@
 //! Implements state estimation using the Extended Kalman Filter algorithm
 //! for robot localization with nonlinear motion and observation models.
 
+use crate::common::{RoboticsError, StateEstimator};
 use nalgebra::{Matrix2, Matrix2x4, Matrix4, Matrix4x2, Vector2, Vector4};
-use crate::common::{StateEstimator, RoboticsError};
 
 /// State representation for EKF (x, y, yaw, velocity)
 pub type EKFState = Vector4<f64>;
@@ -91,17 +91,9 @@ impl EKFLocalizer {
     fn motion_model(x: &EKFState, u: &EKFControl, dt: f64) -> EKFState {
         let yaw = x[2];
         let f = Matrix4::new(
-            1., 0., 0., 0.,
-            0., 1., 0., 0.,
-            0., 0., 1., 0.,
-            0., 0., 0., 1.,
+            1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.,
         );
-        let b = Matrix4x2::new(
-            dt * yaw.cos(), 0.,
-            dt * yaw.sin(), 0.,
-            0., dt,
-            1., 0.,
-        );
+        let b = Matrix4x2::new(dt * yaw.cos(), 0., dt * yaw.sin(), 0., 0., dt, 1., 0.);
         f * x + b * u
     }
 
@@ -110,28 +102,34 @@ impl EKFLocalizer {
         let yaw = x[2];
         let v = u[0];
         Matrix4::new(
-            1., 0., -dt * v * yaw.sin(), dt * yaw.cos(),
-            0., 1., dt * v * yaw.cos(), dt * yaw.sin(),
-            0., 0., 1., 0.,
-            0., 0., 0., 1.,
+            1.,
+            0.,
+            -dt * v * yaw.sin(),
+            dt * yaw.cos(),
+            0.,
+            1.,
+            dt * v * yaw.cos(),
+            dt * yaw.sin(),
+            0.,
+            0.,
+            1.,
+            0.,
+            0.,
+            0.,
+            0.,
+            1.,
         )
     }
 
     /// Observation model: predict measurement from state
     fn observation_model(x: &EKFState) -> EKFMeasurement {
-        let h = Matrix2x4::new(
-            1., 0., 0., 0.,
-            0., 1., 0., 0.,
-        );
+        let h = Matrix2x4::new(1., 0., 0., 0., 0., 1., 0., 0.);
         h * x
     }
 
     /// Jacobian of observation model
     fn jacobian_h() -> Matrix2x4<f64> {
-        Matrix2x4::new(
-            1., 0., 0., 0.,
-            0., 1., 0., 0.,
-        )
+        Matrix2x4::new(1., 0., 0., 0., 0., 1., 0., 0.)
     }
 
     /// Full EKF estimation step (predict + update)
@@ -152,8 +150,9 @@ impl EKFLocalizer {
         let y = measurement - z_pred;
         let s = j_h * p_pred * j_h.transpose() + self.config.r;
 
-        let s_inv = s.try_inverse()
-            .ok_or_else(|| RoboticsError::NumericalError("Failed to invert S matrix".to_string()))?;
+        let s_inv = s.try_inverse().ok_or_else(|| {
+            RoboticsError::NumericalError("Failed to invert S matrix".to_string())
+        })?;
 
         let k = p_pred * j_h.transpose() * s_inv;
         self.state = x_pred + k * y;

--- a/src/localization/ekf.rs
+++ b/src/localization/ekf.rs
@@ -207,7 +207,7 @@ impl StateEstimator for EKFLocalizer {
 
         if let Some(s_inv) = s.try_inverse() {
             let k = self.covariance * j_h.transpose() * s_inv;
-            self.state = self.state + k * y;
+            self.state += k * y;
             self.covariance = (Matrix4::identity() - k * j_h) * self.covariance;
         }
     }

--- a/src/localization/histogram_filter.rs
+++ b/src/localization/histogram_filter.rs
@@ -3,9 +3,9 @@
 //         Ryohei Sasaki (@rsasaki0109)
 //         Rust port
 
+use gnuplot::{AxesCommon, Caption, Color, Figure};
 use nalgebra::{DMatrix, Vector2, Vector4};
 use rand_distr::{Distribution, Normal};
-use gnuplot::{Figure, Caption, Color, AxesCommon};
 
 // Simulation parameters
 const DT: f64 = 0.1; // time step [s]
@@ -130,8 +130,16 @@ impl HistogramFilter {
     }
 
     /// Create histogram filter with initial position
-    fn new_with_initial_pos(min_x: f64, min_y: f64, max_x: f64, max_y: f64, resolution: f64,
-                             init_x: f64, init_y: f64, init_std: f64) -> Self {
+    fn new_with_initial_pos(
+        min_x: f64,
+        min_y: f64,
+        max_x: f64,
+        max_y: f64,
+        resolution: f64,
+        init_x: f64,
+        init_y: f64,
+        init_std: f64,
+    ) -> Self {
         let mut hf = HistogramFilter::new(min_x, min_y, max_x, max_y, resolution);
 
         // Set Gaussian distribution around initial position
@@ -183,8 +191,7 @@ impl HistogramFilter {
                 let nix = ix as i32 + shift_x;
                 let niy = iy as i32 + shift_y;
 
-                if nix >= 0 && nix < x_width as i32 &&
-                   niy >= 0 && niy < y_width as i32 {
+                if nix >= 0 && nix < x_width as i32 && niy >= 0 && niy < y_width as i32 {
                     new_data[(nix as usize, niy as usize)] = old_data[(ix, iy)];
                 }
             }
@@ -229,7 +236,8 @@ impl HistogramFilter {
                         let nj = iy as i32 + kj as i32 - center;
 
                         if ni >= 0 && ni < x_width as i32 && nj >= 0 && nj < y_width as i32 {
-                            sum += self.grid_map.data[(ni as usize, nj as usize)] * kernel[(ki, kj)];
+                            sum +=
+                                self.grid_map.data[(ni as usize, nj as usize)] * kernel[(ki, kj)];
                         }
                     }
                 }
@@ -325,7 +333,11 @@ fn motion_model(x: Vector4<f64>, u: Vector2<f64>, dt: f64) -> Vector4<f64> {
 }
 
 /// Get observations from RFID landmarks
-fn get_observations(x_true: &Vector4<f64>, rfid: &[(f64, f64)], normal: &Normal<f64>) -> Vec<(f64, f64, f64)> {
+fn get_observations(
+    x_true: &Vector4<f64>,
+    rfid: &[(f64, f64)],
+    normal: &Normal<f64>,
+) -> Vec<(f64, f64, f64)> {
     let mut z = Vec::new();
 
     for (lx, ly) in rfid {
@@ -345,20 +357,21 @@ fn main() {
     println!("Histogram Filter 2D Localization start!");
 
     // RFID landmark positions [x, y]
-    let rfid: Vec<(f64, f64)> = vec![
-        (10.0, 0.0),
-        (10.0, 10.0),
-        (0.0, 15.0),
-        (-5.0, 20.0),
-    ];
+    let rfid: Vec<(f64, f64)> = vec![(10.0, 0.0), (10.0, 10.0), (0.0, 15.0), (-5.0, 20.0)];
 
     // Grid area (matching Python version: -15 to 15 for x, -5 to 25 for y)
     let area = (-15.0, -5.0, 15.0, 25.0); // (min_x, min_y, max_x, max_y)
 
     // Initialize histogram filter with initial position at origin
     let mut hf = HistogramFilter::new_with_initial_pos(
-        area.0, area.1, area.2, area.3, XY_RESOLUTION,
-        0.0, 0.0, 1.0  // initial position (x, y) and initial standard deviation
+        area.0,
+        area.1,
+        area.2,
+        area.3,
+        XY_RESOLUTION,
+        0.0,
+        0.0,
+        1.0, // initial position (x, y) and initial standard deviation
     );
 
     // State: [x, y, yaw, v]
@@ -423,7 +436,16 @@ fn main() {
                 .set_y_label("y [m]", &[])
                 .set_x_range(gnuplot::Fix(area.0 - 2.0), gnuplot::Fix(area.2 + 2.0))
                 .set_y_range(gnuplot::Fix(area.1 - 2.0), gnuplot::Fix(area.3 + 2.0))
-                .points(&rfid_x, &rfid_y, &[Caption("RFID"), Color("black"), gnuplot::PointSymbol('O'), gnuplot::PointSize(2.0)])
+                .points(
+                    &rfid_x,
+                    &rfid_y,
+                    &[
+                        Caption("RFID"),
+                        Color("black"),
+                        gnuplot::PointSymbol('O'),
+                        gnuplot::PointSize(2.0),
+                    ],
+                )
                 .lines(&true_x, &true_y, &[Caption("True"), Color("blue")])
                 .lines(&dr_x, &dr_y, &[Caption("Dead Reckoning"), Color("yellow")]);
 
@@ -459,13 +481,28 @@ fn main() {
             heatmap_data.iter(),
             x_width,
             y_width,
-            Some((min_x, min_y, min_x + x_width as f64 * resolution, min_y + y_width as f64 * resolution)),
+            Some((
+                min_x,
+                min_y,
+                min_x + x_width as f64 * resolution,
+                min_y + y_width as f64 * resolution,
+            )),
             &[],
         )
-        .points(&rfid_x, &rfid_y, &[Caption("RFID"), Color("black"), gnuplot::PointSymbol('O'), gnuplot::PointSize(2.0)])
+        .points(
+            &rfid_x,
+            &rfid_y,
+            &[
+                Caption("RFID"),
+                Color("black"),
+                gnuplot::PointSymbol('O'),
+                gnuplot::PointSize(2.0),
+            ],
+        )
         .lines(&true_x, &true_y, &[Caption("True"), Color("blue")])
         .lines(&dr_x, &dr_y, &[Caption("Dead Reckoning"), Color("orange")]);
 
-    fig.save_to_svg("./img/localization/histogram_filter.svg", 640, 480).unwrap();
+    fig.save_to_svg("./img/localization/histogram_filter.svg", 640, 480)
+        .unwrap();
     println!("Plot saved to ./img/localization/histogram_filter.svg");
 }

--- a/src/localization/histogram_filter.rs
+++ b/src/localization/histogram_filter.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, clippy::too_many_arguments)]
 
 // Histogram Filter 2D Localization
 // author: Atsushi Sakai (@Atsushi_twi)

--- a/src/localization/histogram_filter.rs
+++ b/src/localization/histogram_filter.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 // Histogram Filter 2D Localization
 // author: Atsushi Sakai (@Atsushi_twi)
 //         Ryohei Sasaki (@rsasaki0109)
@@ -250,7 +252,7 @@ impl HistogramFilter {
     }
 
     /// Observation update: multiply grid probabilities by observation likelihoods
-    fn observation_update(&mut self, z: &[(f64, f64, f64)], rfid: &[(f64, f64)]) {
+    fn observation_update(&mut self, z: &[(f64, f64, f64)], _rfid: &[(f64, f64)]) {
         for (z_d, z_id_x, z_id_y) in z {
             for ix in 0..self.grid_map.x_width {
                 for iy in 0..self.grid_map.y_width {

--- a/src/localization/mod.rs
+++ b/src/localization/mod.rs
@@ -7,7 +7,6 @@ pub mod unscented_kalman_filter;
 
 // Re-exports
 pub use ekf::{EKFConfig, EKFControl, EKFLocalizer, EKFMeasurement, EKFState};
-pub use histogram_filter::*;
 pub use particle_filter::{
     PFControl, PFMeasurement, PFState, Particle, ParticleFilterConfig, ParticleFilterLocalizer,
 };

--- a/src/localization/mod.rs
+++ b/src/localization/mod.rs
@@ -6,7 +6,11 @@ pub mod particle_filter;
 pub mod unscented_kalman_filter;
 
 // Re-exports
-pub use ekf::{EKFLocalizer, EKFConfig, EKFState, EKFMeasurement, EKFControl};
+pub use ekf::{EKFConfig, EKFControl, EKFLocalizer, EKFMeasurement, EKFState};
 pub use histogram_filter::*;
-pub use particle_filter::{ParticleFilterLocalizer, ParticleFilterConfig, Particle, PFState, PFControl, PFMeasurement};
-pub use unscented_kalman_filter::{UKFLocalizer, UKFConfig, UKFParams, UKFWeights, UKFState, UKFControl, UKFMeasurement};
+pub use particle_filter::{
+    PFControl, PFMeasurement, PFState, Particle, ParticleFilterConfig, ParticleFilterLocalizer,
+};
+pub use unscented_kalman_filter::{
+    UKFConfig, UKFControl, UKFLocalizer, UKFMeasurement, UKFParams, UKFState, UKFWeights,
+};

--- a/src/localization/particle_filter.rs
+++ b/src/localization/particle_filter.rs
@@ -3,12 +3,12 @@
 //! Implements state estimation using Sequential Monte Carlo method
 //! for robot localization with landmark observations.
 
-use nalgebra::{Matrix4, Vector4, Vector2};
+use nalgebra::{Matrix4, Vector2, Vector4};
 use rand::Rng;
-use rand_distr::{Normal, Distribution};
+use rand_distr::{Distribution, Normal};
 use std::f64::consts::PI;
 
-use crate::common::{StateEstimator, Point2D};
+use crate::common::{Point2D, StateEstimator};
 
 /// State representation for Particle Filter (x, y, yaw, velocity)
 pub type PFState = Vector4<f64>;

--- a/src/localization/unscented_kalman_filter.rs
+++ b/src/localization/unscented_kalman_filter.rs
@@ -8,7 +8,7 @@ use nalgebra::{DMatrix, DVector, Matrix2, Matrix4, Vector2, Vector4};
 use rand::Rng;
 use std::f64::consts::PI;
 
-use crate::common::{Point2D, StateEstimator};
+use crate::common::StateEstimator;
 
 /// State representation for UKF (x, y, yaw, velocity)
 pub type UKFState = Vector4<f64>;

--- a/src/localization/unscented_kalman_filter.rs
+++ b/src/localization/unscented_kalman_filter.rs
@@ -4,11 +4,11 @@
 //! UKF propagates sigma points through nonlinear functions for more accurate estimation
 //! compared to EKF linearization.
 
-use nalgebra::{Matrix4, Matrix2, Vector4, Vector2, DMatrix, DVector};
+use nalgebra::{DMatrix, DVector, Matrix2, Matrix4, Vector2, Vector4};
 use rand::Rng;
 use std::f64::consts::PI;
 
-use crate::common::{StateEstimator, Point2D};
+use crate::common::{Point2D, StateEstimator};
 
 /// State representation for UKF (x, y, yaw, velocity)
 pub type UKFState = Vector4<f64>;
@@ -58,10 +58,10 @@ impl Default for UKFConfig {
         Self {
             params: UKFParams::default(),
             process_noise: Vector4::new(
-                0.1_f64.powi(2),           // x variance
-                0.1_f64.powi(2),           // y variance
+                0.1_f64.powi(2),              // x variance
+                0.1_f64.powi(2),              // y variance
                 1.0_f64.to_radians().powi(2), // yaw variance
-                1.0_f64.powi(2),           // velocity variance
+                1.0_f64.powi(2),              // velocity variance
             ),
             observation_noise: Vector2::new(
                 1.0_f64.powi(2), // x position variance
@@ -176,10 +176,10 @@ impl UKFLocalizer {
     fn motion_model(&self, x: &UKFState, u: &UKFControl) -> UKFState {
         let dt = self.config.dt;
         Vector4::new(
-            x[0] + dt * x[3] * x[2].cos(),  // x += dt * v * cos(yaw)
-            x[1] + dt * x[3] * x[2].sin(),  // y += dt * v * sin(yaw)
-            x[2] + dt * u[1],                // yaw += dt * yaw_rate
-            u[0],                            // v = input_v
+            x[0] + dt * x[3] * x[2].cos(), // x += dt * v * cos(yaw)
+            x[1] + dt * x[3] * x[2].sin(), // y += dt * v * sin(yaw)
+            x[2] + dt * u[1],              // yaw += dt * yaw_rate
+            u[0],                          // v = input_v
         )
     }
 
@@ -236,9 +236,7 @@ impl UKFLocalizer {
         let mut sigma_pred = DMatrix::zeros(sigma.nrows(), sigma.ncols());
 
         for i in 0..sigma.ncols() {
-            let x_sigma = Vector4::new(
-                sigma[(0, i)], sigma[(1, i)], sigma[(2, i)], sigma[(3, i)]
-            );
+            let x_sigma = Vector4::new(sigma[(0, i)], sigma[(1, i)], sigma[(2, i)], sigma[(3, i)]);
             let x_pred = self.motion_model(&x_sigma, u);
 
             for j in 0..4 {
@@ -254,9 +252,7 @@ impl UKFLocalizer {
         let mut z_sigma = DMatrix::zeros(2, sigma.ncols());
 
         for i in 0..sigma.ncols() {
-            let x_sigma = Vector4::new(
-                sigma[(0, i)], sigma[(1, i)], sigma[(2, i)], sigma[(3, i)]
-            );
+            let x_sigma = Vector4::new(sigma[(0, i)], sigma[(1, i)], sigma[(2, i)], sigma[(3, i)]);
             let z_pred = self.observation_model(&x_sigma);
 
             z_sigma[(0, i)] = z_pred[0];
@@ -357,7 +353,10 @@ impl UKFLocalizer {
         let pxz = self.calc_cross_covariance(&sigma_dyn, &x_mean, &z_sigma, &z_pred);
 
         // Kalman gain
-        let s_inv = s.clone().try_inverse().unwrap_or_else(|| DMatrix::identity(2, 2));
+        let s_inv = s
+            .clone()
+            .try_inverse()
+            .unwrap_or_else(|| DMatrix::identity(2, 2));
         let k = &pxz * &s_inv;
 
         // Innovation
@@ -533,10 +532,11 @@ pub fn observation(
 
     *x_true = motion_model(x_true, u);
 
-    let z = observation_model(x_true) + Vector2::new(
-        GPS_NOISE_X * rng.gen::<f64>() - GPS_NOISE_X / 2.0,
-        GPS_NOISE_Y * rng.gen::<f64>() - GPS_NOISE_Y / 2.0,
-    );
+    let z = observation_model(x_true)
+        + Vector2::new(
+            GPS_NOISE_X * rng.gen::<f64>() - GPS_NOISE_X / 2.0,
+            GPS_NOISE_Y * rng.gen::<f64>() - GPS_NOISE_Y / 2.0,
+        );
 
     let u_noisy = u + Vector2::new(
         INPUT_NOISE_V * rng.gen::<f64>() - INPUT_NOISE_V / 2.0,

--- a/src/localization/unscented_kalman_filter.rs
+++ b/src/localization/unscented_kalman_filter.rs
@@ -462,6 +462,13 @@ impl LegacyUKFState {
     }
 }
 
+#[allow(deprecated)]
+impl Default for LegacyUKFState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Legacy motion model function
 pub fn motion_model(x: &Vector4<f64>, u: &Vector2<f64>) -> Vector4<f64> {
     const DT: f64 = 0.1;
@@ -524,7 +531,7 @@ pub fn observation(
     u: &Vector2<f64>,
 ) -> (Vector2<f64>, Vector2<f64>) {
     const INPUT_NOISE_V: f64 = 1.0;
-    const INPUT_NOISE_YAW: f64 = 0.5236; // 30 degrees
+    const INPUT_NOISE_YAW: f64 = std::f64::consts::FRAC_PI_6; // 30 degrees
     const GPS_NOISE_X: f64 = 0.5;
     const GPS_NOISE_Y: f64 = 0.5;
 

--- a/src/mapping/gaussian_grid_map.rs
+++ b/src/mapping/gaussian_grid_map.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 // Gaussian Grid Map
 // author: Atsushi Sakai (@Atsushi_twi)
 //         Ryohei Sasaki (@rsasaki0109)
@@ -5,7 +7,6 @@
 
 use gnuplot::{AutoOption, AxesCommon, Figure, PlotOption};
 use nalgebra::DMatrix;
-use std::f64::consts::PI;
 
 // Parameters
 const EXTEND_AREA: f64 = 10.0; // [m] grid map extension area
@@ -135,14 +136,6 @@ fn draw_heatmap(grid_map: &GaussianGridMap, ox: &[f64], oy: &[f64]) {
             z_data.push(grid_map.data[(ix, iy)]);
         }
     }
-
-    // Create coordinate vectors
-    let x_coords: Vec<f64> = (0..x_width)
-        .map(|ix| grid_map.min_x + ix as f64 * grid_map.resolution)
-        .collect();
-    let y_coords: Vec<f64> = (0..y_width)
-        .map(|iy| grid_map.min_y + iy as f64 * grid_map.resolution)
-        .collect();
 
     fig.axes2d()
         .set_title("Gaussian Grid Map", &[])

--- a/src/mapping/gaussian_grid_map.rs
+++ b/src/mapping/gaussian_grid_map.rs
@@ -3,8 +3,8 @@
 //         Ryohei Sasaki (@rsasaki0109)
 //         Rust port
 
+use gnuplot::{AutoOption, AxesCommon, Figure, PlotOption};
 use nalgebra::DMatrix;
-use gnuplot::{Figure, AxesCommon, AutoOption, PlotOption};
 use std::f64::consts::PI;
 
 // Parameters
@@ -45,7 +45,9 @@ impl GaussianGridMap {
                 let y = min_y + iy as f64 * resolution;
 
                 // Find minimum distance to obstacles
-                let min_dist = ox.iter().zip(oy.iter())
+                let min_dist = ox
+                    .iter()
+                    .zip(oy.iter())
                     .map(|(ox_i, oy_i)| ((x - ox_i).powi(2) + (y - oy_i).powi(2)).sqrt())
                     .fold(f64::INFINITY, f64::min);
 
@@ -102,12 +104,12 @@ fn normal_cdf(x: f64, mean: f64, std_dev: f64) -> f64 {
 /// Error function approximation (Horner's method)
 fn erf(x: f64) -> f64 {
     // Approximation constants
-    let a1 =  0.254829592;
+    let a1 = 0.254829592;
     let a2 = -0.284496736;
-    let a3 =  1.421413741;
+    let a3 = 1.421413741;
     let a4 = -1.453152027;
-    let a5 =  1.061405429;
-    let p  =  0.3275911;
+    let a5 = 1.061405429;
+    let p = 0.3275911;
 
     let sign = if x < 0.0 { -1.0 } else { 1.0 };
     let x = x.abs();
@@ -151,17 +153,28 @@ fn draw_heatmap(grid_map: &GaussianGridMap, ox: &[f64], oy: &[f64]) {
             z_data.iter().cloned(),
             x_width,
             y_width,
-            Some((grid_map.min_x, grid_map.min_y, grid_map.max_x, grid_map.max_y)),
-            &[PlotOption::Caption("Probability")]
+            Some((
+                grid_map.min_x,
+                grid_map.min_y,
+                grid_map.max_x,
+                grid_map.max_y,
+            )),
+            &[PlotOption::Caption("Probability")],
         )
         .points(
             ox,
             oy,
-            &[PlotOption::Caption("Obstacles"), PlotOption::Color("white"), gnuplot::PointSymbol('O'), gnuplot::PointSize(1.5)]
+            &[
+                PlotOption::Caption("Obstacles"),
+                PlotOption::Color("white"),
+                gnuplot::PointSymbol('O'),
+                gnuplot::PointSize(1.5),
+            ],
         );
 
     fig.show_and_keep_running().unwrap();
-    fig.save_to_svg("./img/mapping/gaussian_grid_map.svg", 640, 480).unwrap();
+    fig.save_to_svg("./img/mapping/gaussian_grid_map.svg", 640, 480)
+        .unwrap();
     println!("Plot saved to ./img/mapping/gaussian_grid_map.svg");
 }
 
@@ -170,15 +183,11 @@ fn main() {
 
     // Define obstacles (sample points)
     let ox: Vec<f64> = vec![
-        0.0, 1.0, 2.0, 3.0, 4.0, 5.0,
-        0.0, 1.0, 2.0, 3.0, 4.0, 5.0,
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
         5.0, 5.0, 5.0, 5.0, 5.0, 5.0,
     ];
     let oy: Vec<f64> = vec![
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        5.0, 5.0, 5.0, 5.0, 5.0, 5.0,
-        0.0, 1.0, 2.0, 3.0, 4.0, 5.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0,
         0.0, 1.0, 2.0, 3.0, 4.0, 5.0,
     ];
 
@@ -187,8 +196,10 @@ fn main() {
 
     println!("Grid map created:");
     println!("  Size: {} x {}", grid_map.x_width, grid_map.y_width);
-    println!("  Bounds: ({:.1}, {:.1}) to ({:.1}, {:.1})",
-             grid_map.min_x, grid_map.min_y, grid_map.max_x, grid_map.max_y);
+    println!(
+        "  Bounds: ({:.1}, {:.1}) to ({:.1}, {:.1})",
+        grid_map.min_x, grid_map.min_y, grid_map.max_x, grid_map.max_y
+    );
 
     // Draw heatmap
     draw_heatmap(&grid_map, &ox, &oy);

--- a/src/mapping/mod.rs
+++ b/src/mapping/mod.rs
@@ -5,5 +5,4 @@ pub mod ndt;
 pub mod ray_casting_grid_map;
 
 pub use gaussian_grid_map::*;
-pub use ndt::*;
 pub use ray_casting_grid_map::*;

--- a/src/mapping/ndt.rs
+++ b/src/mapping/ndt.rs
@@ -325,7 +325,7 @@ fn main() {
         // 2) For each grid cell cluster, plot them in blue "x"
         //    We stored ndt_map.grid_index_map => index -> Vec<usize>
         //    We'll gather them in a separate pass so they can be plotted group by group.
-        for (_grid_idx, point_inds) in &ndt_map.grid_index_map {
+        for point_inds in ndt_map.grid_index_map.values() {
             if point_inds.is_empty() {
                 continue;
             }

--- a/src/mapping/ndt.rs
+++ b/src/mapping/ndt.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
+use gnuplot::AxesCommon;
+use gnuplot::{Axes2D, Caption, Color, Figure, PointSymbol};
+use na::{DMatrix, Matrix2, SymmetricEigen, Vector2};
 use nalgebra as na; // For matrices, vectors, stats, etc.
-use na::{DMatrix, Matrix2, Vector2, SymmetricEigen};
 use rand::prelude::*;
 use rand_distr::{Distribution, Uniform};
-use gnuplot::{Figure, Axes2D, Caption, Color, PointSymbol};
-use gnuplot::AxesCommon;
 
 #[derive(Debug, Clone)]
 struct NDTGrid {
@@ -45,12 +45,7 @@ struct GridMap {
 }
 
 impl GridMap {
-    fn new(width: usize,
-           height: usize,
-           resolution: f64,
-           center_x: f64,
-           center_y: f64) -> Self
-    {
+    fn new(width: usize, height: usize, resolution: f64, center_x: f64, center_y: f64) -> Self {
         let data = vec![NDTGrid::default(); width * height];
         GridMap {
             width,
@@ -58,7 +53,7 @@ impl GridMap {
             resolution,
             center_x,
             center_y,
-            data
+            data,
         }
     }
 
@@ -87,8 +82,8 @@ impl GridMap {
         let col = idx % self.width;
 
         // center in grid coords:
-        let cx = (col as f64 + 0.5) - (self.width as f64)/2.0;
-        let cy = (row as f64 + 0.5) - (self.height as f64)/2.0;
+        let cx = (col as f64 + 0.5) - (self.width as f64) / 2.0;
+        let cy = (row as f64 + 0.5) - (self.height as f64) / 2.0;
         // scale by resolution and add the map center:
         let x = self.center_x + cx * self.resolution;
         let y = self.center_y + cy * self.resolution;
@@ -155,7 +150,9 @@ impl NDTMap {
                 ndt.mean_y = mean_y;
 
                 // Center of the cell in world coords:
-                let (cx, cy) = self.grid_map.calc_grid_central_xy_position_from_grid_index(*grid_index);
+                let (cx, cy) = self
+                    .grid_map
+                    .calc_grid_central_xy_position_from_grid_index(*grid_index);
                 ndt.center_grid_x = cx;
                 ndt.center_grid_y = cy;
 
@@ -213,8 +210,7 @@ fn compute_covariance_2d(xs: &[f64], ys: &[f64], mean_x: f64, mean_y: f64) -> Ma
     }
     // sample covariance uses n-1
     let denom = n - 1.0;
-    Matrix2::new(sxx/denom, sxy/denom,
-                 sxy/denom, syy/denom)
+    Matrix2::new(sxx / denom, sxy / denom, sxy / denom, syy / denom)
 }
 
 /// Generates dummy corridor-like data with random noise.
@@ -320,11 +316,7 @@ fn main() {
         axes.points(
             &ox,
             &oy,
-            &[
-                Caption("Raw observation"),
-                Color("red"),
-                PointSymbol('O'),
-            ],
+            &[Caption("Raw observation"), Color("red"), PointSymbol('O')],
         );
 
         // 2) For each grid cell cluster, plot them in blue "x"
@@ -336,14 +328,7 @@ fn main() {
             }
             let cx: Vec<f64> = point_inds.iter().map(|&i| ox[i]).collect();
             let cy: Vec<f64> = point_inds.iter().map(|&i| oy[i]).collect();
-            axes.points(
-                &cx,
-                &cy,
-                &[
-                    Color("blue"),
-                    PointSymbol('x'),
-                ],
-            );
+            axes.points(&cx, &cy, &[Color("blue"), PointSymbol('x')]);
         }
 
         // 3) plot the covariance ellipses for each valid NDT cell

--- a/src/mapping/ndt.rs
+++ b/src/mapping/ndt.rs
@@ -1,8 +1,9 @@
+#![allow(dead_code)]
+
 use std::collections::HashMap;
 
-use gnuplot::AxesCommon;
-use gnuplot::{Axes2D, Caption, Color, Figure, PointSymbol};
-use na::{DMatrix, Matrix2, SymmetricEigen, Vector2};
+use gnuplot::{Caption, Color, Figure, PointSymbol};
+use na::{Matrix2, SymmetricEigen, Vector2};
 use nalgebra as na; // For matrices, vectors, stats, etc.
 use rand::prelude::*;
 use rand_distr::{Distribution, Uniform};
@@ -133,8 +134,10 @@ impl NDTMap {
     /// Build each cell's NDTGrid from the points that fall in it.
     fn construct_grid_map(&mut self) {
         for (grid_index, inds) in &self.grid_index_map {
-            let mut ndt = NDTGrid::default();
-            ndt.n_points = inds.len();
+            let mut ndt = NDTGrid {
+                n_points: inds.len(),
+                ..NDTGrid::default()
+            };
             if ndt.n_points >= self.min_n_points {
                 // Compute means:
                 let mut sum_x = 0.0;
@@ -311,7 +314,7 @@ fn main() {
     let mut fg = Figure::new();
     {
         // 1) plot raw data in red (dots)
-        let mut axes = fg.axes2d();
+        let axes = fg.axes2d();
         // axes.set_aspect_ratio(1.0); // similar to plt.axis("equal")
         axes.points(
             &ox,

--- a/src/mapping/ray_casting_grid_map.rs
+++ b/src/mapping/ray_casting_grid_map.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::needless_borrows_for_generic_args)]
+
 // Ray Casting Grid Map
 // author: Atsushi Sakai (@Atsushi_twi)
 //         Ryohei Sasaki (@rsasaki0109)
@@ -117,10 +119,7 @@ impl RayCastingGridMap {
 
                 let cell_info = CellInfo { ix, iy, distance };
 
-                cells_by_angle
-                    .entry(angle_id)
-                    .or_insert_with(Vec::new)
-                    .push(cell_info);
+                cells_by_angle.entry(angle_id).or_default().push(cell_info);
             }
         }
 

--- a/src/mapping/ray_casting_grid_map.rs
+++ b/src/mapping/ray_casting_grid_map.rs
@@ -3,8 +3,8 @@
 //         Ryohei Sasaki (@rsasaki0109)
 //         Rust port
 
+use gnuplot::{AutoOption, AxesCommon, Figure, PlotOption};
 use nalgebra::DMatrix;
-use gnuplot::{Figure, AxesCommon, AutoOption, PlotOption};
 use std::collections::HashMap;
 use std::f64::consts::PI;
 
@@ -65,7 +65,12 @@ impl RayCastingGridMap {
 
         // Precompute cell database
         let precast_db = Self::precompute_db(
-            x_width, y_width, origin_ix, origin_iy, resolution, yaw_resolution
+            x_width,
+            y_width,
+            origin_ix,
+            origin_iy,
+            resolution,
+            yaw_resolution,
         );
 
         let mut grid_map = RayCastingGridMap {
@@ -133,8 +138,11 @@ impl RayCastingGridMap {
         let obs_ix = ((obs_x - self.min_x) / self.resolution).round() as i32;
         let obs_iy = ((obs_y - self.min_y) / self.resolution).round() as i32;
 
-        if obs_ix < 0 || obs_ix >= self.x_width as i32 ||
-           obs_iy < 0 || obs_iy >= self.y_width as i32 {
+        if obs_ix < 0
+            || obs_ix >= self.x_width as i32
+            || obs_iy < 0
+            || obs_iy >= self.y_width as i32
+        {
             return;
         }
 
@@ -212,17 +220,28 @@ fn draw_heatmap(grid_map: &RayCastingGridMap, ox: &[f64], oy: &[f64]) {
             z_data.iter().cloned(),
             x_width,
             y_width,
-            Some((grid_map.min_x, grid_map.min_y, grid_map.max_x, grid_map.max_y)),
-            &[PlotOption::Caption("Occupancy")]
+            Some((
+                grid_map.min_x,
+                grid_map.min_y,
+                grid_map.max_x,
+                grid_map.max_y,
+            )),
+            &[PlotOption::Caption("Occupancy")],
         )
         .points(
             ox,
             oy,
-            &[PlotOption::Caption("Obstacles"), PlotOption::Color("red"), gnuplot::PointSymbol('O'), gnuplot::PointSize(1.0)]
+            &[
+                PlotOption::Caption("Obstacles"),
+                PlotOption::Color("red"),
+                gnuplot::PointSymbol('O'),
+                gnuplot::PointSize(1.0),
+            ],
         );
 
     fig.show_and_keep_running().unwrap();
-    fig.save_to_svg("./img/mapping/ray_casting_grid_map.svg", 640, 480).unwrap();
+    fig.save_to_svg("./img/mapping/ray_casting_grid_map.svg", 640, 480)
+        .unwrap();
     println!("Plot saved to ./img/mapping/ray_casting_grid_map.svg");
 }
 
@@ -265,8 +284,10 @@ fn main() {
 
     println!("Grid map created:");
     println!("  Size: {} x {}", grid_map.x_width, grid_map.y_width);
-    println!("  Bounds: ({:.1}, {:.1}) to ({:.1}, {:.1})",
-             grid_map.min_x, grid_map.min_y, grid_map.max_x, grid_map.max_y);
+    println!(
+        "  Bounds: ({:.1}, {:.1}) to ({:.1}, {:.1})",
+        grid_map.min_x, grid_map.min_y, grid_map.max_x, grid_map.max_y
+    );
 
     // Draw heatmap
     draw_heatmap(&grid_map, &ox, &oy);

--- a/src/mission_planning/behavior_tree.rs
+++ b/src/mission_planning/behavior_tree.rs
@@ -1,0 +1,386 @@
+//! Behavior Tree implementation for mission planning.
+//!
+//! This module provides a compact behavior tree runtime suitable for
+//! robotics decision making with a shared blackboard.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BehaviorStatus {
+    Success,
+    Failure,
+    Running,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Blackboard {
+    pub battery_level: f64,
+    pub obstacle_detected: bool,
+    pub path_ready: bool,
+    pub goal_visible: bool,
+}
+
+impl Default for Blackboard {
+    fn default() -> Self {
+        Self {
+            battery_level: 100.0,
+            obstacle_detected: false,
+            path_ready: true,
+            goal_visible: true,
+        }
+    }
+}
+
+pub trait BehaviorNode {
+    fn tick(&mut self, blackboard: &Blackboard) -> BehaviorStatus;
+    fn reset(&mut self) {}
+    fn name(&self) -> &str;
+}
+
+pub struct BehaviorTree {
+    root: Box<dyn BehaviorNode>,
+}
+
+impl BehaviorTree {
+    pub fn new(root: Box<dyn BehaviorNode>) -> Self {
+        Self { root }
+    }
+
+    pub fn tick(&mut self, blackboard: &Blackboard) -> BehaviorStatus {
+        self.root.tick(blackboard)
+    }
+
+    pub fn reset(&mut self) {
+        self.root.reset();
+    }
+
+    pub fn root_name(&self) -> &str {
+        self.root.name()
+    }
+}
+
+pub struct ConditionNode {
+    name: String,
+    evaluator: Box<dyn Fn(&Blackboard) -> bool>,
+}
+
+impl ConditionNode {
+    pub fn new(name: impl Into<String>, evaluator: impl Fn(&Blackboard) -> bool + 'static) -> Self {
+        Self {
+            name: name.into(),
+            evaluator: Box::new(evaluator),
+        }
+    }
+}
+
+impl BehaviorNode for ConditionNode {
+    fn tick(&mut self, blackboard: &Blackboard) -> BehaviorStatus {
+        if (self.evaluator)(blackboard) {
+            BehaviorStatus::Success
+        } else {
+            BehaviorStatus::Failure
+        }
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+pub struct ActionNode {
+    name: String,
+    action: Box<dyn FnMut(&Blackboard) -> BehaviorStatus>,
+}
+
+impl ActionNode {
+    pub fn new(
+        name: impl Into<String>,
+        action: impl FnMut(&Blackboard) -> BehaviorStatus + 'static,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            action: Box::new(action),
+        }
+    }
+}
+
+impl BehaviorNode for ActionNode {
+    fn tick(&mut self, blackboard: &Blackboard) -> BehaviorStatus {
+        (self.action)(blackboard)
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+pub struct SequenceNode {
+    name: String,
+    children: Vec<Box<dyn BehaviorNode>>,
+    current_index: usize,
+}
+
+impl SequenceNode {
+    pub fn new(name: impl Into<String>, children: Vec<Box<dyn BehaviorNode>>) -> Self {
+        Self {
+            name: name.into(),
+            children,
+            current_index: 0,
+        }
+    }
+}
+
+impl BehaviorNode for SequenceNode {
+    fn tick(&mut self, blackboard: &Blackboard) -> BehaviorStatus {
+        while self.current_index < self.children.len() {
+            match self.children[self.current_index].tick(blackboard) {
+                BehaviorStatus::Success => {
+                    self.children[self.current_index].reset();
+                    self.current_index += 1;
+                }
+                BehaviorStatus::Failure => {
+                    self.reset();
+                    return BehaviorStatus::Failure;
+                }
+                BehaviorStatus::Running => return BehaviorStatus::Running,
+            }
+        }
+
+        self.reset();
+        BehaviorStatus::Success
+    }
+
+    fn reset(&mut self) {
+        self.current_index = 0;
+        for child in &mut self.children {
+            child.reset();
+        }
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+pub struct SelectorNode {
+    name: String,
+    children: Vec<Box<dyn BehaviorNode>>,
+    current_index: usize,
+}
+
+impl SelectorNode {
+    pub fn new(name: impl Into<String>, children: Vec<Box<dyn BehaviorNode>>) -> Self {
+        Self {
+            name: name.into(),
+            children,
+            current_index: 0,
+        }
+    }
+}
+
+impl BehaviorNode for SelectorNode {
+    fn tick(&mut self, blackboard: &Blackboard) -> BehaviorStatus {
+        while self.current_index < self.children.len() {
+            match self.children[self.current_index].tick(blackboard) {
+                BehaviorStatus::Success => {
+                    self.reset();
+                    return BehaviorStatus::Success;
+                }
+                BehaviorStatus::Failure => {
+                    self.children[self.current_index].reset();
+                    self.current_index += 1;
+                }
+                BehaviorStatus::Running => return BehaviorStatus::Running,
+            }
+        }
+
+        self.reset();
+        BehaviorStatus::Failure
+    }
+
+    fn reset(&mut self) {
+        self.current_index = 0;
+        for child in &mut self.children {
+            child.reset();
+        }
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+pub fn condition(
+    name: impl Into<String>,
+    evaluator: impl Fn(&Blackboard) -> bool + 'static,
+) -> Box<dyn BehaviorNode> {
+    Box::new(ConditionNode::new(name, evaluator))
+}
+
+pub fn action(
+    name: impl Into<String>,
+    executor: impl FnMut(&Blackboard) -> BehaviorStatus + 'static,
+) -> Box<dyn BehaviorNode> {
+    Box::new(ActionNode::new(name, executor))
+}
+
+pub fn sequence(
+    name: impl Into<String>,
+    children: Vec<Box<dyn BehaviorNode>>,
+) -> Box<dyn BehaviorNode> {
+    Box::new(SequenceNode::new(name, children))
+}
+
+pub fn selector(
+    name: impl Into<String>,
+    children: Vec<Box<dyn BehaviorNode>>,
+) -> Box<dyn BehaviorNode> {
+    Box::new(SelectorNode::new(name, children))
+}
+
+pub fn create_demo_behavior_tree() -> BehaviorTree {
+    BehaviorTree::new(selector(
+        "mission_root",
+        vec![
+            sequence(
+                "navigate",
+                vec![
+                    condition("battery_ok", |bb| bb.battery_level > 20.0),
+                    condition("path_ready", |bb| bb.path_ready),
+                    condition("goal_visible", |bb| bb.goal_visible),
+                    action("move_to_goal", |_| BehaviorStatus::Success),
+                ],
+            ),
+            sequence(
+                "avoid",
+                vec![
+                    condition("obstacle_detected", |bb| bb.obstacle_detected),
+                    action("hover_and_replan", |_| BehaviorStatus::Running),
+                ],
+            ),
+            action("hold_position", |_| BehaviorStatus::Running),
+        ],
+    ))
+}
+
+pub fn demo_behavior_tree() {
+    let scenarios = [
+        (
+            "Nominal navigation",
+            Blackboard {
+                battery_level: 90.0,
+                obstacle_detected: false,
+                path_ready: true,
+                goal_visible: true,
+            },
+        ),
+        (
+            "Obstacle avoidance",
+            Blackboard {
+                battery_level: 90.0,
+                obstacle_detected: true,
+                path_ready: false,
+                goal_visible: false,
+            },
+        ),
+        (
+            "Low battery hold",
+            Blackboard {
+                battery_level: 5.0,
+                obstacle_detected: false,
+                path_ready: false,
+                goal_visible: false,
+            },
+        ),
+    ];
+
+    let mut tree = create_demo_behavior_tree();
+    println!("Behavior tree root: {}", tree.root_name());
+
+    for (label, blackboard) in scenarios {
+        tree.reset();
+        let status = tree.tick(&blackboard);
+        println!(
+            "{} => {:?} (battery={:.1}, obstacle={}, path_ready={}, goal_visible={})",
+            label,
+            status,
+            blackboard.battery_level,
+            blackboard.obstacle_detected,
+            blackboard.path_ready,
+            blackboard.goal_visible
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sequence_succeeds_when_all_children_succeed() {
+        let mut tree = BehaviorTree::new(sequence(
+            "sequence",
+            vec![
+                condition("battery_ok", |bb| bb.battery_level > 20.0),
+                action("move", |_| BehaviorStatus::Success),
+            ],
+        ));
+
+        let status = tree.tick(&Blackboard::default());
+
+        assert_eq!(status, BehaviorStatus::Success);
+    }
+
+    #[test]
+    fn test_selector_uses_fallback_branch() {
+        let mut tree = BehaviorTree::new(selector(
+            "selector",
+            vec![
+                condition("goal_visible", |bb| bb.goal_visible),
+                action("fallback", |_| BehaviorStatus::Success),
+            ],
+        ));
+
+        let status = tree.tick(&Blackboard {
+            goal_visible: false,
+            ..Default::default()
+        });
+
+        assert_eq!(status, BehaviorStatus::Success);
+    }
+
+    #[test]
+    fn test_running_action_resumes_until_success() {
+        let mut tree = BehaviorTree::new(sequence(
+            "warmup",
+            vec![
+                action("spin_up", {
+                    let mut count = 0;
+                    move |_| {
+                        count += 1;
+                        if count < 2 {
+                            BehaviorStatus::Running
+                        } else {
+                            BehaviorStatus::Success
+                        }
+                    }
+                }),
+                action("execute", |_| BehaviorStatus::Success),
+            ],
+        ));
+
+        assert_eq!(tree.tick(&Blackboard::default()), BehaviorStatus::Running);
+        assert_eq!(tree.tick(&Blackboard::default()), BehaviorStatus::Success);
+    }
+
+    #[test]
+    fn test_demo_tree_holds_position_on_low_battery() {
+        let mut tree = create_demo_behavior_tree();
+        let status = tree.tick(&Blackboard {
+            battery_level: 5.0,
+            obstacle_detected: false,
+            path_ready: false,
+            goal_visible: false,
+        });
+
+        assert_eq!(status, BehaviorStatus::Running);
+    }
+}

--- a/src/mission_planning/mod.rs
+++ b/src/mission_planning/mod.rs
@@ -1,3 +1,4 @@
 // Mission Planning algorithms module
 
+pub mod behavior_tree;
 pub mod state_machine;

--- a/src/mission_planning/state_machine.rs
+++ b/src/mission_planning/state_machine.rs
@@ -13,9 +13,9 @@ use std::collections::HashMap;
 use std::fmt;
 
 /// Type alias for callback functions
-pub type CallbackFn = Box<dyn Fn() -> ()>;
+pub type CallbackFn = Box<dyn Fn()>;
 pub type GuardFn = Box<dyn Fn() -> bool>;
-pub type ActionFn = Box<dyn Fn() -> ()>;
+pub type ActionFn = Box<dyn Fn()>;
 
 /// Represents a state in the state machine
 #[derive(Clone, PartialEq)]
@@ -468,6 +468,12 @@ impl RobotBehavior {
 
     pub fn obstacle_detected(&self) -> bool {
         self.has_obstacle
+    }
+}
+
+impl Default for RobotBehavior {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/mission_planning/state_machine.rs
+++ b/src/mission_planning/state_machine.rs
@@ -1,10 +1,10 @@
 /*!
  * State Machine implementation for Mission Planning
- * 
+ *
  * This module implements a finite state machine for robot behavior management.
  * It provides a flexible framework for defining states, transitions, events,
  * guards, and actions in robotics applications.
- * 
+ *
  * Ported from PythonRobotics
  * Original author: Wang Zheng (@Aglargil)
  */
@@ -167,7 +167,7 @@ impl StateMachine {
     pub fn process(&mut self, event: &str) -> Result<(), String> {
         if let Some(ref current_state) = self.current_state {
             let key = (current_state.name.clone(), event.to_string());
-            
+
             if let Some(transition) = self.transitions.get(&key).cloned() {
                 self.execute_transition(&transition, event)
             } else {
@@ -184,7 +184,7 @@ impl StateMachine {
     /// Execute a transition
     fn execute_transition(&mut self, transition: &Transition, event: &str) -> Result<(), String> {
         let current_state = self.current_state.as_ref().unwrap();
-        
+
         // Check guard condition
         if let Some(ref guard) = transition.guard {
             println!("  checking guard: {}", guard);
@@ -210,7 +210,7 @@ impl StateMachine {
                 "|{}| transitioning from <{}> to <{}> on event [{}]",
                 self.name, current_state.name, transition.dst_state, event
             );
-            
+
             // Record transition history
             self.transition_history.push((
                 current_state.name.clone(),
@@ -226,7 +226,10 @@ impl StateMachine {
                 self.current_state = Some(new_state.clone());
                 new_state.enter();
             } else {
-                return Err(format!("Destination state '{}' not found", transition.dst_state));
+                return Err(format!(
+                    "Destination state '{}' not found",
+                    transition.dst_state
+                ));
             }
         } else {
             println!(
@@ -272,7 +275,7 @@ impl StateMachine {
         let mut diagram = Vec::new();
         diagram.push(format!("State Machine: {}", self.name));
         diagram.push("".to_string());
-        
+
         if let Some(ref current) = self.current_state {
             diagram.push(format!("Current State: {}", current.name));
             diagram.push("".to_string());
@@ -280,16 +283,22 @@ impl StateMachine {
 
         diagram.push("States:".to_string());
         for state in self.states.values() {
-            let marker = if Some(state) == self.current_state.as_ref() { " [CURRENT]" } else { "" };
+            let marker = if Some(state) == self.current_state.as_ref() {
+                " [CURRENT]"
+            } else {
+                ""
+            };
             diagram.push(format!("  - {}{}", state.name, marker));
         }
         diagram.push("".to_string());
 
         diagram.push("Transitions:".to_string());
         for transition in self.transitions.values() {
-            let mut trans_str = format!("  {} --[{}]--> {}", 
-                transition.src_state, transition.event, transition.dst_state);
-            
+            let mut trans_str = format!(
+                "  {} --[{}]--> {}",
+                transition.src_state, transition.event, transition.dst_state
+            );
+
             if let Some(ref guard) = transition.guard {
                 trans_str.push_str(&format!(" [guard: {}]", guard));
             }
@@ -326,7 +335,8 @@ impl StateMachine {
         // Position states in a circle
         let mut state_positions: HashMap<String, (f64, f64)> = HashMap::new();
         for (i, state_name) in state_names.iter().enumerate() {
-            let angle = std::f64::consts::PI / 2.0 - 2.0 * std::f64::consts::PI * i as f64 / n_states as f64;
+            let angle = std::f64::consts::PI / 2.0
+                - 2.0 * std::f64::consts::PI * i as f64 / n_states as f64;
             let x = cx + radius * angle.cos();
             let y = cy - radius * angle.sin(); // SVG y is inverted
             state_positions.insert(state_name.clone(), (x, y));
@@ -353,7 +363,7 @@ impl StateMachine {
         for transition in self.transitions.values() {
             if let (Some(&(x1, y1)), Some(&(x2, y2))) = (
                 state_positions.get(&transition.src_state),
-                state_positions.get(&transition.dst_state)
+                state_positions.get(&transition.dst_state),
             ) {
                 if transition.src_state != transition.dst_state {
                     let dx = x2 - x1;
@@ -466,57 +476,64 @@ pub fn create_robot_state_machine() -> StateMachine {
     let mut machine = StateMachine::new("RobotController");
 
     // Define states
-    machine.register_state(State::with_callbacks("idle", Some("on_enter_idle"), Some("on_exit_idle")));
-    machine.register_state(State::with_callbacks("moving", Some("on_enter_moving"), Some("on_exit_moving")));
-    machine.register_state(State::with_callbacks("avoiding", Some("on_enter_avoiding"), None));
-    machine.register_state(State::with_callbacks("charging", Some("on_enter_charging"), None));
-    machine.register_state(State::with_callbacks("emergency", Some("on_enter_emergency"), None));
+    machine.register_state(State::with_callbacks(
+        "idle",
+        Some("on_enter_idle"),
+        Some("on_exit_idle"),
+    ));
+    machine.register_state(State::with_callbacks(
+        "moving",
+        Some("on_enter_moving"),
+        Some("on_exit_moving"),
+    ));
+    machine.register_state(State::with_callbacks(
+        "avoiding",
+        Some("on_enter_avoiding"),
+        None,
+    ));
+    machine.register_state(State::with_callbacks(
+        "charging",
+        Some("on_enter_charging"),
+        None,
+    ));
+    machine.register_state(State::with_callbacks(
+        "emergency",
+        Some("on_enter_emergency"),
+        None,
+    ));
 
     // Define transitions
     machine.add_transition(
         Transition::new("idle", "start", "moving")
             .with_guard("can_start")
-            .with_action("start_motors")
+            .with_action("start_motors"),
     );
 
     machine.add_transition(
-        Transition::new("moving", "obstacle", "avoiding")
-            .with_action("stop_motors")
+        Transition::new("moving", "obstacle", "avoiding").with_action("stop_motors"),
+    );
+
+    machine
+        .add_transition(Transition::new("avoiding", "clear", "moving").with_action("start_motors"));
+
+    machine.add_transition(
+        Transition::new("moving", "low_battery", "charging").with_action("save_position"),
+    );
+
+    machine
+        .add_transition(Transition::new("charging", "charged", "idle").with_action("play_sound"));
+
+    machine.add_transition(Transition::new("moving", "stop", "idle").with_action("stop_motors"));
+
+    machine.add_transition(
+        Transition::new("idle", "emergency", "emergency").with_action("send_alert"),
     );
 
     machine.add_transition(
-        Transition::new("avoiding", "clear", "moving")
-            .with_action("start_motors")
+        Transition::new("moving", "emergency", "emergency").with_action("send_alert"),
     );
 
-    machine.add_transition(
-        Transition::new("moving", "low_battery", "charging")
-            .with_action("save_position")
-    );
-
-    machine.add_transition(
-        Transition::new("charging", "charged", "idle")
-            .with_action("play_sound")
-    );
-
-    machine.add_transition(
-        Transition::new("moving", "stop", "idle")
-            .with_action("stop_motors")
-    );
-
-    machine.add_transition(
-        Transition::new("idle", "emergency", "emergency")
-            .with_action("send_alert")
-    );
-
-    machine.add_transition(
-        Transition::new("moving", "emergency", "emergency")
-            .with_action("send_alert")
-    );
-
-    machine.add_transition(
-        Transition::new("emergency", "reset", "idle")
-    );
+    machine.add_transition(Transition::new("emergency", "reset", "idle"));
 
     machine
 }
@@ -529,16 +546,16 @@ pub fn demo_state_machine() {
     std::fs::create_dir_all("img/mission_planning").unwrap_or_default();
 
     let mut machine = create_robot_state_machine();
-    
+
     // Set initial state
     machine.set_initial_state("idle");
-    
+
     println!("\n{}\n", machine.generate_diagram());
 
     // Simulate a sequence of events
     let events = vec![
         "start",
-        "obstacle", 
+        "obstacle",
         "clear",
         "low_battery",
         "charged",
@@ -548,7 +565,7 @@ pub fn demo_state_machine() {
     ];
 
     println!("=== Processing Events ===\n");
-    
+
     for event in events {
         println!("Processing event: [{}]", event);
         match machine.process(event) {
@@ -606,7 +623,7 @@ mod tests {
         let transition = Transition::new("idle", "start", "running")
             .with_guard("can_start")
             .with_action("start_motors");
-        
+
         assert_eq!(transition.src_state, "idle");
         assert_eq!(transition.event, "start");
         assert_eq!(transition.dst_state, "running");
@@ -617,15 +634,11 @@ mod tests {
     #[test]
     fn test_simple_transition() {
         let mut machine = StateMachine::new("test");
-        
+
         machine.add_transition(Transition::new("idle", "start", "running"));
         machine.set_initial_state("idle");
-        
+
         assert!(machine.process("start").is_ok());
         assert_eq!(machine.get_current_state().unwrap().name, "running");
     }
-}
-
-fn main() {
-    demo_state_machine();
 }

--- a/src/mission_planning/state_machine.rs
+++ b/src/mission_planning/state_machine.rs
@@ -641,4 +641,27 @@ mod tests {
         assert!(machine.process("start").is_ok());
         assert_eq!(machine.get_current_state().unwrap().name, "running");
     }
+
+    #[test]
+    fn test_robot_state_machine_follows_demo_transitions() {
+        let mut machine = create_robot_state_machine();
+        machine.set_initial_state("idle");
+
+        assert!(machine.process("start").is_ok());
+        assert_eq!(machine.get_current_state().unwrap().name, "moving");
+
+        assert!(machine.process("low_battery").is_ok());
+        assert_eq!(machine.get_current_state().unwrap().name, "charging");
+
+        let history = machine.get_transition_history();
+        assert_eq!(history.len(), 2);
+        assert_eq!(
+            history.last(),
+            Some(&(
+                "moving".to_string(),
+                "low_battery".to_string(),
+                "charging".to_string()
+            ))
+        );
+    }
 }

--- a/src/path_planning/a_star.rs
+++ b/src/path_planning/a_star.rs
@@ -3,10 +3,10 @@
 //! Grid-based path planning using A* search algorithm with
 //! configurable heuristic weight.
 
-use std::collections::{HashMap, BinaryHeap};
 use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
 
-use crate::common::{Point2D, Path2D, PathPlanner, RoboticsError};
+use crate::common::{Path2D, PathPlanner, Point2D, RoboticsError};
 use crate::utils::{GridMap, Node};
 
 /// Configuration for A* planner
@@ -51,7 +51,10 @@ impl PartialEq for PriorityNode {
 impl Ord for PriorityNode {
     fn cmp(&self, other: &Self) -> Ordering {
         // Reverse ordering for min-heap behavior
-        other.priority.partial_cmp(&self.priority).unwrap_or(Ordering::Equal)
+        other
+            .priority
+            .partial_cmp(&self.priority)
+            .unwrap_or(Ordering::Equal)
     }
 }
 
@@ -74,7 +77,11 @@ impl AStarPlanner {
         let grid_map = GridMap::new(ox, oy, config.resolution, config.robot_radius);
         let motion = Self::get_motion_model();
 
-        AStarPlanner { grid_map, config, motion }
+        AStarPlanner {
+            grid_map,
+            config,
+            motion,
+        }
     }
 
     /// Create from obstacle x/y vectors with default config
@@ -104,8 +111,7 @@ impl AStarPlanner {
     }
 
     fn calc_heuristic(&self, n1_x: i32, n1_y: i32, n2_x: i32, n2_y: i32) -> f64 {
-        self.config.heuristic_weight
-            * (((n1_x - n2_x).pow(2) + (n1_y - n2_y).pow(2)) as f64).sqrt()
+        self.config.heuristic_weight * (((n1_x - n2_x).pow(2) + (n1_y - n2_y).pow(2)) as f64).sqrt()
     }
 
     fn get_motion_model() -> Vec<(i32, i32, f64)> {
@@ -223,10 +229,14 @@ mod tests {
 
         // Boundary
         for i in 0..11 {
-            ox.push(i as f64); oy.push(0.0);
-            ox.push(i as f64); oy.push(10.0);
-            ox.push(0.0); oy.push(i as f64);
-            ox.push(10.0); oy.push(i as f64);
+            ox.push(i as f64);
+            oy.push(0.0);
+            ox.push(i as f64);
+            oy.push(10.0);
+            ox.push(0.0);
+            oy.push(i as f64);
+            ox.push(10.0);
+            oy.push(i as f64);
         }
 
         // Internal obstacle

--- a/src/path_planning/a_star.rs
+++ b/src/path_planning/a_star.rs
@@ -260,7 +260,7 @@ mod tests {
         assert!(result.is_ok());
 
         let path = result.unwrap();
-        assert!(path.len() > 0);
+        assert!(!path.is_empty());
     }
 
     #[test]
@@ -272,7 +272,7 @@ mod tests {
         assert!(result.is_some());
 
         let (rx, ry) = result.unwrap();
-        assert!(rx.len() > 0);
+        assert!(!rx.is_empty());
         assert_eq!(rx.len(), ry.len());
     }
 }

--- a/src/path_planning/bezier_path.rs
+++ b/src/path_planning/bezier_path.rs
@@ -4,53 +4,53 @@
 // author: Atsushi Sakai(@Atsushi_twi)
 //         Ryohei Sasaki(@rsasaki0109)
 
-use rust_robotics::path_planning::cubic_spline_planner;
 use plotlib::page::Page;
 use plotlib::repr::Plot;
-use plotlib::view::ContinuousView;
-use plotlib::style::PointStyle;
 use plotlib::style::LineStyle;
+use plotlib::style::PointStyle;
+use plotlib::view::ContinuousView;
+use rust_robotics::path_planning::cubic_spline_planner;
 
 fn calc_4points_bezier_path(
-    x_start: (f64, f64, f64), x_goal: (f64, f64, f64), offset: f64)
--> (Vec<(f64, f64)>, [(f64, f64) ;4])
-{
+    x_start: (f64, f64, f64),
+    x_goal: (f64, f64, f64),
+    offset: f64,
+) -> (Vec<(f64, f64)>, [(f64, f64); 4]) {
     let x_diff = (x_start.0 - x_goal.0, x_start.1 - x_goal.1);
     let dist = ((x_diff.0).powi(2) + (x_diff.1).powi(2)).sqrt() / offset;
     let control_points = [
         (x_start.0, x_start.1),
-        (x_start.0 + dist * (x_start.2).cos(), x_start.1 + dist * (x_start.2).sin()),
-        (x_goal.0 - dist * (x_goal.2).cos(), x_goal.1 - dist * (x_goal.2).sin()),
-        (x_goal.0, x_goal.1)
-        ]; 
+        (
+            x_start.0 + dist * (x_start.2).cos(),
+            x_start.1 + dist * (x_start.2).sin(),
+        ),
+        (
+            x_goal.0 - dist * (x_goal.2).cos(),
+            x_goal.1 - dist * (x_goal.2).sin(),
+        ),
+        (x_goal.0, x_goal.1),
+    ];
     let path = calc_bezier_path(control_points, 100);
     (path, control_points)
 }
 
-fn calc_bezier_path(
-    control_points: [(f64, f64) ;4], n_points: usize)
--> Vec<(f64, f64)>
-{
-    let mut traj : Vec<(f64, f64)> = Vec::with_capacity(n_points);
-    for i in 0..n_points-1 {
+fn calc_bezier_path(control_points: [(f64, f64); 4], n_points: usize) -> Vec<(f64, f64)> {
+    let mut traj: Vec<(f64, f64)> = Vec::with_capacity(n_points);
+    for i in 0..n_points - 1 {
         let t = (i as f64) / ((n_points as f64) - 1.);
         traj.push(bezier(t, control_points));
     }
     traj
 }
 
-fn bernstein_poly(n: i32, i: i32, t: f64) -> f64
-{
+fn bernstein_poly(n: i32, i: i32, t: f64) -> f64 {
     (binom(n, i) as f64) * t.powi(i) * (1. - t).powi(n - i)
 }
 
-fn bezier(
-    t: f64, control_points: [(f64, f64) ;4]
-) -> (f64, f64)
-{
-    let n = control_points.len()-1;
+fn bezier(t: f64, control_points: [(f64, f64); 4]) -> (f64, f64) {
+    let n = control_points.len() - 1;
     let mut point = (0., 0.);
-    for i in 0..n+1 {
+    for i in 0..n + 1 {
         let ber_poly = bernstein_poly(n as i32, i as i32, t);
         point.0 += ber_poly * control_points[i].0;
         point.1 += ber_poly * control_points[i].1;
@@ -60,20 +60,23 @@ fn bezier(
 
 // Ref:Donald E.Knuth, "The Art of Computer Programming (2)"
 fn binom(n: i32, k: i32) -> i32 {
-    (0..n + 1)
-        .rev()
-        .zip(1..k + 1)
-        .fold(1, |mut r, (n, d)| { r *= n; r /= d; r })
+    (0..n + 1).rev().zip(1..k + 1).fold(1, |mut r, (n, d)| {
+        r *= n;
+        r /= d;
+        r
+    })
 }
 
 #[warn(dead_code)]
 fn bezier_derivatives_control_points(
-    control_points: [(f64, f64) ;4], n_derivatives: usize) -> Vec<[(f64, f64) ;4]> {
+    control_points: [(f64, f64); 4],
+    n_derivatives: usize,
+) -> Vec<[(f64, f64); 4]> {
     let mut w = vec![control_points];
-    let mut tmp :[(f64, f64) ;4] = Default::default(); 
-    let n = w.len(); 
-    for i in 0..n_derivatives-1 {
-        for j in 0..n-1 {
+    let mut tmp: [(f64, f64); 4] = Default::default();
+    let n = w.len();
+    for i in 0..n_derivatives - 1 {
+        for j in 0..n - 1 {
             tmp[j].0 = ((n - 1) as f64) * (w[i][j + 1].0 - w[i][j].0);
             tmp[j].1 = ((n - 1) as f64) * (w[i][j + 1].1 - w[i][j].1);
         }
@@ -89,8 +92,8 @@ fn curvature(dx: f64, dy: f64, ddx: f64, ddy: f64) -> f64 {
 
 fn main() {
     // [x, y, yaw]
-    let start_x = (10., 1., 180.0/180.0 * std::f64::consts::PI);
-    let end_x = (0., -3., - 45.0/180.0 * std::f64::consts::PI);
+    let start_x = (10., 1., 180.0 / 180.0 * std::f64::consts::PI);
+    let end_x = (0., -3., -45.0 / 180.0 * std::f64::consts::PI);
 
     let offset = 3.;
 
@@ -103,27 +106,14 @@ fn main() {
     let mut arrow_goal = vec![(end_x.0, end_x.1)];
     arrow_goal.push((end_x.0 + (end_x.2).cos(), end_x.1 + (end_x.2).sin()));
 
-    let s0: Plot = Plot::new(control_points.to_vec()).point_style(
-        PointStyle::new()
-            .colour("#000000"),
-    );
+    let s0: Plot =
+        Plot::new(control_points.to_vec()).point_style(PointStyle::new().colour("#000000"));
 
-    let s1: Plot = Plot::new(path).line_style(
-        LineStyle::new() 
-            .colour("#35C788"),
-    );
+    let s1: Plot = Plot::new(path).line_style(LineStyle::new().colour("#35C788"));
 
-    let s2: Plot = Plot::new(arrow_start).line_style(
-        LineStyle::new() 
-            .colour("#DD3355")
-            .width(2.),
-    );
+    let s2: Plot = Plot::new(arrow_start).line_style(LineStyle::new().colour("#DD3355").width(2.));
 
-    let s3: Plot = Plot::new(arrow_goal).line_style(
-        LineStyle::new() 
-            .colour("#DD3355")
-            .width(2.),
-    ); 
+    let s3: Plot = Plot::new(arrow_goal).line_style(LineStyle::new().colour("#DD3355").width(2.));
 
     let v = ContinuousView::new()
         .add(s0)

--- a/src/path_planning/bezier_path.rs
+++ b/src/path_planning/bezier_path.rs
@@ -4,7 +4,7 @@
 // author: Atsushi Sakai(@Atsushi_twi)
 //         Ryohei Sasaki(@rsasaki0109)
 
-use crate::path_planning::cubic_spline_planner;
+use rust_robotics::path_planning::cubic_spline_planner;
 use plotlib::page::Page;
 use plotlib::repr::Plot;
 use plotlib::view::ContinuousView;

--- a/src/path_planning/bezier_path.rs
+++ b/src/path_planning/bezier_path.rs
@@ -93,7 +93,7 @@ fn curvature(dx: f64, dy: f64, ddx: f64, ddy: f64) -> f64 {
 
 fn main() {
     // [x, y, yaw]
-    let start_x = (10., 1., 180.0 / 180.0 * std::f64::consts::PI);
+    let start_x = (10., 1., std::f64::consts::PI);
     let end_x = (0., -3., -45.0 / 180.0 * std::f64::consts::PI);
 
     let offset = 3.;

--- a/src/path_planning/bezier_path.rs
+++ b/src/path_planning/bezier_path.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::needless_range_loop, clippy::type_complexity)]
+
 //
 // Path planning with Bezier curve.
 //
@@ -9,7 +11,6 @@ use plotlib::repr::Plot;
 use plotlib::style::LineStyle;
 use plotlib::style::PointStyle;
 use plotlib::view::ContinuousView;
-use rust_robotics::path_planning::cubic_spline_planner;
 
 fn calc_4points_bezier_path(
     x_start: (f64, f64, f64),
@@ -67,7 +68,7 @@ fn binom(n: i32, k: i32) -> i32 {
     })
 }
 
-#[warn(dead_code)]
+#[allow(dead_code)]
 fn bezier_derivatives_control_points(
     control_points: [(f64, f64); 4],
     n_derivatives: usize,
@@ -85,7 +86,7 @@ fn bezier_derivatives_control_points(
     w
 }
 
-#[warn(dead_code)]
+#[allow(dead_code)]
 fn curvature(dx: f64, dy: f64, ddx: f64, ddy: f64) -> f64 {
     (dx * ddy - dy * ddx) / (dx.powi(2) + dy.powi(2)).powf(3. / 2.)
 }

--- a/src/path_planning/bezier_path_planning.rs
+++ b/src/path_planning/bezier_path_planning.rs
@@ -3,7 +3,7 @@
 // Author: Atsushi Sakai(@Atsushi_twi)
 //         Rust implementation
 
-use gnuplot::{Figure, Caption, Color, AxesCommon};
+use gnuplot::{AxesCommon, Caption, Color, Figure};
 use std::f64::consts::PI;
 
 // Binomial coefficient calculation (replacement for scipy.special.comb)
@@ -14,9 +14,9 @@ fn binomial_coefficient(n: usize, k: usize) -> f64 {
     if k == 0 || k == n {
         return 1.0;
     }
-    
+
     let k = if k > n - k { n - k } else { k }; // Take advantage of symmetry
-    
+
     let mut result = 1.0;
     for i in 0..k {
         result *= (n - i) as f64;
@@ -35,89 +35,98 @@ fn bezier(t: f64, control_points: &[(f64, f64)]) -> (f64, f64) {
     let n = control_points.len() - 1;
     let mut x = 0.0;
     let mut y = 0.0;
-    
+
     for (i, &(px, py)) in control_points.iter().enumerate() {
         let basis = bernstein_poly(n, i, t);
         x += basis * px;
         y += basis * py;
     }
-    
+
     (x, y)
 }
 
 // Compute bezier path (trajectory) given control points
 fn calc_bezier_path(control_points: &[(f64, f64)], n_points: usize) -> Vec<(f64, f64)> {
     let mut trajectory = Vec::new();
-    
+
     for i in 0..n_points {
         let t = i as f64 / (n_points - 1) as f64;
         trajectory.push(bezier(t, control_points));
     }
-    
+
     trajectory
 }
 
 // Compute control points and path given start and end position
-fn calc_4points_bezier_path(sx: f64, sy: f64, syaw: f64, ex: f64, ey: f64, eyaw: f64, offset: f64) 
-    -> (Vec<(f64, f64)>, Vec<(f64, f64)>) {
+fn calc_4points_bezier_path(
+    sx: f64,
+    sy: f64,
+    syaw: f64,
+    ex: f64,
+    ey: f64,
+    eyaw: f64,
+    offset: f64,
+) -> (Vec<(f64, f64)>, Vec<(f64, f64)>) {
     let dist = ((sx - ex).powi(2) + (sy - ey).powi(2)).sqrt() / offset;
-    
+
     let control_points = vec![
         (sx, sy),
         (sx + dist * syaw.cos(), sy + dist * syaw.sin()),
         (ex - dist * eyaw.cos(), ey - dist * eyaw.sin()),
         (ex, ey),
     ];
-    
+
     let path = calc_bezier_path(&control_points, 100);
-    
+
     (path, control_points)
 }
 
 // Compute control points of the successive derivatives of a given bezier curve
-fn bezier_derivatives_control_points(control_points: &[(f64, f64)], n_derivatives: usize) 
-    -> Vec<Vec<(f64, f64)>> {
+fn bezier_derivatives_control_points(
+    control_points: &[(f64, f64)],
+    n_derivatives: usize,
+) -> Vec<Vec<(f64, f64)>> {
     let mut derivatives = vec![control_points.to_vec()];
-    
+
     for i in 0..n_derivatives {
         let current = &derivatives[i];
         let n = current.len();
-        
+
         if n <= 1 {
             break;
         }
-        
+
         let mut next_derivative = Vec::new();
-        for j in 0..n-1 {
+        for j in 0..n - 1 {
             let dx = (n - 1) as f64 * (current[j + 1].0 - current[j].0);
             let dy = (n - 1) as f64 * (current[j + 1].1 - current[j].1);
             next_derivative.push((dx, dy));
         }
         derivatives.push(next_derivative);
     }
-    
+
     derivatives
 }
 
 // Calculate curvature at parameter t
 fn calc_curvature(control_points: &[(f64, f64)], t: f64) -> f64 {
     let derivatives = bezier_derivatives_control_points(control_points, 2);
-    
+
     if derivatives.len() < 3 {
         return 0.0;
     }
-    
+
     let first_deriv = bezier(t, &derivatives[1]);
     let second_deriv = bezier(t, &derivatives[2]);
-    
+
     let dx = first_deriv.0;
     let dy = first_deriv.1;
     let ddx = second_deriv.0;
     let ddy = second_deriv.1;
-    
+
     let numerator = dx * ddy - dy * ddx;
     let denominator = (dx * dx + dy * dy).powf(1.5);
-    
+
     if denominator.abs() < 1e-10 {
         0.0
     } else {
@@ -139,159 +148,187 @@ impl BezierPathPlanner {
             curvature: Vec::new(),
         }
     }
-    
-    pub fn planning(&mut self, sx: f64, sy: f64, syaw: f64, ex: f64, ey: f64, eyaw: f64, offset: f64) -> bool {
+
+    pub fn planning(
+        &mut self,
+        sx: f64,
+        sy: f64,
+        syaw: f64,
+        ex: f64,
+        ey: f64,
+        eyaw: f64,
+        offset: f64,
+    ) -> bool {
         let (path, control_points) = calc_4points_bezier_path(sx, sy, syaw, ex, ey, eyaw, offset);
-        
+
         // Calculate curvature along the path
         let mut curvature = Vec::new();
         for i in 0..path.len() {
             let t = i as f64 / (path.len() - 1) as f64;
             curvature.push(calc_curvature(&control_points, t));
         }
-        
+
         self.path = path;
         self.control_points = control_points;
         self.curvature = curvature;
-        
+
         println!("Bezier path generated with {} points", self.path.len());
         true
     }
-    
-    pub fn planning_with_control_points(&mut self, control_points: Vec<(f64, f64)>, n_points: usize) -> bool {
+
+    pub fn planning_with_control_points(
+        &mut self,
+        control_points: Vec<(f64, f64)>,
+        n_points: usize,
+    ) -> bool {
         if control_points.len() < 2 {
             println!("Need at least 2 control points");
             return false;
         }
-        
+
         let path = calc_bezier_path(&control_points, n_points);
-        
+
         // Calculate curvature along the path
         let mut curvature = Vec::new();
         for i in 0..path.len() {
             let t = i as f64 / (path.len() - 1) as f64;
             curvature.push(calc_curvature(&control_points, t));
         }
-        
+
         self.path = path;
         self.control_points = control_points;
         self.curvature = curvature;
-        
-        println!("Bezier path generated with {} points from {} control points", 
-                 self.path.len(), self.control_points.len());
+
+        println!(
+            "Bezier path generated with {} points from {} control points",
+            self.path.len(),
+            self.control_points.len()
+        );
         true
     }
-    
+
     pub fn visualize(&self) {
         if self.path.is_empty() {
             println!("No path to visualize");
             return;
         }
-        
+
         let mut fg = Figure::new();
         let axes = fg.axes2d();
-        
+
         // Plot path
         let path_x: Vec<f64> = self.path.iter().map(|p| p.0).collect();
         let path_y: Vec<f64> = self.path.iter().map(|p| p.1).collect();
         axes.lines(&path_x, &path_y, &[Caption("Bezier Path"), Color("blue")]);
-        
+
         // Plot control points
         let control_x: Vec<f64> = self.control_points.iter().map(|p| p.0).collect();
         let control_y: Vec<f64> = self.control_points.iter().map(|p| p.1).collect();
-        axes.points(&control_x, &control_y, &[Caption("Control Points"), Color("red")]);
-        axes.lines(&control_x, &control_y, &[Caption("Control Polygon"), Color("red")]);
-        
+        axes.points(
+            &control_x,
+            &control_y,
+            &[Caption("Control Points"), Color("red")],
+        );
+        axes.lines(
+            &control_x,
+            &control_y,
+            &[Caption("Control Polygon"), Color("red")],
+        );
+
         axes.set_title("Bezier Path Planning", &[])
             .set_x_label("X [m]", &[])
             .set_y_label("Y [m]", &[])
             .set_aspect_ratio(gnuplot::AutoOption::Fix(1.0));
-        
+
         let output_path = "img/path_planning/bezier_path_result.png";
         fg.save_to_png(output_path, 800, 600).unwrap();
         println!("Plot saved to: {}", output_path);
-        
+
         fg.show().unwrap();
     }
-    
+
     pub fn visualize_curvature(&self) {
         if self.curvature.is_empty() {
             return;
         }
-        
+
         let mut fg = Figure::new();
         let axes = fg.axes2d();
-        
+
         let s: Vec<f64> = (0..self.curvature.len()).map(|i| i as f64).collect();
         axes.lines(&s, &self.curvature, &[Caption("Curvature"), Color("red")]);
-        
+
         axes.set_title("Bezier Path Curvature Profile", &[])
             .set_x_label("Point Index", &[])
             .set_y_label("Curvature [1/m]", &[]);
-        
-        fg.save_to_png("img/path_planning/bezier_curvature_profile.png", 800, 600).unwrap();
+
+        fg.save_to_png("img/path_planning/bezier_curvature_profile.png", 800, 600)
+            .unwrap();
         println!("Curvature profile saved to img/path_planning/bezier_curvature_profile.png");
     }
 }
 
 fn main() {
     println!("Bezier path planner start!!");
-    
+
     // Example 1: 4-point Bezier path from start/end poses
     let start_x = 10.0;
     let start_y = 1.0;
     let start_yaw = (180.0_f64).to_radians();
-    
+
     let end_x = -0.0;
     let end_y = -3.0;
     let end_yaw = (45.0_f64).to_radians();
     let offset = 3.0;
-    
+
     let mut planner = BezierPathPlanner::new();
-    
+
     if planner.planning(start_x, start_y, start_yaw, end_x, end_y, end_yaw, offset) {
         println!("4-point Bezier path generated successfully!");
         planner.visualize();
         planner.visualize_curvature();
     }
-    
+
     // Example 2: Bezier path with custom control points
-    let control_points = vec![
-        (-1.0, 0.0),
-        (3.0, -3.0),
-        (4.0, 1.0),
-        (2.0, 1.0),
-        (1.0, 3.0),
-    ];
-    
+    let control_points = vec![(-1.0, 0.0), (3.0, -3.0), (4.0, 1.0), (2.0, 1.0), (1.0, 3.0)];
+
     let mut planner2 = BezierPathPlanner::new();
-    
+
     if planner2.planning_with_control_points(control_points, 100) {
         println!("Custom control points Bezier path generated successfully!");
-        
+
         // Save as separate file
         let mut fg = Figure::new();
         let axes = fg.axes2d();
-        
+
         let path_x: Vec<f64> = planner2.path.iter().map(|p| p.0).collect();
         let path_y: Vec<f64> = planner2.path.iter().map(|p| p.1).collect();
         axes.lines(&path_x, &path_y, &[Caption("Bezier Path"), Color("blue")]);
-        
+
         let control_x: Vec<f64> = planner2.control_points.iter().map(|p| p.0).collect();
         let control_y: Vec<f64> = planner2.control_points.iter().map(|p| p.1).collect();
-        axes.points(&control_x, &control_y, &[Caption("Control Points"), Color("red")]);
-        axes.lines(&control_x, &control_y, &[Caption("Control Polygon"), Color("red")]);
-        
+        axes.points(
+            &control_x,
+            &control_y,
+            &[Caption("Control Points"), Color("red")],
+        );
+        axes.lines(
+            &control_x,
+            &control_y,
+            &[Caption("Control Polygon"), Color("red")],
+        );
+
         axes.set_title("Bezier Path with Custom Control Points", &[])
             .set_x_label("X [m]", &[])
             .set_y_label("Y [m]", &[])
             .set_aspect_ratio(gnuplot::AutoOption::Fix(1.0));
-        
-        fg.save_to_png("img/path_planning/bezier_custom_result.png", 800, 600).unwrap();
+
+        fg.save_to_png("img/path_planning/bezier_custom_result.png", 800, 600)
+            .unwrap();
         println!("Custom control points plot saved to: img/path_planning/bezier_custom_result.png");
-        
+
         fg.show().unwrap();
     }
-    
+
     println!("Bezier path planner finish!!");
 }

--- a/src/path_planning/bezier_path_planning.rs
+++ b/src/path_planning/bezier_path_planning.rs
@@ -1,10 +1,11 @@
+#![allow(dead_code, clippy::too_many_arguments, clippy::type_complexity)]
+
 // Path planning with Bezier curve.
 //
 // Author: Atsushi Sakai(@Atsushi_twi)
 //         Rust implementation
 
 use gnuplot::{AxesCommon, Caption, Color, Figure};
-use std::f64::consts::PI;
 
 // Binomial coefficient calculation (replacement for scipy.special.comb)
 fn binomial_coefficient(n: usize, k: usize) -> f64 {
@@ -265,6 +266,12 @@ impl BezierPathPlanner {
         fg.save_to_png("img/path_planning/bezier_curvature_profile.png", 800, 600)
             .unwrap();
         println!("Curvature profile saved to img/path_planning/bezier_curvature_profile.png");
+    }
+}
+
+impl Default for BezierPathPlanner {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/path_planning/csp.rs
+++ b/src/path_planning/csp.rs
@@ -7,9 +7,9 @@ use rust_robotics::path_planning::cubic_spline_planner;
 
 use plotlib::page::Page;
 use plotlib::repr::Plot;
-use plotlib::view::ContinuousView;
-use plotlib::style::PointStyle;
 use plotlib::style::LineStyle;
+use plotlib::style::PointStyle;
+use plotlib::view::ContinuousView;
 
 fn main() {
     let points = vec![
@@ -32,28 +32,20 @@ fn main() {
         y.push(p.1);
     }
 
-
     let sp = cubic_spline_planner::Spline2D::new(x, y);
-    let s_end = sp.s[sp.s.len()-1]; 
+    let s_end = sp.s[sp.s.len() - 1];
     let n = (s_end / ds) as usize;
-    let mut pos: Vec<(f64,f64)> = Vec::with_capacity(nx);
-    for i in 0..n-1 {
-        let pair = sp.clone().calc_position((i as f64/ (n -1)as f64)  * s_end);
+    let mut pos: Vec<(f64, f64)> = Vec::with_capacity(nx);
+    for i in 0..n - 1 {
+        let pair = sp
+            .clone()
+            .calc_position((i as f64 / (n - 1) as f64) * s_end);
         pos.push(pair);
     }
 
+    let s0: Plot = Plot::new(points).point_style(PointStyle::new().colour("#000000"));
 
-    let s0: Plot = Plot::new(points).point_style(
-        PointStyle::new()
-            .colour("#000000"),
-    );
-
-    let s1: Plot = Plot::new(pos).line_style(
-        LineStyle::new() 
-            .colour("#35C788")
-            .width(2.),
-    ); 
-
+    let s1: Plot = Plot::new(pos).line_style(LineStyle::new().colour("#35C788").width(2.));
 
     let v = ContinuousView::new()
         .add(s0)

--- a/src/path_planning/csp.rs
+++ b/src/path_planning/csp.rs
@@ -3,7 +3,7 @@
 //
 // Author: Atsushi Sakai(@Atsushi_twi)
 //         Ryohei Sasaki(@rsasaki0109)
-use crate::path_planning::cubic_spline_planner;
+use rust_robotics::path_planning::cubic_spline_planner;
 
 use plotlib::page::Page;
 use plotlib::repr::Plot;

--- a/src/path_planning/csp.rs
+++ b/src/path_planning/csp.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 // https://github.com/AtsushiSakai/PythonRobotics/tree/master/PathPlanning/CubicSpline
 // Cubic spline planner
 //

--- a/src/path_planning/cubic_spline_planner.rs
+++ b/src/path_planning/cubic_spline_planner.rs
@@ -68,8 +68,7 @@ impl Spline {
         let i = self.clone().__search_index(t);
         let x = self.x[i];
         let dx = t - x;
-        let result = self.a[i] + self.b[i] * dx + self.c[i] * dx.powi(2) + self.d[i] * dx.powi(3);
-        result
+        self.a[i] + self.b[i] * dx + self.c[i] * dx.powi(2) + self.d[i] * dx.powi(3)
     }
 
     fn calcd(self, t: f64) -> f64 {
@@ -79,16 +78,14 @@ impl Spline {
         let b = self.b[i];
         let c = self.c[i];
         let d = self.d[i];
-        let result = b + 2. * c * dx + 3. * d * dx.powi(2);
-        result
+        b + 2. * c * dx + 3. * d * dx.powi(2)
     }
 
     fn calcdd(self, t: f64) -> f64 {
         let i = self.clone().__search_index(t);
         let x = self.x[i];
         let dx = t - x;
-        let result = 2. * self.c[i] + 6. * self.d[i] * dx;
-        result
+        2. * self.c[i] + 6. * self.d[i] * dx
     }
 
     fn __search_index(self, t: f64) -> usize {
@@ -125,11 +122,11 @@ impl Spline {
     fn bisect(self, t: f64, s: usize, e: usize) -> usize {
         let mid = (s + e) / 2;
         if t == self.x[mid] || e - s <= 1 {
-            return mid;
+            mid
         } else if t > self.x[mid] {
-            return self.bisect(t, mid, e);
+            self.bisect(t, mid, e)
         } else {
-            return self.bisect(t, s, mid);
+            self.bisect(t, s, mid)
         }
     }
 }
@@ -183,15 +180,13 @@ impl Spline2D {
         let ddx = self.sx.calcdd(is);
         let dy = self.sy.clone().calcd(is);
         let ddy = self.sy.calcdd(is);
-        let k = (ddy * dx - ddx * dy) / ((dx.powi(2) + dy.powi(2)).powf(3. / 2.));
-        k
+        (ddy * dx - ddx * dy) / ((dx.powi(2) + dy.powi(2)).powf(3. / 2.))
     }
 
     fn calc_yaw(self, is: f64) -> f64 {
         let dx = self.sx.calcd(is);
         let dy = self.sy.calcd(is);
-        let yaw = dy.atan2(dx);
-        yaw
+        dy.atan2(dx)
     }
 }
 

--- a/src/path_planning/cubic_spline_planner.rs
+++ b/src/path_planning/cubic_spline_planner.rs
@@ -1,3 +1,11 @@
+#![allow(
+    dead_code,
+    clippy::needless_borrows_for_generic_args,
+    clippy::new_without_default,
+    clippy::ptr_arg,
+    clippy::type_complexity
+)]
+
 // https://github.com/AtsushiSakai/PythonRobotics/tree/master/PathPlanning/CubicSpline
 // https://github.com/onlytailei/CppRobotics/blob/master/include/cubic_spline.h
 // Cubic spline planner
@@ -47,10 +55,10 @@ impl Spline {
         }
 
         Spline {
-            a: a,
-            b: b,
-            c: c,
-            d: d,
+            a,
+            b,
+            c,
+            d,
             x: x.to_vec(),
             y: y.to_vec(),
         }
@@ -139,11 +147,7 @@ impl Spline2D {
         let sx = Spline::new(&s, &x);
         let sy = Spline::new(&s, &y);
 
-        Spline2D {
-            s: s,
-            sx: sx,
-            sy: sy,
-        }
+        Spline2D { s, sx, sy }
     }
 
     fn __calc_s(x: &Vec<f64>, y: &Vec<f64>) -> Vec<f64> {

--- a/src/path_planning/cubic_spline_planner.rs
+++ b/src/path_planning/cubic_spline_planner.rs
@@ -7,10 +7,10 @@
 //         Ryohei Sasaki(@rsasaki0109)
 
 extern crate nalgebra as na;
-use gnuplot::{Figure, Caption, Color, AxesCommon};
+use gnuplot::{AxesCommon, Caption, Color, Figure};
 use std::f64::consts::PI;
 
-#[derive(Debug, Clone)] 
+#[derive(Debug, Clone)]
 struct Spline {
     a: Vec<f64>,
     b: Vec<f64>,
@@ -21,41 +21,42 @@ struct Spline {
 }
 
 impl Spline {
-    fn new(x: &Vec<f64>, y: &Vec<f64>)-> Spline{
+    fn new(x: &Vec<f64>, y: &Vec<f64>) -> Spline {
         let nx = x.len();
         let mut b: Vec<f64> = Vec::with_capacity(nx);
         let mut d: Vec<f64> = Vec::with_capacity(nx);
-        let mut h: Vec<f64> = Vec::with_capacity(nx-1);
-        for i in 0..nx-1 {
-            h.push(x[i+1] - x[i]);
+        let mut h: Vec<f64> = Vec::with_capacity(nx - 1);
+        for i in 0..nx - 1 {
+            h.push(x[i + 1] - x[i]);
         }
         let a = y.clone();
         let a_mat = Spline::__calc_a(&h);
         let b_mat = Spline::__calc_b(&h, &a);
-        
+
         let a_mat_inv = a_mat.try_inverse().unwrap();
-        
+
         let c_na = a_mat_inv * b_mat;
         let mut c: Vec<f64> = Vec::with_capacity(c_na.len());
-        for i in 0..c_na.len(){
+        for i in 0..c_na.len() {
             c.push(c_na[i]);
         }
-        for i in 0..nx-1 {
-            d.push((c[i+1] - c[i]) / (3. * h[i]));
-            let tb = (a[i + 1] - a[i]) / h[i] - h[i] * 
-                (c[i + 1] + 2.0 * c[i]) / 3.0;
+        for i in 0..nx - 1 {
+            d.push((c[i + 1] - c[i]) / (3. * h[i]));
+            let tb = (a[i + 1] - a[i]) / h[i] - h[i] * (c[i + 1] + 2.0 * c[i]) / 3.0;
             b.push(tb);
         }
 
         Spline {
-          a: a, b: b,
-          c: c, d: d,
-          x: x.to_vec(), y: y.to_vec(),
+            a: a,
+            b: b,
+            c: c,
+            d: d,
+            x: x.to_vec(),
+            y: y.to_vec(),
         }
     }
-    
-      
-    fn calc(self, t: f64)-> f64 {
+
+    fn calc(self, t: f64) -> f64 {
         let i = self.clone().__search_index(t);
         let x = self.x[i];
         let dx = t - x;
@@ -63,72 +64,69 @@ impl Spline {
         result
     }
 
-    fn calcd(self, t: f64)-> f64 {
+    fn calcd(self, t: f64) -> f64 {
         let i = self.clone().__search_index(t);
         let x = self.x[i];
         let dx = t - x;
         let b = self.b[i];
         let c = self.c[i];
         let d = self.d[i];
-        let result = b + 2. * c * dx +  3. * d * dx.powi(2);
+        let result = b + 2. * c * dx + 3. * d * dx.powi(2);
         result
     }
 
-    fn calcdd(self, t: f64)-> f64 {
+    fn calcdd(self, t: f64) -> f64 {
         let i = self.clone().__search_index(t);
         let x = self.x[i];
         let dx = t - x;
-        let result = 2. * self.c[i] +  6. * self.d[i] * dx;
+        let result = 2. * self.c[i] + 6. * self.d[i] * dx;
         result
     }
 
-    fn __search_index(self, t: f64)-> usize {
+    fn __search_index(self, t: f64) -> usize {
         let nx = self.x.len();
         self.bisect(t, 0, nx)
     }
 
-    fn __calc_a(h: &Vec<f64>)-> na::DMatrix<f64> {
-        let nx = h.len()+1;
-        let mut a = na::DMatrix::from_diagonal_element(nx, nx, 0.0) ;
+    fn __calc_a(h: &Vec<f64>) -> na::DMatrix<f64> {
+        let nx = h.len() + 1;
+        let mut a = na::DMatrix::from_diagonal_element(nx, nx, 0.0);
         a[(0, 0)] = 1.;
-        for i in 0..nx-1 {
-            if i != nx-2 {
-                a[(i+1, i+1)] = 2.0 * (h[i] + h[i + 1]);
+        for i in 0..nx - 1 {
+            if i != nx - 2 {
+                a[(i + 1, i + 1)] = 2.0 * (h[i] + h[i + 1]);
             }
-            a[(i+1, i)] = h[i];
-            a[(i, i+1)] = h[i];
+            a[(i + 1, i)] = h[i];
+            a[(i, i + 1)] = h[i];
         }
         a[(0, 1)] = 0.;
-        a[(nx-1, nx-2)] = 0.;
-        a[(nx-1, nx-1)] = 1.;
+        a[(nx - 1, nx - 2)] = 0.;
+        a[(nx - 1, nx - 1)] = 1.;
         a
     }
 
-    fn __calc_b(h: &Vec<f64>, a: &Vec<f64>)-> na::DVector<f64> {
-        let nx = h.len() +1;
+    fn __calc_b(h: &Vec<f64>, a: &Vec<f64>) -> na::DVector<f64> {
+        let nx = h.len() + 1;
         let mut b = na::DVector::zeros(nx);
-        for i in 0..nx-2 {
-            b[i + 1] = 3.0 * (a[i + 2] - a[i + 1]) /
-            h[i + 1] - 3.0 * (a[i + 1] - a[i]) / h[i];
+        for i in 0..nx - 2 {
+            b[i + 1] = 3.0 * (a[i + 2] - a[i + 1]) / h[i + 1] - 3.0 * (a[i + 1] - a[i]) / h[i];
         }
         b
     }
-    
-    fn bisect(self, t: f64, s: usize, e: usize) -> usize
-    {
+
+    fn bisect(self, t: f64, s: usize, e: usize) -> usize {
         let mid = (s + e) / 2;
         if t == self.x[mid] || e - s <= 1 {
-            return mid
+            return mid;
         } else if t > self.x[mid] {
-            return self.bisect(t, mid, e)
+            return self.bisect(t, mid, e);
         } else {
-            return self.bisect(t, s, mid)
+            return self.bisect(t, s, mid);
         }
     }
 }
 
-
-#[derive(Debug, Clone)] 
+#[derive(Debug, Clone)]
 pub struct Spline2D {
     pub s: Vec<f64>,
     sx: Spline,
@@ -136,51 +134,47 @@ pub struct Spline2D {
 }
 
 impl Spline2D {
-
-    pub fn new(x: Vec<f64>, y: Vec<f64>)-> Spline2D {
+    pub fn new(x: Vec<f64>, y: Vec<f64>) -> Spline2D {
         let s = Spline2D::__calc_s(&x, &y);
         let sx = Spline::new(&s, &x);
         let sy = Spline::new(&s, &y);
 
         Spline2D {
-          s: s,
-          sx: sx, sy: sy,
+            s: s,
+            sx: sx,
+            sy: sy,
         }
     }
 
-    fn __calc_s(x: &Vec<f64>, y: &Vec<f64>) -> Vec<f64>
-    {
+    fn __calc_s(x: &Vec<f64>, y: &Vec<f64>) -> Vec<f64> {
         let nx = x.len();
-        let mut dx: Vec<f64> = Vec::with_capacity(nx-1);
-        let mut dy: Vec<f64> = Vec::with_capacity(nx-1);
-        
-        
-        for i in 0..nx-1 {
-            dx.push(x[i+1] - x[i]);
-            dy.push(y[i+1] - y[i]);
+        let mut dx: Vec<f64> = Vec::with_capacity(nx - 1);
+        let mut dy: Vec<f64> = Vec::with_capacity(nx - 1);
+
+        for i in 0..nx - 1 {
+            dx.push(x[i + 1] - x[i]);
+            dy.push(y[i + 1] - y[i]);
         }
-        let mut ds: Vec<f64> = Vec::with_capacity(nx-1);
-        for i in 0..nx-1 {
+        let mut ds: Vec<f64> = Vec::with_capacity(nx - 1);
+        for i in 0..nx - 1 {
             let dsi = (dx[i].powi(2) + dy[i].powi(2)).sqrt();
             ds.push(dsi);
         }
         let mut s: Vec<f64> = Vec::with_capacity(nx);
         s.push(0.);
-        for i in 0..nx-1 {
+        for i in 0..nx - 1 {
             s.push(s[i] + ds[i]);
         }
         s
     }
 
-    pub fn calc_position(self, is: f64) -> (f64, f64)
-    {
+    pub fn calc_position(self, is: f64) -> (f64, f64) {
         let x = self.sx.calc(is);
         let y = self.sy.calc(is);
         (x, y)
     }
 
-    fn calc_curvature(self, is: f64) -> f64
-    {
+    fn calc_curvature(self, is: f64) -> f64 {
         let dx = self.sx.clone().calcd(is);
         let ddx = self.sx.calcdd(is);
         let dy = self.sy.clone().calcd(is);
@@ -189,28 +183,28 @@ impl Spline2D {
         k
     }
 
-    fn calc_yaw(self, is: f64) -> f64
-    {
-        let dx = self.sx.calcd(is); 
+    fn calc_yaw(self, is: f64) -> f64 {
+        let dx = self.sx.calcd(is);
         let dy = self.sy.calcd(is);
-        let yaw = dy.atan2(dx); 
+        let yaw = dy.atan2(dx);
         yaw
     }
-    
 }
 
-pub fn calc_spline_course(x: Vec<f64>, y: Vec<f64>, ds: f64) -> 
-(Vec<(f64,f64)>, Vec<f64>, Vec<f64>, Vec<f64>)
-{
+pub fn calc_spline_course(
+    x: Vec<f64>,
+    y: Vec<f64>,
+    ds: f64,
+) -> (Vec<(f64, f64)>, Vec<f64>, Vec<f64>, Vec<f64>) {
     let sp = Spline2D::new(x, y);
-    let s_end = sp.s[sp.s.len()-1]; 
+    let s_end = sp.s[sp.s.len() - 1];
     let n = (s_end / ds) as usize;
-    let mut r: Vec<(f64,f64)> = Vec::with_capacity(n);
+    let mut r: Vec<(f64, f64)> = Vec::with_capacity(n);
     let mut ryaw: Vec<f64> = Vec::with_capacity(n);
     let mut rk: Vec<f64> = Vec::with_capacity(n);
     let mut s: Vec<f64> = Vec::with_capacity(n);
-    for i in 0..n-1 {
-        let is = (i as f64/ (n -1)as f64)  * s_end;
+    for i in 0..n - 1 {
+        let is = (i as f64 / (n - 1) as f64) * s_end;
         let pair = sp.clone().calc_position(is);
         r.push(pair);
         ryaw.push(sp.clone().calc_yaw(is));
@@ -244,13 +238,16 @@ impl CubicSplinePlanner {
         }
 
         let (path, yaw, curvature, s) = calc_spline_course(waypoints_x, waypoints_y, ds);
-        
+
         self.path = path;
         self.yaw = yaw;
         self.curvature = curvature;
         self.s = s;
 
-        println!("Cubic spline path generated with {} points", self.path.len());
+        println!(
+            "Cubic spline path generated with {} points",
+            self.path.len()
+        );
         true
     }
 
@@ -264,12 +261,20 @@ impl CubicSplinePlanner {
         let axes = fg.axes2d();
 
         // Plot waypoints
-        axes.points(waypoints_x, waypoints_y, &[Caption("Waypoints"), Color("red")]);
+        axes.points(
+            waypoints_x,
+            waypoints_y,
+            &[Caption("Waypoints"), Color("red")],
+        );
 
         // Plot spline path
         let path_x: Vec<f64> = self.path.iter().map(|p| p.0).collect();
         let path_y: Vec<f64> = self.path.iter().map(|p| p.1).collect();
-        axes.lines(&path_x, &path_y, &[Caption("Cubic Spline Path"), Color("blue")]);
+        axes.lines(
+            &path_x,
+            &path_y,
+            &[Caption("Cubic Spline Path"), Color("blue")],
+        );
 
         axes.set_title("Cubic Spline Path Planning", &[])
             .set_x_label("X [m]", &[])
@@ -297,16 +302,26 @@ impl CubicSplinePlanner {
         axes.set_title("Yaw Profile", &[])
             .set_x_label("Distance [m]", &[])
             .set_y_label("Yaw [deg]", &[]);
-        fg.save_to_png("img/path_planning/cubic_spline_yaw_profile.png", 800, 600).unwrap();
+        fg.save_to_png("img/path_planning/cubic_spline_yaw_profile.png", 800, 600)
+            .unwrap();
 
         // Curvature profile
         let mut fg = Figure::new();
         let axes = fg.axes2d();
-        axes.lines(&self.s, &self.curvature, &[Caption("Curvature"), Color("red")]);
+        axes.lines(
+            &self.s,
+            &self.curvature,
+            &[Caption("Curvature"), Color("red")],
+        );
         axes.set_title("Curvature Profile", &[])
             .set_x_label("Distance [m]", &[])
             .set_y_label("Curvature [1/m]", &[]);
-        fg.save_to_png("img/path_planning/cubic_spline_curvature_profile.png", 800, 600).unwrap();
+        fg.save_to_png(
+            "img/path_planning/cubic_spline_curvature_profile.png",
+            800,
+            600,
+        )
+        .unwrap();
 
         println!("Profile plots saved to img/path_planning/");
     }

--- a/src/path_planning/d_star_lite.rs
+++ b/src/path_planning/d_star_lite.rs
@@ -327,16 +327,14 @@ fn main() {
 
     // 障害物の位置（境界）
     let mut ox: Vec<i32> = (0..MAP_SIZE)
-        .map(|x| x)
-        .chain(std::iter::repeat(MAP_SIZE).take((MAP_SIZE + 1) as usize))
+        .chain(std::iter::repeat_n(MAP_SIZE, (MAP_SIZE + 1) as usize))
         .chain((0..=MAP_SIZE).rev())
-        .chain(std::iter::repeat(0).take((MAP_SIZE + 1) as usize))
+        .chain(std::iter::repeat_n(0, (MAP_SIZE + 1) as usize))
         .collect();
 
-    let mut oy: Vec<i32> = std::iter::repeat(0)
-        .take((MAP_SIZE + 1) as usize)
-        .chain((0..MAP_SIZE).map(|y| y))
-        .chain(std::iter::repeat(MAP_SIZE).take((MAP_SIZE + 1) as usize))
+    let mut oy: Vec<i32> = std::iter::repeat_n(0, (MAP_SIZE + 1) as usize)
+        .chain(0..MAP_SIZE)
+        .chain(std::iter::repeat_n(MAP_SIZE, (MAP_SIZE + 1) as usize))
         .chain((0..=MAP_SIZE).rev())
         .collect();
 

--- a/src/path_planning/d_star_lite.rs
+++ b/src/path_planning/d_star_lite.rs
@@ -1,3 +1,9 @@
+#![allow(
+    dead_code,
+    clippy::legacy_numeric_constants,
+    clippy::needless_borrows_for_generic_args
+)]
+
 use gnuplot::{AxesCommon, Caption, Color, Figure};
 use nalgebra as na;
 use std::cmp::Ordering;
@@ -385,9 +391,9 @@ fn main() {
             );
 
             // Plot start and goal
-            axes.points(&[sx], &[sy], &[Caption("Start"), Color("blue")]);
+            axes.points([sx], [sy], &[Caption("Start"), Color("blue")]);
 
-            axes.points(&[gx], &[gy], &[Caption("Goal"), Color("red")]);
+            axes.points([gx], [gy], &[Caption("Goal"), Color("red")]);
 
             // Plot path if found
             if let Some(path) = &path {
@@ -429,7 +435,7 @@ fn main() {
         }
 
         // 画像を表示
-        fg.show();
+        let _ = fg.show();
     }
 
     if let Some(path) = path {

--- a/src/path_planning/d_star_lite.rs
+++ b/src/path_planning/d_star_lite.rs
@@ -1,14 +1,14 @@
+use gnuplot::{AxesCommon, Caption, Color, Figure};
+use nalgebra as na;
+use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashSet};
 use std::f64::INFINITY;
-use std::cmp::Ordering;
-use gnuplot::{Figure, Caption, Color, AxesCommon};
-use nalgebra as na;
 
 // D* Lite parameters
 const SHOW_ANIMATION: bool = true;
-const PAUSE_TIME: f64 = 0.1;  // アニメーションの表示間隔を少し長くする
+const PAUSE_TIME: f64 = 0.1; // アニメーションの表示間隔を少し長くする
 const P_CREATE_RANDOM_OBSTACLE: f64 = 0.0;
-const DEBUG: bool = true;  // デバッグログを有効にする
+const DEBUG: bool = true; // デバッグログを有効にする
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct Node {
@@ -70,29 +70,29 @@ struct DStarLite {
     y_min_world: i32,
     x_max: i32,
     y_max: i32,
-    
+
     // Start and goal positions
     start: Node,
     goal: Node,
-    
+
     // Algorithm state
     km: f64,
     rhs: na::DMatrix<f64>,
     g: na::DMatrix<f64>,
-    
+
     // Priority queue
     u: BinaryHeap<(Key, Node)>,
-    
+
     // Obstacles
     obstacles: HashSet<(i32, i32)>,
     detected_obstacles: HashSet<(i32, i32)>,
-    
+
     // Motion model (8-connected grid)
     motions: [Node; 8],
-    
+
     // For visualization
     detected_obstacles_for_plotting: Vec<(f64, f64)>,
-    
+
     // State
     initialized: bool,
 }
@@ -103,26 +103,27 @@ impl DStarLite {
         let y_min_world = *oy.iter().min().unwrap_or(&0);
         let x_max = ox.iter().max().unwrap_or(&0) - x_min_world + 1;
         let y_max = oy.iter().max().unwrap_or(&0) - y_min_world + 1;
-        
-        let obstacles: HashSet<_> = ox.iter()
+
+        let obstacles: HashSet<_> = ox
+            .iter()
             .zip(oy.iter())
             .map(|(&x, &y)| (x - x_min_world, y - y_min_world))
             .collect();
-        
+
         let g = na::DMatrix::from_element(x_max as usize, y_max as usize, INFINITY);
         let rhs = na::DMatrix::from_element(x_max as usize, y_max as usize, INFINITY);
-        
+
         let motions = [
             Node::new(1, 0),   // Right
-            Node::new(0, 1),    // Down
-            Node::new(-1, 0),   // Left
-            Node::new(0, -1),   // Up
-            Node::new(1, 1),    // Down-Right
-            Node::new(1, -1),   // Up-Right
-            Node::new(-1, 1),   // Down-Left
-            Node::new(-1, -1),  // Up-Left
+            Node::new(0, 1),   // Down
+            Node::new(-1, 0),  // Left
+            Node::new(0, -1),  // Up
+            Node::new(1, 1),   // Down-Right
+            Node::new(1, -1),  // Up-Right
+            Node::new(-1, 1),  // Down-Left
+            Node::new(-1, -1), // Up-Left
         ];
-        
+
         DStarLite {
             x_min_world,
             y_min_world,
@@ -141,61 +142,64 @@ impl DStarLite {
             initialized: false,
         }
     }
-    
+
     fn is_valid(&self, node: &Node) -> bool {
         node.x >= 0 && node.x < self.x_max && node.y >= 0 && node.y < self.y_max
     }
-    
+
     fn is_obstacle(&self, node: &Node) -> bool {
-        self.obstacles.contains(&(node.x, node.y)) || 
-        self.detected_obstacles.contains(&(node.x, node.y))
+        self.obstacles.contains(&(node.x, node.y))
+            || self.detected_obstacles.contains(&(node.x, node.y))
     }
-    
+
     fn get_neighbors(&self, node: &Node) -> Vec<Node> {
-        self.motions.iter()
+        self.motions
+            .iter()
             .map(|m| node.add(m))
             .filter(|n| self.is_valid(n))
             .collect()
     }
-    
+
     fn calculate_key(&self, node: &Node) -> Key {
-        let min_rhs_g = self.g[(node.x as usize, node.y as usize)].min(self.rhs[(node.x as usize, node.y as usize)]);
+        let min_rhs_g = self.g[(node.x as usize, node.y as usize)]
+            .min(self.rhs[(node.x as usize, node.y as usize)]);
         let h = self.heuristic(&self.start, node);
         Key {
             k1: min_rhs_g + h + self.km,
             k2: min_rhs_g,
         }
     }
-    
+
     fn heuristic(&self, a: &Node, b: &Node) -> f64 {
         let dx = (a.x - b.x).abs() as f64;
         let dy = (a.y - b.y).abs() as f64;
         (dx * dx + dy * dy).sqrt()
     }
-    
+
     fn c(&self, u: &Node, v: &Node) -> f64 {
         if self.is_obstacle(v) {
             return INFINITY;
         }
         self.heuristic(u, v)
     }
-    
+
     fn initialize(&mut self, start: Node, goal: Node) {
         self.start = Node::new(start.x - self.x_min_world, start.y - self.y_min_world);
         self.goal = Node::new(goal.x - self.x_min_world, goal.y - self.y_min_world);
-        
+
         if !self.initialized {
             self.initialized = true;
             self.u.clear();
             self.km = 0.0;
-            self.rhs = na::DMatrix::from_element(self.x_max as usize, self.y_max as usize, INFINITY);
+            self.rhs =
+                na::DMatrix::from_element(self.x_max as usize, self.y_max as usize, INFINITY);
             self.g = na::DMatrix::from_element(self.x_max as usize, self.y_max as usize, INFINITY);
             self.rhs[(self.goal.x as usize, self.goal.y as usize)] = 0.0;
             self.u.push((self.calculate_key(&self.goal), self.goal));
             self.detected_obstacles.clear();
         }
     }
-    
+
     fn update_vertex(&mut self, u: Node) {
         if u.x != self.goal.x || u.y != self.goal.y {
             let mut min_rhs = INFINITY;
@@ -207,19 +211,21 @@ impl DStarLite {
             }
             self.rhs[(u.x as usize, u.y as usize)] = min_rhs;
         }
-        
+
         // Remove u from U if it's there
         self.u = std::mem::take(&mut self.u)
             .into_iter()
             .filter(|(_, node)| node.x != u.x || node.y != u.y)
             .collect();
-            
+
         // If g(u) != rhs(u), add u to U with key(u)
-        if (self.g[(u.x as usize, u.y as usize)] - self.rhs[(u.x as usize, u.y as usize)]).abs() > 1e-6 {
+        if (self.g[(u.x as usize, u.y as usize)] - self.rhs[(u.x as usize, u.y as usize)]).abs()
+            > 1e-6
+        {
             self.u.push((self.calculate_key(&u), u));
         }
     }
-    
+
     fn compute_shortest_path(&mut self) {
         if DEBUG {
             println!("Starting compute_shortest_path");
@@ -227,12 +233,13 @@ impl DStarLite {
         }
         while !self.u.is_empty() {
             let (k_old, u) = self.u.pop().unwrap();
-            
+
             if k_old < self.calculate_key(&u) {
                 self.u.push((self.calculate_key(&u), u));
-            } else if self.g[(u.x as usize, u.y as usize)] > self.rhs[(u.x as usize, u.y as usize)] {
+            } else if self.g[(u.x as usize, u.y as usize)] > self.rhs[(u.x as usize, u.y as usize)]
+            {
                 self.g[(u.x as usize, u.y as usize)] = self.rhs[(u.x as usize, u.y as usize)];
-                
+
                 for s in self.get_neighbors(&u) {
                     self.update_vertex(s);
                 }
@@ -245,60 +252,62 @@ impl DStarLite {
             }
         }
     }
-    
+
     fn plan(&mut self, start: Node, goal: Node) -> Option<Vec<Node>> {
         self.initialize(start, goal);
-        
+
         // First planning
         self.compute_shortest_path();
-        
+
         // Reconstruct path
         self.reconstruct_path()
     }
-    
+
     fn reconstruct_path(&self) -> Option<Vec<Node>> {
         let mut path = Vec::new();
         let mut current = self.start;
-        
+
         while current.x != self.goal.x || current.y != self.goal.y {
             path.push(Node::new(
                 current.x + self.x_min_world,
                 current.y + self.y_min_world,
             ));
-            
+
             let mut min_cost = INFINITY;
             let mut next_node = current;
-            
+
             for neighbor in self.get_neighbors(&current) {
-                let cost = self.c(&current, &neighbor) + self.g[(neighbor.x as usize, neighbor.y as usize)];
+                let cost = self.c(&current, &neighbor)
+                    + self.g[(neighbor.x as usize, neighbor.y as usize)];
                 if cost < min_cost {
                     min_cost = cost;
                     next_node = neighbor;
                 }
             }
-            
+
             if next_node.x == current.x && next_node.y == current.y {
                 // No path found
                 return None;
             }
-            
+
             current = next_node;
         }
-        
+
         // Add the goal node
         path.push(Node::new(
             self.goal.x + self.x_min_world,
             self.goal.y + self.y_min_world,
         ));
-        
+
         Some(path)
     }
-    
+
     fn add_obstacle(&mut self, x: i32, y: i32) {
         let node = Node::new(x - self.x_min_world, y - self.y_min_world);
         if self.is_valid(&node) {
             self.detected_obstacles.insert((node.x, node.y));
-            self.detected_obstacles_for_plotting.push((x as f64, y as f64));
+            self.detected_obstacles_for_plotting
+                .push((x as f64, y as f64));
             self.update_vertex(node);
         }
     }
@@ -306,110 +315,103 @@ impl DStarLite {
 
 fn main() {
     println!("D* Lite path planning");
-    
+
     // マップサイズを小さくする
     const MAP_SIZE: i32 = 20;
-    
+
     // 障害物の位置（境界）
-    let mut ox: Vec<i32> = (0..MAP_SIZE).map(|x| x)
+    let mut ox: Vec<i32> = (0..MAP_SIZE)
+        .map(|x| x)
         .chain(std::iter::repeat(MAP_SIZE).take((MAP_SIZE + 1) as usize))
         .chain((0..=MAP_SIZE).rev())
         .chain(std::iter::repeat(0).take((MAP_SIZE + 1) as usize))
         .collect();
-        
-    let mut oy: Vec<i32> = std::iter::repeat(0).take((MAP_SIZE + 1) as usize)
+
+    let mut oy: Vec<i32> = std::iter::repeat(0)
+        .take((MAP_SIZE + 1) as usize)
         .chain((0..MAP_SIZE).map(|y| y))
         .chain(std::iter::repeat(MAP_SIZE).take((MAP_SIZE + 1) as usize))
         .chain((0..=MAP_SIZE).rev())
         .collect();
-    
+
     // 中央に障害物を追加
     for i in 5..15 {
         ox.push(i);
         oy.push(10);
     }
-    
+
     // スタートとゴールの位置（マップサイズに合わせて調整）
     let sx = 2.0;
     let sy = 2.0;
     let gx = (MAP_SIZE - 2) as f64;
     let gy = (MAP_SIZE - 2) as f64;
-    
+
     if DEBUG {
         println!("Map size: {}x{}", MAP_SIZE, MAP_SIZE);
         println!("Start: ({}, {})", sx, sy);
         println!("Goal: ({}, {})", gx, gy);
         println!("Number of obstacles: {}", ox.len());
     }
-    
+
     let mut d_star_lite = DStarLite::new(&ox, &oy);
-    
+
     // 初期パスの計画
     if DEBUG {
         println!("Planning initial path...");
     }
-    
+
     let start_time = std::time::Instant::now();
     let path = d_star_lite.plan(
         Node::new(sx as i32, sy as i32),
         Node::new(gx as i32, gy as i32),
     );
-    
+
     if DEBUG {
         let elapsed = start_time.elapsed();
         println!("Path planning took: {:.2?}", elapsed);
     }
-    
+
     // Visualization
     if SHOW_ANIMATION {
         let mut fg = Figure::new();
         {
             let axes = fg.axes2d();
-            
+
             // Plot obstacles
             axes.points(
                 ox.iter().map(|&x| x as f64),
                 oy.iter().map(|&y| y as f64),
                 &[Caption("Obstacle"), Color("black")],
             );
-            
+
             // Plot start and goal
-            axes.points(
-                &[sx],
-                &[sy],
-                &[Caption("Start"), Color("blue")],
-            );
-            
-            axes.points(
-                &[gx],
-                &[gy],
-                &[Caption("Goal"), Color("red")],
-            );
-            
+            axes.points(&[sx], &[sy], &[Caption("Start"), Color("blue")]);
+
+            axes.points(&[gx], &[gy], &[Caption("Goal"), Color("red")]);
+
             // Plot path if found
             if let Some(path) = &path {
                 let path_x: Vec<f64> = path.iter().map(|n| n.x as f64).collect();
                 let path_y: Vec<f64> = path.iter().map(|n| n.y as f64).collect();
-                
-                axes.lines(
-                    &path_x,
-                    &path_y,
-                    &[Caption("Path"), Color("green")],
-                );
+
+                axes.lines(&path_x, &path_y, &[Caption("Path"), Color("green")]);
             }
-            
+
             // Plot detected obstacles
             if !d_star_lite.detected_obstacles_for_plotting.is_empty() {
-                let (detected_x, detected_y): (Vec<f64>, Vec<f64>) = 
-                    d_star_lite.detected_obstacles_for_plotting.iter().cloned().unzip();
-                
+                let (detected_x, detected_y): (Vec<f64>, Vec<f64>) = d_star_lite
+                    .detected_obstacles_for_plotting
+                    .iter()
+                    .cloned()
+                    .unzip();
+
                 axes.points(
                     detected_x,
                     detected_y,
                     &[Caption("Detected"), Color("yellow")],
                 );
             }
-            
+
             axes.set_title("D* Lite Path Planning", &[]);
             axes.set_x_label("X [m]", &[]);
             axes.set_y_label("Y [m]", &[]);
@@ -417,7 +419,7 @@ fn main() {
             axes.set_x_ticks(Some((gnuplot::Fix(20.0), 10)), &[], &[]);
             axes.set_y_ticks(Some((gnuplot::Fix(20.0), 10)), &[], &[]);
         }
-        
+
         // 画像をファイルに保存
         let img_path = "d_star_lite_result.png";
         if let Err(e) = fg.save_to_png(img_path, 800, 600) {
@@ -425,11 +427,11 @@ fn main() {
         } else if DEBUG {
             println!("Image saved to: {}", img_path);
         }
-        
+
         // 画像を表示
         fg.show();
     }
-    
+
     if let Some(path) = path {
         println!("Path found with {} points", path.len());
     } else {

--- a/src/path_planning/dijkstra.rs
+++ b/src/path_planning/dijkstra.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::needless_borrows_for_generic_args)]
+
 // Dijkstra path planning
 // author: Salah Eddine Ghamri (s.ghamri)
 
@@ -65,7 +67,7 @@ fn dijkstra_planner(obstacle_map: &grid_map::Map, start: &(usize, usize), goal: 
     let (mut ci, mut cj) = start;
 
     pq.push((Reverse(NotNan::new(0.0).unwrap()), (ci, cj)));
-    dist.insert((ci, cj), 0.0 as f64);
+    dist.insert((ci, cj), 0.0);
 
     let mut fg = Figure::new();
     let mut map_x = vec![];
@@ -106,8 +108,8 @@ fn dijkstra_planner(obstacle_map: &grid_map::Map, start: &(usize, usize), goal: 
                     neighbors_x.push(nj as i32);
                     neighbors_y.push(-(ni as i32));
 
-                    let delta_x = (ci as f64 - ni as f64) as f64;
-                    let delta_y = (cj as f64 - nj as f64) as f64;
+                    let delta_x = ci as f64 - ni as f64;
+                    let delta_y = cj as f64 - nj as f64;
                     let edge_distance = (delta_x * delta_x + delta_y * delta_y).sqrt();
                     let alt = distance.0.into_inner() + edge_distance;
 
@@ -166,7 +168,7 @@ fn dijkstra_planner(obstacle_map: &grid_map::Map, start: &(usize, usize), goal: 
             )
             .lines(&path_x, &path_y, &[Color("black"), LineWidth(3.0)]);
 
-        let crate_dir = option_env!("CARGO_MANIFEST_DIR").unwrap();
+        let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
         fg.show_and_keep_running().unwrap();
         sleep(Duration::from_millis(10));
 

--- a/src/path_planning/dijkstra.rs
+++ b/src/path_planning/dijkstra.rs
@@ -14,7 +14,7 @@ use std::collections::BinaryHeap;
 
 use na::DMatrix;
 extern crate nalgebra as na;
-use crate::utils::grid_map;
+use rust_robotics::utils::grid_map;
 
 // The neighbors function returns adjacent cell coordinates for a given cell in a grid
 // while excluding out-of-bound and the cell itself.

--- a/src/path_planning/dwa.rs
+++ b/src/path_planning/dwa.rs
@@ -7,7 +7,7 @@
 use nalgebra::{Vector2, Vector4, Vector5};
 use std::f64::consts::PI;
 
-use crate::common::{Point2D, Path2D, State2D, ControlInput, Obstacles};
+use crate::common::{ControlInput, Obstacles, Path2D, Point2D, State2D};
 
 /// Robot state for DWA: [x, y, yaw, v, omega]
 pub type DWAState = Vector5<f64>;
@@ -100,7 +100,9 @@ impl Trajectory {
 
     /// Convert to Path2D
     pub fn to_path(&self) -> Path2D {
-        let points: Vec<Point2D> = self.states.iter()
+        let points: Vec<Point2D> = self
+            .states
+            .iter()
             .map(|s| Point2D::new(s[0], s[1]))
             .collect();
         Path2D::from_points(points)
@@ -171,7 +173,8 @@ impl DWAPlanner {
 
     /// Set obstacles from tuples
     pub fn set_obstacles_from_tuples(&mut self, obstacles: &[(f64, f64)]) {
-        self.obstacles = obstacles.iter()
+        self.obstacles = obstacles
+            .iter()
             .map(|(x, y)| Point2D::new(*x, *y))
             .collect();
     }
@@ -190,11 +193,11 @@ impl DWAPlanner {
     fn motion(&self, state: &DWAState, control: &DWAControl) -> DWAState {
         let dt = self.config.dt;
         let mut next = *state;
-        next[2] += control[1] * dt;  // yaw += omega * dt
-        next[0] += control[0] * state[2].cos() * dt;  // x += v * cos(yaw) * dt
-        next[1] += control[0] * state[2].sin() * dt;  // y += v * sin(yaw) * dt
-        next[3] = control[0];  // v
-        next[4] = control[1];  // omega
+        next[2] += control[1] * dt; // yaw += omega * dt
+        next[0] += control[0] * state[2].cos() * dt; // x += v * cos(yaw) * dt
+        next[1] += control[0] * state[2].sin() * dt; // y += v * sin(yaw) * dt
+        next[3] = control[0]; // v
+        next[4] = control[1]; // omega
         next
     }
 
@@ -290,7 +293,7 @@ impl DWAPlanner {
                 let dist = (dx * dx + dy * dy).sqrt();
 
                 if dist <= self.config.robot_radius {
-                    return f64::MAX;  // Collision
+                    return f64::MAX; // Collision
                 }
 
                 if dist < min_dist {
@@ -324,7 +327,8 @@ impl DWAPlanner {
                 // Calculate costs
                 let goal_cost = config.to_goal_cost_gain * self.calc_to_goal_cost(&trajectory);
                 let speed_cost = config.speed_cost_gain * self.calc_speed_cost(&trajectory);
-                let obstacle_cost = config.obstacle_cost_gain * self.calc_obstacle_cost(&trajectory);
+                let obstacle_cost =
+                    config.obstacle_cost_gain * self.calc_obstacle_cost(&trajectory);
 
                 let total_cost = goal_cost + speed_cost + obstacle_cost;
 
@@ -467,11 +471,7 @@ pub fn predict_trajectory(
 
 /// Legacy obstacle cost calculation
 #[allow(deprecated)]
-pub fn calc_obstacle_cost(
-    trajectory: &[Vector5<f64>],
-    ob: &[(f64, f64)],
-    config: &Config,
-) -> f64 {
+pub fn calc_obstacle_cost(trajectory: &[Vector5<f64>], ob: &[(f64, f64)], config: &Config) -> f64 {
     if trajectory.is_empty() || ob.is_empty() {
         return 0.0;
     }
@@ -542,7 +542,8 @@ pub fn calc_control_and_trajectory(
         while y <= dw[3] {
             let trajectory = predict_trajectory(x, v, y, config);
             let to_goal_cost = config.to_goal_cost_gain * calc_to_goal_cost(&trajectory, goal);
-            let speed_cost = config.speed_cost_gain * (config.max_speed - trajectory.last().unwrap()[3]);
+            let speed_cost =
+                config.speed_cost_gain * (config.max_speed - trajectory.last().unwrap()[3]);
             let ob_cost = config.obstacle_cost_gain * calc_obstacle_cost(&trajectory, ob, config);
             let final_cost = to_goal_cost + speed_cost + ob_cost;
 

--- a/src/path_planning/dwa.rs
+++ b/src/path_planning/dwa.rs
@@ -5,9 +5,8 @@
 //! the best trajectory based on goal direction, speed, and obstacle clearance.
 
 use nalgebra::{Vector2, Vector4, Vector5};
-use std::f64::consts::PI;
 
-use crate::common::{ControlInput, Obstacles, Path2D, Point2D, State2D};
+use crate::common::{ControlInput, Path2D, Point2D, State2D};
 
 /// Robot state for DWA: [x, y, yaw, v, omega]
 pub type DWAState = Vector5<f64>;

--- a/src/path_planning/frenet_optimal_trajectory.rs
+++ b/src/path_planning/frenet_optimal_trajectory.rs
@@ -3,7 +3,7 @@
 //         Ryohei Sasaki (@rsasaki0109)
 //         Rust port
 
-use gnuplot::{Figure, Caption, Color, AxesCommon, PointSymbol, PointSize};
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
 use std::f64::consts::PI;
 
 // Parameters
@@ -52,9 +52,15 @@ impl QuinticPolynomial {
 
         // Solve for a3, a4, a5
         let a = nalgebra::Matrix3::new(
-            t3, t4, t5,
-            3.0 * t2, 4.0 * t3, 5.0 * t4,
-            6.0 * time, 12.0 * t2, 20.0 * t3,
+            t3,
+            t4,
+            t5,
+            3.0 * t2,
+            4.0 * t3,
+            5.0 * t4,
+            6.0 * time,
+            12.0 * t2,
+            20.0 * t3,
         );
 
         let b = nalgebra::Vector3::new(
@@ -63,7 +69,10 @@ impl QuinticPolynomial {
             axe - 2.0 * a2,
         );
 
-        let x = a.try_inverse().map(|inv| inv * b).unwrap_or(nalgebra::Vector3::zeros());
+        let x = a
+            .try_inverse()
+            .map(|inv| inv * b)
+            .unwrap_or(nalgebra::Vector3::zeros());
 
         QuinticPolynomial {
             a0,
@@ -76,11 +85,20 @@ impl QuinticPolynomial {
     }
 
     fn calc_point(&self, t: f64) -> f64 {
-        self.a0 + self.a1 * t + self.a2 * t.powi(2) + self.a3 * t.powi(3) + self.a4 * t.powi(4) + self.a5 * t.powi(5)
+        self.a0
+            + self.a1 * t
+            + self.a2 * t.powi(2)
+            + self.a3 * t.powi(3)
+            + self.a4 * t.powi(4)
+            + self.a5 * t.powi(5)
     }
 
     fn calc_first_derivative(&self, t: f64) -> f64 {
-        self.a1 + 2.0 * self.a2 * t + 3.0 * self.a3 * t.powi(2) + 4.0 * self.a4 * t.powi(3) + 5.0 * self.a5 * t.powi(4)
+        self.a1
+            + 2.0 * self.a2 * t
+            + 3.0 * self.a3 * t.powi(2)
+            + 4.0 * self.a4 * t.powi(3)
+            + 5.0 * self.a5 * t.powi(4)
     }
 
     fn calc_second_derivative(&self, t: f64) -> f64 {
@@ -111,17 +129,14 @@ impl QuarticPolynomial {
         let t3 = t2 * time;
 
         // Solve for a3, a4
-        let a = nalgebra::Matrix2::new(
-            3.0 * t2, 4.0 * t3,
-            6.0 * time, 12.0 * t2,
-        );
+        let a = nalgebra::Matrix2::new(3.0 * t2, 4.0 * t3, 6.0 * time, 12.0 * t2);
 
-        let b = nalgebra::Vector2::new(
-            vxe - a1 - 2.0 * a2 * time,
-            axe - 2.0 * a2,
-        );
+        let b = nalgebra::Vector2::new(vxe - a1 - 2.0 * a2 * time, axe - 2.0 * a2);
 
-        let x = a.try_inverse().map(|inv| inv * b).unwrap_or(nalgebra::Vector2::zeros());
+        let x = a
+            .try_inverse()
+            .map(|inv| inv * b)
+            .unwrap_or(nalgebra::Vector2::zeros());
 
         QuarticPolynomial {
             a0,
@@ -152,23 +167,23 @@ impl QuarticPolynomial {
 /// Frenet path
 #[derive(Clone)]
 struct FrenetPath {
-    t: Vec<f64>,      // time
-    d: Vec<f64>,      // lateral position
-    d_d: Vec<f64>,    // lateral velocity
-    d_dd: Vec<f64>,   // lateral acceleration
-    d_ddd: Vec<f64>,  // lateral jerk
-    s: Vec<f64>,      // longitudinal position
-    s_d: Vec<f64>,    // longitudinal velocity
-    s_dd: Vec<f64>,   // longitudinal acceleration
-    s_ddd: Vec<f64>,  // longitudinal jerk
-    cd: f64,          // lateral cost
-    cv: f64,          // velocity cost
-    cf: f64,          // total cost
-    x: Vec<f64>,      // cartesian x
-    y: Vec<f64>,      // cartesian y
-    yaw: Vec<f64>,    // heading
-    ds: Vec<f64>,     // arc length
-    c: Vec<f64>,      // curvature
+    t: Vec<f64>,     // time
+    d: Vec<f64>,     // lateral position
+    d_d: Vec<f64>,   // lateral velocity
+    d_dd: Vec<f64>,  // lateral acceleration
+    d_ddd: Vec<f64>, // lateral jerk
+    s: Vec<f64>,     // longitudinal position
+    s_d: Vec<f64>,   // longitudinal velocity
+    s_dd: Vec<f64>,  // longitudinal acceleration
+    s_ddd: Vec<f64>, // longitudinal jerk
+    cd: f64,         // lateral cost
+    cv: f64,         // velocity cost
+    cf: f64,         // total cost
+    x: Vec<f64>,     // cartesian x
+    y: Vec<f64>,     // cartesian y
+    yaw: Vec<f64>,   // heading
+    ds: Vec<f64>,    // arc length
+    c: Vec<f64>,     // curvature
 }
 
 impl FrenetPath {
@@ -341,7 +356,11 @@ fn calc_frenet_paths(c_speed: f64, c_d: f64, c_d_d: f64, c_d_dd: f64, s0: f64) -
             }
 
             // Longitudinal motion (velocity keeping - quartic polynomial)
-            for tv in [TARGET_SPEED - D_T_S * N_S_SAMPLE as f64, TARGET_SPEED, TARGET_SPEED + D_T_S * N_S_SAMPLE as f64] {
+            for tv in [
+                TARGET_SPEED - D_T_S * N_S_SAMPLE as f64,
+                TARGET_SPEED,
+                TARGET_SPEED + D_T_S * N_S_SAMPLE as f64,
+            ] {
                 let mut tfp = fp.clone();
 
                 let lon_qp = QuarticPolynomial::new(s0, c_speed, 0.0, tv, 0.0, ti);
@@ -467,7 +486,9 @@ fn frenet_optimal_planning(
     check_paths(&mut fplist, ob);
 
     // Find minimum cost path
-    fplist.into_iter().min_by(|a, b| a.cf.partial_cmp(&b.cf).unwrap())
+    fplist
+        .into_iter()
+        .min_by(|a, b| a.cf.partial_cmp(&b.cf).unwrap())
 }
 
 fn main() {
@@ -544,9 +565,27 @@ fn main() {
                     .set_y_label("y [m]", &[])
                     .set_aspect_ratio(gnuplot::AutoOption::Fix(1.0))
                     .lines(&ref_x, &ref_y, &[Caption("Reference"), Color("gray")])
-                    .points(&ob_x, &ob_y, &[Caption("Obstacles"), Color("black"), PointSymbol('O'), PointSize(2.0)])
+                    .points(
+                        &ob_x,
+                        &ob_y,
+                        &[
+                            Caption("Obstacles"),
+                            Color("black"),
+                            PointSymbol('O'),
+                            PointSize(2.0),
+                        ],
+                    )
                     .lines(&fp.x, &fp.y, &[Caption("Trajectory"), Color("green")])
-                    .points(&[fp.x[0]], &[fp.y[0]], &[Caption("Vehicle"), Color("red"), PointSymbol('*'), PointSize(3.0)]);
+                    .points(
+                        &[fp.x[0]],
+                        &[fp.y[0]],
+                        &[
+                            Caption("Vehicle"),
+                            Color("red"),
+                            PointSymbol('*'),
+                            PointSize(3.0),
+                        ],
+                    );
 
                 fig.show_and_keep_running().unwrap();
             }
@@ -571,9 +610,23 @@ fn main() {
         .set_x_label("x [m]", &[])
         .set_y_label("y [m]", &[])
         .lines(&ref_x, &ref_y, &[Caption("Reference"), Color("gray")])
-        .points(&ob_x, &ob_y, &[Caption("Obstacles"), Color("black"), PointSymbol('O'), PointSize(2.0)])
+        .points(
+            &ob_x,
+            &ob_y,
+            &[
+                Caption("Obstacles"),
+                Color("black"),
+                PointSymbol('O'),
+                PointSize(2.0),
+            ],
+        )
         .lines(&h_x, &h_y, &[Caption("Trajectory"), Color("green")]);
 
-    fig.save_to_svg("./img/path_planning/frenet_optimal_trajectory.svg", 640, 480).unwrap();
+    fig.save_to_svg(
+        "./img/path_planning/frenet_optimal_trajectory.svg",
+        640,
+        480,
+    )
+    .unwrap();
     println!("Plot saved to ./img/path_planning/frenet_optimal_trajectory.svg");
 }

--- a/src/path_planning/frenet_optimal_trajectory.rs
+++ b/src/path_planning/frenet_optimal_trajectory.rs
@@ -1,10 +1,11 @@
+#![allow(dead_code)]
+
 // Frenet Optimal Trajectory planning
 // author: Atsushi Sakai (@Atsushi_twi)
 //         Ryohei Sasaki (@rsasaki0109)
 //         Rust port
 
 use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
-use std::f64::consts::PI;
 
 // Parameters
 const MAX_SPEED: f64 = 50.0 / 3.6; // maximum speed [m/s]
@@ -229,7 +230,7 @@ struct CubicSpline1D {
 impl CubicSpline1D {
     fn new(x: &[f64], y: &[f64]) -> Self {
         let n = x.len();
-        let mut a = y.to_vec();
+        let a = y.to_vec();
         let mut b = vec![0.0; n];
         let mut c = vec![0.0; n];
         let mut d = vec![0.0; n];
@@ -365,7 +366,7 @@ fn calc_frenet_paths(c_speed: f64, c_d: f64, c_d_d: f64, c_d_dd: f64, s0: f64) -
 
                 let lon_qp = QuarticPolynomial::new(s0, c_speed, 0.0, tv, 0.0, ti);
 
-                for (i, &t) in tfp.t.iter().enumerate() {
+                for (_i, &t) in tfp.t.iter().enumerate() {
                     tfp.s.push(lon_qp.calc_point(t));
                     tfp.s_d.push(lon_qp.calc_first_derivative(t));
                     tfp.s_dd.push(lon_qp.calc_second_derivative(t));
@@ -577,8 +578,8 @@ fn main() {
                     )
                     .lines(&fp.x, &fp.y, &[Caption("Trajectory"), Color("green")])
                     .points(
-                        &[fp.x[0]],
-                        &[fp.y[0]],
+                        [fp.x[0]],
+                        [fp.y[0]],
                         &[
                             Caption("Vehicle"),
                             Color("red"),

--- a/src/path_planning/frenet_optimal_trajectory.rs
+++ b/src/path_planning/frenet_optimal_trajectory.rs
@@ -366,7 +366,7 @@ fn calc_frenet_paths(c_speed: f64, c_d: f64, c_d_d: f64, c_d_dd: f64, s0: f64) -
 
                 let lon_qp = QuarticPolynomial::new(s0, c_speed, 0.0, tv, 0.0, ti);
 
-                for (_i, &t) in tfp.t.iter().enumerate() {
+                for &t in &tfp.t {
                     tfp.s.push(lon_qp.calc_point(t));
                     tfp.s_d.push(lon_qp.calc_first_derivative(t));
                     tfp.s_dd.push(lon_qp.calc_second_derivative(t));
@@ -396,7 +396,7 @@ fn calc_frenet_paths(c_speed: f64, c_d: f64, c_d_d: f64, c_d_dd: f64, s0: f64) -
 }
 
 /// Calculate global positions from Frenet paths
-fn calc_global_paths(fplist: &mut Vec<FrenetPath>, csp: &CubicSpline2D) {
+fn calc_global_paths(fplist: &mut [FrenetPath], csp: &CubicSpline2D) {
     for fp in fplist.iter_mut() {
         for i in 0..fp.s.len() {
             let s = fp.s[i];

--- a/src/path_planning/informed_rrt_star.rs
+++ b/src/path_planning/informed_rrt_star.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::needless_borrows_for_generic_args)]
+
 use gnuplot::{AxesCommon, Caption, Color, Figure};
 use rand::Rng;
 use std::f64::consts::PI;
@@ -106,20 +108,20 @@ impl InformedRRTStar {
                 self.node_list.push(new_node);
                 self.rewire(new_node_index, &near_inds);
 
-                if self.is_near_goal(&self.node_list[new_node_index]) {
-                    if self.check_segment_collision(
+                if self.is_near_goal(&self.node_list[new_node_index])
+                    && self.check_segment_collision(
                         self.node_list[new_node_index].x,
                         self.node_list[new_node_index].y,
                         self.goal.x,
                         self.goal.y,
-                    ) {
-                        let temp_path = self.get_final_course(new_node_index);
-                        let temp_path_len = self.get_path_len(&temp_path);
-                        if temp_path_len < c_best {
-                            path = Some(temp_path);
-                            c_best = temp_path_len;
-                            println!("Found better path with cost: {:.2}", c_best);
-                        }
+                    )
+                {
+                    let temp_path = self.get_final_course(new_node_index);
+                    let temp_path_len = self.get_path_len(&temp_path);
+                    if temp_path_len < c_best {
+                        path = Some(temp_path);
+                        c_best = temp_path_len;
+                        println!("Found better path with cost: {:.2}", c_best);
                     }
                 }
             }
@@ -338,7 +340,7 @@ impl InformedRRTStar {
         for node in &self.node_list {
             if let Some(parent_index) = node.parent {
                 let parent = &self.node_list[parent_index];
-                axes.lines(&[parent.x, node.x], &[parent.y, node.y], &[Color("blue")]);
+                axes.lines([parent.x, node.x], [parent.y, node.y], &[Color("blue")]);
             }
         }
 

--- a/src/path_planning/informed_rrt_star.rs
+++ b/src/path_planning/informed_rrt_star.rs
@@ -1,6 +1,6 @@
-use std::f64::consts::PI;
+use gnuplot::{AxesCommon, Caption, Color, Figure};
 use rand::Rng;
-use gnuplot::{Figure, Caption, Color, AxesCommon};
+use std::f64::consts::PI;
 
 #[derive(Clone, Debug)]
 pub struct Node {
@@ -62,7 +62,8 @@ impl InformedRRTStar {
         let mut path = None;
 
         // Computing the sampling space
-        let c_min = ((self.start.x - self.goal.x).powi(2) + (self.start.y - self.goal.y).powi(2)).sqrt();
+        let c_min =
+            ((self.start.x - self.goal.x).powi(2) + (self.start.y - self.goal.y).powi(2)).sqrt();
         let x_center = [
             (self.start.x + self.goal.x) / 2.0,
             (self.start.y + self.goal.y) / 2.0,
@@ -78,10 +79,7 @@ impl InformedRRTStar {
         // Rotation matrix for ellipse
         let cos_theta = e_theta.cos();
         let sin_theta = e_theta.sin();
-        let rotation_matrix = [
-            [cos_theta, -sin_theta],
-            [sin_theta, cos_theta],
-        ];
+        let rotation_matrix = [[cos_theta, -sin_theta], [sin_theta, cos_theta]];
 
         for i in 0..self.max_iter {
             if i % 100 == 0 {
@@ -174,22 +172,25 @@ impl InformedRRTStar {
         near_inds
     }
 
-    fn informed_sample(&self, c_max: f64, c_min: f64, x_center: &[f64; 2], rotation_matrix: &[[f64; 2]; 2]) -> [f64; 2] {
+    fn informed_sample(
+        &self,
+        c_max: f64,
+        c_min: f64,
+        x_center: &[f64; 2],
+        rotation_matrix: &[[f64; 2]; 2],
+    ) -> [f64; 2] {
         if c_max < f64::INFINITY {
-            let r = [
-                c_max / 2.0,
-                (c_max * c_max - c_min * c_min).sqrt() / 2.0,
-            ];
+            let r = [c_max / 2.0, (c_max * c_max - c_min * c_min).sqrt() / 2.0];
 
             let x_ball = self.sample_unit_ball();
-            
+
             // Transform unit ball sample
             let scaled = [r[0] * x_ball[0], r[1] * x_ball[1]];
             let rotated = [
                 rotation_matrix[0][0] * scaled[0] + rotation_matrix[0][1] * scaled[1],
                 rotation_matrix[1][0] * scaled[0] + rotation_matrix[1][1] * scaled[1],
             ];
-            
+
             [rotated[0] + x_center[0], rotated[1] + x_center[1]]
         } else {
             self.sample_free_space()
@@ -203,10 +204,7 @@ impl InformedRRTStar {
 
         let (a, b) = if b < a { (b, a) } else { (a, b) };
 
-        let sample = (
-            b * (2.0 * PI * a / b).cos(),
-            b * (2.0 * PI * a / b).sin(),
-        );
+        let sample = (b * (2.0 * PI * a / b).cos(), b * (2.0 * PI * a / b).sin());
         [sample.0, sample.1]
     }
 
@@ -270,7 +268,8 @@ impl InformedRRTStar {
             let near_node = &self.node_list[i];
             let new_node = &self.node_list[new_node_index];
 
-            let d = ((near_node.x - new_node.x).powi(2) + (near_node.y - new_node.y).powi(2)).sqrt();
+            let d =
+                ((near_node.x - new_node.x).powi(2) + (near_node.y - new_node.y).powi(2)).sqrt();
             let s_cost = new_node.cost + d;
 
             if near_node.cost > s_cost {
@@ -289,7 +288,9 @@ impl InformedRRTStar {
         }
 
         let l2 = (w[0] - v[0]).powi(2) + (w[1] - v[1]).powi(2);
-        let t = (((p[0] - v[0]) * (w[0] - v[0]) + (p[1] - v[1]) * (w[1] - v[1])) / l2).max(0.0).min(1.0);
+        let t = (((p[0] - v[0]) * (w[0] - v[0]) + (p[1] - v[1]) * (w[1] - v[1])) / l2)
+            .max(0.0)
+            .min(1.0);
         let projection = [v[0] + t * (w[0] - v[0]), v[1] + t * (w[1] - v[1])];
         (p[0] - projection[0]).powi(2) + (p[1] - projection[1]).powi(2)
     }
@@ -345,12 +346,24 @@ impl InformedRRTStar {
         if !path.is_empty() {
             let path_x: Vec<f64> = path.iter().map(|node| node[0]).collect();
             let path_y: Vec<f64> = path.iter().map(|node| node[1]).collect();
-            axes.lines(&path_x, &path_y, &[Caption("Informed RRT* Path"), Color("red")]);
+            axes.lines(
+                &path_x,
+                &path_y,
+                &[Caption("Informed RRT* Path"), Color("red")],
+            );
         }
 
         // Plot start and goal
-        axes.points(&[self.start.x], &[self.start.y], &[Caption("Start"), Color("green")]);
-        axes.points(&[self.goal.x], &[self.goal.y], &[Caption("Goal"), Color("blue")]);
+        axes.points(
+            &[self.start.x],
+            &[self.start.y],
+            &[Caption("Start"), Color("green")],
+        );
+        axes.points(
+            &[self.goal.x],
+            &[self.goal.y],
+            &[Caption("Goal"), Color("blue")],
+        );
 
         axes.set_title("Informed RRT* Path Planning", &[])
             .set_x_label("X [m]", &[])
@@ -380,13 +393,13 @@ fn main() {
     ];
 
     let mut rrt = InformedRRTStar::new(
-        (0.0, 0.0),    // start
-        (5.0, 10.0),   // goal
+        (0.0, 0.0),  // start
+        (5.0, 10.0), // goal
         obstacle_list,
-        (-2.0, 15.0),  // rand_area
-        0.5,           // expand_dis
-        10,            // goal_sample_rate
-        300,           // max_iter
+        (-2.0, 15.0), // rand_area
+        0.5,          // expand_dis
+        10,           // goal_sample_rate
+        300,          // max_iter
     );
 
     if let Some(path) = rrt.planning() {

--- a/src/path_planning/informed_rrt_star.rs
+++ b/src/path_planning/informed_rrt_star.rs
@@ -290,9 +290,8 @@ impl InformedRRTStar {
         }
 
         let l2 = (w[0] - v[0]).powi(2) + (w[1] - v[1]).powi(2);
-        let t = (((p[0] - v[0]) * (w[0] - v[0]) + (p[1] - v[1]) * (w[1] - v[1])) / l2)
-            .max(0.0)
-            .min(1.0);
+        let t =
+            (((p[0] - v[0]) * (w[0] - v[0]) + (p[1] - v[1]) * (w[1] - v[1])) / l2).clamp(0.0, 1.0);
         let projection = [v[0] + t * (w[0] - v[0]), v[1] + t * (w[1] - v[1])];
         (p[0] - projection[0]).powi(2) + (p[1] - projection[1]).powi(2)
     }

--- a/src/path_planning/jps.rs
+++ b/src/path_planning/jps.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::collapsible_if)]
+
 //! Jump Point Search (JPS) path planning algorithm
 //!
 //! JPS is an optimization of A* for uniform-cost grids that reduces the
@@ -63,7 +65,6 @@ struct PriorityNode {
     cost: f64,
     priority: f64,
     index: usize,
-    direction: Option<Direction>,
 }
 
 impl Eq for PriorityNode {}
@@ -461,7 +462,6 @@ impl PathPlanner for JPSPlanner {
             cost: 0.0,
             priority: self.calc_heuristic(start_x, start_y, goal_x, goal_y),
             index: start_index,
-            direction: None,
         });
 
         while let Some(current) = open_set.pop() {
@@ -509,7 +509,6 @@ impl PathPlanner for JPSPlanner {
                     cost: new_cost,
                     priority,
                     index: new_index,
-                    direction: Some(dir),
                 });
             }
         }
@@ -584,7 +583,7 @@ mod tests {
         assert!(result.is_ok());
 
         let path = result.unwrap();
-        assert!(path.len() > 0);
+        assert!(!path.is_empty());
 
         // Check that path starts near start and ends near goal
         let first = &path.points[0];
@@ -607,7 +606,7 @@ mod tests {
         assert!(result.is_ok());
 
         let path = result.unwrap();
-        assert!(path.len() > 0);
+        assert!(!path.is_empty());
     }
 
     #[test]
@@ -619,7 +618,7 @@ mod tests {
         assert!(result.is_some());
 
         let (rx, ry) = result.unwrap();
-        assert!(rx.len() > 0);
+        assert!(!rx.is_empty());
         assert_eq!(rx.len(), ry.len());
     }
 

--- a/src/path_planning/jps.rs
+++ b/src/path_planning/jps.rs
@@ -169,14 +169,7 @@ impl JPSPlanner {
     }
 
     /// Jump in a given direction from (x, y) until we find a jump point or hit an obstacle
-    fn jump(
-        &self,
-        x: i32,
-        y: i32,
-        dir: Direction,
-        goal_x: i32,
-        goal_y: i32,
-    ) -> Option<(i32, i32)> {
+    fn jump(&self, x: i32, y: i32, dir: Direction, goal_x: i32, goal_y: i32) -> Option<(i32, i32)> {
         let nx = x + dir.dx;
         let ny = y + dir.dy;
 
@@ -694,6 +687,10 @@ mod tests {
         assert!(path.len() >= 2, "Path should have at least start and goal");
         // Verify path is roughly diagonal (total length should be close to sqrt(2) * 16 ≈ 22.6)
         let total_len = path.total_length();
-        assert!(total_len < 30.0, "Path should be efficient, got length {}", total_len);
+        assert!(
+            total_len < 30.0,
+            "Path should be efficient, got length {}",
+            total_len
+        );
     }
 }

--- a/src/path_planning/mod.rs
+++ b/src/path_planning/mod.rs
@@ -9,22 +9,22 @@
 
 // Grid-based planners
 pub mod a_star;
-pub mod dijkstra;
 pub mod d_star_lite;
+pub mod dijkstra;
 pub mod jps;
 pub mod theta_star;
 
 // Sampling-based planners
-pub mod rrt;
-pub mod rrt_star;
 pub mod informed_rrt_star;
 pub mod prm;
+pub mod rrt;
+pub mod rrt_star;
 pub mod voronoi_road_map;
 
 // Other planners
 pub mod dwa;
-pub mod potential_field;
 pub mod frenet_optimal_trajectory;
+pub mod potential_field;
 
 // State Lattice Planner
 pub mod state_lattice;
@@ -38,9 +38,9 @@ pub mod quintic_polynomials;
 pub mod reeds_shepp_path;
 
 // Re-exports for convenience
-pub use a_star::{AStarPlanner, AStarConfig};
-pub use jps::{JPSPlanner, JPSConfig};
-pub use theta_star::{ThetaStarPlanner, ThetaStarConfig};
-pub use rrt::{RRTPlanner, RRTConfig, RRTNode, CircleObstacle, AreaBounds};
-pub use dwa::{DWAPlanner, DWAConfig, DWAState, DWAControl, Trajectory as DWATrajectory};
+pub use a_star::{AStarConfig, AStarPlanner};
+pub use dwa::{DWAConfig, DWAControl, DWAPlanner, DWAState, Trajectory as DWATrajectory};
+pub use jps::{JPSConfig, JPSPlanner};
+pub use rrt::{AreaBounds, CircleObstacle, RRTConfig, RRTNode, RRTPlanner};
 pub use state_lattice::{StateLattice, StateLatticeConfig};
+pub use theta_star::{ThetaStarConfig, ThetaStarPlanner};

--- a/src/path_planning/potential_field.rs
+++ b/src/path_planning/potential_field.rs
@@ -1,11 +1,11 @@
+use gnuplot::{AxesCommon, Caption, Color, Figure};
 use std::collections::VecDeque;
-use gnuplot::{Figure, Caption, Color, AxesCommon};
 
 // Parameters
-const KP: f64 = 5.0;  // attractive potential gain
-const ETA: f64 = 100.0;  // repulsive potential gain
-const AREA_WIDTH: f64 = 30.0;  // potential area width [m]
-const OSCILLATIONS_DETECTION_LENGTH: usize = 3;  // number of previous positions used to check oscillations
+const KP: f64 = 5.0; // attractive potential gain
+const ETA: f64 = 100.0; // repulsive potential gain
+const AREA_WIDTH: f64 = 30.0; // potential area width [m]
+const OSCILLATIONS_DETECTION_LENGTH: usize = 3; // number of previous positions used to check oscillations
 const SHOW_ANIMATION: bool = true;
 
 pub struct PotentialFieldPlanner {
@@ -21,7 +21,15 @@ impl PotentialFieldPlanner {
         }
     }
 
-    pub fn planning(&self, sx: f64, sy: f64, gx: f64, gy: f64, ox: &[f64], oy: &[f64]) -> Option<(Vec<f64>, Vec<f64>)> {
+    pub fn planning(
+        &self,
+        sx: f64,
+        sy: f64,
+        gx: f64,
+        gy: f64,
+        ox: &[f64],
+        oy: &[f64],
+    ) -> Option<(Vec<f64>, Vec<f64>)> {
         // Calculate potential field
         let (pmap, minx, miny) = self.calc_potential_field(gx, gy, ox, oy, sx, sy);
 
@@ -47,9 +55,13 @@ impl PotentialFieldPlanner {
             for motion_step in &motion {
                 let inx = ix + motion_step[0];
                 let iny = iy + motion_step[1];
-                
-                let p = if inx >= pmap.len() as i32 || iny >= pmap[0].len() as i32 || inx < 0 || iny < 0 {
-                    f64::INFINITY  // outside area
+
+                let p = if inx >= pmap.len() as i32
+                    || iny >= pmap[0].len() as i32
+                    || inx < 0
+                    || iny < 0
+                {
+                    f64::INFINITY // outside area
                 } else {
                     pmap[inx as usize][iny as usize]
                 };
@@ -79,12 +91,32 @@ impl PotentialFieldPlanner {
         Some((rx, ry))
     }
 
-    fn calc_potential_field(&self, gx: f64, gy: f64, ox: &[f64], oy: &[f64], sx: f64, sy: f64) -> (Vec<Vec<f64>>, f64, f64) {
-        let minx = [ox.iter().fold(f64::INFINITY, |a, &b| a.min(b)), sx, gx].iter().fold(f64::INFINITY, |a, &b| a.min(b)) - AREA_WIDTH / 2.0;
-        let miny = [oy.iter().fold(f64::INFINITY, |a, &b| a.min(b)), sy, gy].iter().fold(f64::INFINITY, |a, &b| a.min(b)) - AREA_WIDTH / 2.0;
-        let maxx = [ox.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)), sx, gx].iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)) + AREA_WIDTH / 2.0;
-        let maxy = [oy.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)), sy, gy].iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)) + AREA_WIDTH / 2.0;
-        
+    fn calc_potential_field(
+        &self,
+        gx: f64,
+        gy: f64,
+        ox: &[f64],
+        oy: &[f64],
+        sx: f64,
+        sy: f64,
+    ) -> (Vec<Vec<f64>>, f64, f64) {
+        let minx = [ox.iter().fold(f64::INFINITY, |a, &b| a.min(b)), sx, gx]
+            .iter()
+            .fold(f64::INFINITY, |a, &b| a.min(b))
+            - AREA_WIDTH / 2.0;
+        let miny = [oy.iter().fold(f64::INFINITY, |a, &b| a.min(b)), sy, gy]
+            .iter()
+            .fold(f64::INFINITY, |a, &b| a.min(b))
+            - AREA_WIDTH / 2.0;
+        let maxx = [ox.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)), sx, gx]
+            .iter()
+            .fold(f64::NEG_INFINITY, |a, &b| a.max(b))
+            + AREA_WIDTH / 2.0;
+        let maxy = [oy.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)), sy, gy]
+            .iter()
+            .fold(f64::NEG_INFINITY, |a, &b| a.max(b))
+            + AREA_WIDTH / 2.0;
+
         let xw = ((maxx - minx) / self.resolution).round() as usize;
         let yw = ((maxy - miny) / self.resolution).round() as usize;
 
@@ -146,7 +178,12 @@ impl PotentialFieldPlanner {
         ]
     }
 
-    fn oscillations_detection(&self, previous_ids: &mut VecDeque<(i32, i32)>, ix: i32, iy: i32) -> bool {
+    fn oscillations_detection(
+        &self,
+        previous_ids: &mut VecDeque<(i32, i32)>,
+        ix: i32,
+        iy: i32,
+    ) -> bool {
         previous_ids.push_back((ix, iy));
 
         if previous_ids.len() > OSCILLATIONS_DETECTION_LENGTH {
@@ -164,7 +201,17 @@ impl PotentialFieldPlanner {
         false
     }
 
-    pub fn visualize_path(&self, rx: &[f64], ry: &[f64], sx: f64, sy: f64, gx: f64, gy: f64, ox: &[f64], oy: &[f64]) {
+    pub fn visualize_path(
+        &self,
+        rx: &[f64],
+        ry: &[f64],
+        sx: f64,
+        sy: f64,
+        gx: f64,
+        gy: f64,
+        ox: &[f64],
+        oy: &[f64],
+    ) {
         if !SHOW_ANIMATION {
             return;
         }
@@ -199,7 +246,7 @@ impl PotentialFieldPlanner {
 fn main() {
     println!("Potential Field path planning start!!");
 
-    let sx = 0.0;  // start x position [m]
+    let sx = 0.0; // start x position [m]
     let sy = 10.0; // start y position [m]
     let gx = 30.0; // goal x position [m]
     let gy = 30.0; // goal y position [m]

--- a/src/path_planning/potential_field.rs
+++ b/src/path_planning/potential_field.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, clippy::too_many_arguments)]
 
 use gnuplot::{AxesCommon, Caption, Color, Figure};
 use std::collections::VecDeque;
@@ -127,12 +127,12 @@ impl PotentialFieldPlanner {
 
         for (ix, column) in pmap.iter_mut().enumerate().take(xw) {
             let x = ix as f64 * self.resolution + minx;
-            for iy in 0..yw {
+            for (iy, value) in column.iter_mut().enumerate().take(yw) {
                 let y = iy as f64 * self.resolution + miny;
                 let ug = self.calc_attractive_potential(x, y, gx, gy);
                 let uo = self.calc_repulsive_potential(x, y, ox, oy);
                 let uf = ug + uo;
-                column[iy] = uf;
+                *value = uf;
             }
         }
 

--- a/src/path_planning/potential_field.rs
+++ b/src/path_planning/potential_field.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use gnuplot::{AxesCommon, Caption, Color, Figure};
 use std::collections::VecDeque;
 
@@ -123,14 +125,14 @@ impl PotentialFieldPlanner {
         // Calculate each potential
         let mut pmap = vec![vec![0.0; yw]; xw];
 
-        for ix in 0..xw {
+        for (ix, column) in pmap.iter_mut().enumerate().take(xw) {
             let x = ix as f64 * self.resolution + minx;
             for iy in 0..yw {
                 let y = iy as f64 * self.resolution + miny;
                 let ug = self.calc_attractive_potential(x, y, gx, gy);
                 let uo = self.calc_repulsive_potential(x, y, ox, oy);
                 let uf = ug + uo;
-                pmap[ix][iy] = uf;
+                column[iy] = uf;
             }
         }
 
@@ -217,7 +219,7 @@ impl PotentialFieldPlanner {
         }
 
         let mut fg = Figure::new();
-        let mut axes = fg.axes2d();
+        let axes = fg.axes2d();
 
         // Plot obstacles
         axes.points(ox, oy, &[Caption("Obstacles"), Color("black")]);
@@ -226,8 +228,8 @@ impl PotentialFieldPlanner {
         axes.lines(rx, ry, &[Caption("Potential Field Path"), Color("red")]);
 
         // Plot start and goal
-        axes.points(&[sx], &[sy], &[Caption("Start"), Color("green")]);
-        axes.points(&[gx], &[gy], &[Caption("Goal"), Color("blue")]);
+        axes.points([sx], [sy], &[Caption("Start"), Color("green")]);
+        axes.points([gx], [gy], &[Caption("Goal"), Color("blue")]);
 
         axes.set_title("Potential Field Path Planning", &[])
             .set_x_label("X [m]", &[])

--- a/src/path_planning/prm.rs
+++ b/src/path_planning/prm.rs
@@ -3,10 +3,10 @@
 //         Ryohei Sasaki (@rsasaki0109)
 //         Rust port
 
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
 use rand::Rng;
-use std::collections::{BinaryHeap, HashMap};
 use std::cmp::Ordering;
-use gnuplot::{Figure, Caption, Color, AxesCommon, PointSymbol, PointSize};
+use std::collections::{BinaryHeap, HashMap};
 
 // Parameters
 const N_SAMPLE: usize = 500; // number of sample points
@@ -54,7 +54,10 @@ impl Eq for QueueItem {}
 impl Ord for QueueItem {
     fn cmp(&self, other: &Self) -> Ordering {
         // Reverse for min-heap
-        other.cost.partial_cmp(&self.cost).unwrap_or(Ordering::Equal)
+        other
+            .cost
+            .partial_cmp(&self.cost)
+            .unwrap_or(Ordering::Equal)
     }
 }
 
@@ -76,7 +79,8 @@ impl KDTree {
 
     /// Find k nearest neighbors
     fn query_knn(&self, x: f64, y: f64, k: usize) -> Vec<(usize, f64)> {
-        let mut distances: Vec<(usize, f64)> = self.points
+        let mut distances: Vec<(usize, f64)> = self
+            .points
             .iter()
             .enumerate()
             .map(|(i, (px, py))| {
@@ -142,18 +146,18 @@ impl PRMPlanner {
 
         // Sample points
         let (sample_x, sample_y) = Self::sample_points(
-            start, goal,
-            min_x, max_x, min_y, max_y,
+            start,
+            goal,
+            min_x,
+            max_x,
+            min_y,
+            max_y,
             robot_radius,
             &obstacle_tree,
         );
 
         // Generate road map
-        let road_map = Self::generate_road_map(
-            &sample_x, &sample_y,
-            robot_radius,
-            &obstacle_tree,
-        );
+        let road_map = Self::generate_road_map(&sample_x, &sample_y, robot_radius, &obstacle_tree);
 
         PRMPlanner {
             sample_x,
@@ -207,7 +211,11 @@ impl PRMPlanner {
         obstacle_tree: &KDTree,
     ) -> Vec<Vec<usize>> {
         let sample_tree = KDTree::new(
-            sample_x.iter().zip(sample_y.iter()).map(|(&x, &y)| (x, y)).collect()
+            sample_x
+                .iter()
+                .zip(sample_y.iter())
+                .map(|(&x, &y)| (x, y))
+                .collect(),
         );
 
         let mut road_map: Vec<Vec<usize>> = vec![Vec::new(); sample_x.len()];
@@ -227,12 +235,8 @@ impl PRMPlanner {
                 }
 
                 // Check collision
-                if !Self::is_collision(
-                    x, y,
-                    sample_x[j], sample_y[j],
-                    robot_radius,
-                    obstacle_tree,
-                ) {
+                if !Self::is_collision(x, y, sample_x[j], sample_y[j], robot_radius, obstacle_tree)
+                {
                     road_map[i].push(j);
                 }
             }
@@ -243,8 +247,10 @@ impl PRMPlanner {
 
     /// Check if path between two points collides with obstacles
     fn is_collision(
-        x1: f64, y1: f64,
-        x2: f64, y2: f64,
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
         robot_radius: f64,
         obstacle_tree: &KDTree,
     ) -> bool {
@@ -279,7 +285,8 @@ impl PRMPlanner {
         let start_idx = n - 2;
         let goal_idx = n - 1;
 
-        let mut nodes: Vec<Node> = self.sample_x
+        let mut nodes: Vec<Node> = self
+            .sample_x
             .iter()
             .zip(self.sample_y.iter())
             .map(|(&x, &y)| Node::new(x, y))
@@ -288,7 +295,10 @@ impl PRMPlanner {
         nodes[start_idx].cost = 0.0;
 
         let mut open_set = BinaryHeap::new();
-        open_set.push(QueueItem { cost: 0.0, index: start_idx });
+        open_set.push(QueueItem {
+            cost: 0.0,
+            index: start_idx,
+        });
 
         let mut closed_set: HashMap<usize, bool> = HashMap::new();
 
@@ -446,10 +456,46 @@ fn main() {
     axes.lines(&edge_x, &edge_y, &[Color("#D3D3D3")]);
 
     // Draw obstacles and samples
-    axes.points(&ox, &oy, &[Caption("Obstacles"), Color("black"), PointSymbol('.'), PointSize(0.5)])
-        .points(sample_x, sample_y, &[Caption("Samples"), Color("gray"), PointSymbol('.'), PointSize(1.0)])
-        .points(&[start.0], &[start.1], &[Caption("Start"), Color("blue"), PointSymbol('O'), PointSize(2.0)])
-        .points(&[goal.0], &[goal.1], &[Caption("Goal"), Color("red"), PointSymbol('O'), PointSize(2.0)]);
+    axes.points(
+        &ox,
+        &oy,
+        &[
+            Caption("Obstacles"),
+            Color("black"),
+            PointSymbol('.'),
+            PointSize(0.5),
+        ],
+    )
+    .points(
+        sample_x,
+        sample_y,
+        &[
+            Caption("Samples"),
+            Color("gray"),
+            PointSymbol('.'),
+            PointSize(1.0),
+        ],
+    )
+    .points(
+        &[start.0],
+        &[start.1],
+        &[
+            Caption("Start"),
+            Color("blue"),
+            PointSymbol('O'),
+            PointSize(2.0),
+        ],
+    )
+    .points(
+        &[goal.0],
+        &[goal.1],
+        &[
+            Caption("Goal"),
+            Color("red"),
+            PointSymbol('O'),
+            PointSize(2.0),
+        ],
+    );
 
     // Draw path
     if let Some((path_x, path_y)) = &path {
@@ -463,7 +509,8 @@ fn main() {
         fig.show_and_keep_running().unwrap();
     }
 
-    fig.save_to_svg("./img/path_planning/prm.svg", 640, 480).unwrap();
+    fig.save_to_svg("./img/path_planning/prm.svg", 640, 480)
+        .unwrap();
     println!("Plot saved to ./img/path_planning/prm.svg");
 
     println!("Done!");

--- a/src/path_planning/prm.rs
+++ b/src/path_planning/prm.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::too_many_arguments)]
+
 // Probabilistic Road-Map (PRM) path planning
 // author: Atsushi Sakai (@Atsushi_twi)
 //         Ryohei Sasaki (@rsasaki0109)
@@ -94,22 +96,6 @@ impl KDTree {
         distances
     }
 
-    /// Find all points within radius
-    fn query_radius(&self, x: f64, y: f64, radius: f64) -> Vec<(usize, f64)> {
-        self.points
-            .iter()
-            .enumerate()
-            .filter_map(|(i, (px, py))| {
-                let d = ((x - px).powi(2) + (y - py).powi(2)).sqrt();
-                if d <= radius {
-                    Some((i, d))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
     /// Get minimum distance to any point
     fn min_distance(&self, x: f64, y: f64) -> f64 {
         self.points
@@ -124,7 +110,6 @@ pub struct PRMPlanner {
     sample_x: Vec<f64>,
     sample_y: Vec<f64>,
     road_map: Vec<Vec<usize>>,
-    obstacle_tree: KDTree,
 }
 
 impl PRMPlanner {
@@ -163,7 +148,6 @@ impl PRMPlanner {
             sample_x,
             sample_y,
             road_map,
-            obstacle_tree,
         }
     }
 
@@ -477,8 +461,8 @@ fn main() {
         ],
     )
     .points(
-        &[start.0],
-        &[start.1],
+        [start.0],
+        [start.1],
         &[
             Caption("Start"),
             Color("blue"),
@@ -487,8 +471,8 @@ fn main() {
         ],
     )
     .points(
-        &[goal.0],
-        &[goal.1],
+        [goal.0],
+        [goal.1],
         &[
             Caption("Goal"),
             Color("red"),

--- a/src/path_planning/quintic_polynomials.rs
+++ b/src/path_planning/quintic_polynomials.rs
@@ -1,9 +1,9 @@
-use gnuplot::{Figure, Caption, Color, AxesCommon};
+use gnuplot::{AxesCommon, Caption, Color, Figure};
 use std::f64::consts::PI;
 
 // Parameters
 const MAX_T: f64 = 100.0; // maximum time to the goal [s]
-const MIN_T: f64 = 5.0;   // minimum time to the goal [s]
+const MIN_T: f64 = 5.0; // minimum time to the goal [s]
 const SHOW_ANIMATION: bool = true;
 
 #[derive(Debug, Clone)]
@@ -46,7 +46,7 @@ impl QuinticPolynomial {
 
         // Solve using Cramer's rule
         let det_a = Self::determinant_3x3(&a_matrix);
-        
+
         let mut a3_matrix = a_matrix;
         a3_matrix[0][0] = b[0];
         a3_matrix[1][0] = b[1];
@@ -65,7 +65,14 @@ impl QuinticPolynomial {
         a5_matrix[2][2] = b[2];
         let a5 = Self::determinant_3x3(&a5_matrix) / det_a;
 
-        QuinticPolynomial { a0, a1, a2, a3, a4, a5 }
+        QuinticPolynomial {
+            a0,
+            a1,
+            a2,
+            a3,
+            a4,
+            a5,
+        }
     }
 
     fn determinant_3x3(matrix: &[[f64; 3]; 3]) -> f64 {
@@ -75,18 +82,24 @@ impl QuinticPolynomial {
     }
 
     pub fn calc_point(&self, t: f64) -> f64 {
-        self.a0 + self.a1 * t + self.a2 * t.powi(2) + 
-        self.a3 * t.powi(3) + self.a4 * t.powi(4) + self.a5 * t.powi(5)
+        self.a0
+            + self.a1 * t
+            + self.a2 * t.powi(2)
+            + self.a3 * t.powi(3)
+            + self.a4 * t.powi(4)
+            + self.a5 * t.powi(5)
     }
 
     pub fn calc_first_derivative(&self, t: f64) -> f64 {
-        self.a1 + 2.0 * self.a2 * t + 
-        3.0 * self.a3 * t.powi(2) + 4.0 * self.a4 * t.powi(3) + 5.0 * self.a5 * t.powi(4)
+        self.a1
+            + 2.0 * self.a2 * t
+            + 3.0 * self.a3 * t.powi(2)
+            + 4.0 * self.a4 * t.powi(3)
+            + 5.0 * self.a5 * t.powi(4)
     }
 
     pub fn calc_second_derivative(&self, t: f64) -> f64 {
-        2.0 * self.a2 + 6.0 * self.a3 * t + 
-        12.0 * self.a4 * t.powi(2) + 20.0 * self.a5 * t.powi(3)
+        2.0 * self.a2 + 6.0 * self.a3 * t + 12.0 * self.a4 * t.powi(2) + 20.0 * self.a5 * t.powi(3)
     }
 
     pub fn calc_third_derivative(&self, t: f64) -> f64 {
@@ -120,9 +133,19 @@ impl QuinticPolynomialsPlanner {
 
     pub fn planning(
         &mut self,
-        sx: f64, sy: f64, syaw: f64, sv: f64, sa: f64,
-        gx: f64, gy: f64, gyaw: f64, gv: f64, ga: f64,
-        max_accel: f64, max_jerk: f64, dt: f64,
+        sx: f64,
+        sy: f64,
+        syaw: f64,
+        sv: f64,
+        sa: f64,
+        gx: f64,
+        gy: f64,
+        gyaw: f64,
+        gv: f64,
+        ga: f64,
+        max_accel: f64,
+        max_jerk: f64,
+        dt: f64,
     ) -> bool {
         let vxs = sv * syaw.cos();
         let vys = sv * syaw.sin();
@@ -163,7 +186,9 @@ impl QuinticPolynomialsPlanner {
                 let ax = xqp.calc_second_derivative(current_t);
                 let ay = yqp.calc_second_derivative(current_t);
                 let mut a = (ax * ax + ay * ay).sqrt();
-                if self.rv.len() >= 2 && self.rv[self.rv.len() - 1] - self.rv[self.rv.len() - 2] < 0.0 {
+                if self.rv.len() >= 2
+                    && self.rv[self.rv.len() - 1] - self.rv[self.rv.len() - 2] < 0.0
+                {
                     a *= -1.0;
                 }
                 self.ra.push(a);
@@ -171,7 +196,9 @@ impl QuinticPolynomialsPlanner {
                 let jx = xqp.calc_third_derivative(current_t);
                 let jy = yqp.calc_third_derivative(current_t);
                 let mut j = (jx * jx + jy * jy).sqrt();
-                if self.ra.len() >= 2 && self.ra[self.ra.len() - 1] - self.ra[self.ra.len() - 2] < 0.0 {
+                if self.ra.len() >= 2
+                    && self.ra[self.ra.len() - 1] - self.ra[self.ra.len() - 2] < 0.0
+                {
                     j *= -1.0;
                 }
                 self.rj.push(j);
@@ -202,7 +229,11 @@ impl QuinticPolynomialsPlanner {
         let axes = fg.axes2d();
 
         // Plot path
-        axes.lines(&self.rx, &self.ry, &[Caption("Quintic Polynomial Path"), Color("red")]);
+        axes.lines(
+            &self.rx,
+            &self.ry,
+            &[Caption("Quintic Polynomial Path"), Color("red")],
+        );
 
         // Plot start and goal positions
         axes.points(&[sx], &[sy], &[Caption("Start"), Color("green")]);
@@ -244,7 +275,8 @@ impl QuinticPolynomialsPlanner {
         axes.set_title("Yaw Profile", &[])
             .set_x_label("Time [s]", &[])
             .set_y_label("Yaw [deg]", &[]);
-        fg.save_to_png("img/path_planning/quintic_yaw_profile.png", 800, 600).unwrap();
+        fg.save_to_png("img/path_planning/quintic_yaw_profile.png", 800, 600)
+            .unwrap();
 
         // Velocity profile
         let mut fg = Figure::new();
@@ -253,16 +285,26 @@ impl QuinticPolynomialsPlanner {
         axes.set_title("Velocity Profile", &[])
             .set_x_label("Time [s]", &[])
             .set_y_label("Speed [m/s]", &[]);
-        fg.save_to_png("img/path_planning/quintic_velocity_profile.png", 800, 600).unwrap();
+        fg.save_to_png("img/path_planning/quintic_velocity_profile.png", 800, 600)
+            .unwrap();
 
         // Acceleration profile
         let mut fg = Figure::new();
         let axes = fg.axes2d();
-        axes.lines(&self.time, &self.ra, &[Caption("Acceleration"), Color("red")]);
+        axes.lines(
+            &self.time,
+            &self.ra,
+            &[Caption("Acceleration"), Color("red")],
+        );
         axes.set_title("Acceleration Profile", &[])
             .set_x_label("Time [s]", &[])
             .set_y_label("Accel [m/s²]", &[]);
-        fg.save_to_png("img/path_planning/quintic_acceleration_profile.png", 800, 600).unwrap();
+        fg.save_to_png(
+            "img/path_planning/quintic_acceleration_profile.png",
+            800,
+            600,
+        )
+        .unwrap();
 
         // Jerk profile
         let mut fg = Figure::new();
@@ -271,7 +313,8 @@ impl QuinticPolynomialsPlanner {
         axes.set_title("Jerk Profile", &[])
             .set_x_label("Time [s]", &[])
             .set_y_label("Jerk [m/s³]", &[]);
-        fg.save_to_png("img/path_planning/quintic_jerk_profile.png", 800, 600).unwrap();
+        fg.save_to_png("img/path_planning/quintic_jerk_profile.png", 800, 600)
+            .unwrap();
 
         println!("Profile plots saved to img/path_planning/");
     }
@@ -280,23 +323,25 @@ impl QuinticPolynomialsPlanner {
 fn main() {
     println!("Quintic Polynomials Planner start!!");
 
-    let sx = 10.0;  // start x position [m]
-    let sy = 10.0;  // start y position [m]
+    let sx = 10.0; // start x position [m]
+    let sy = 10.0; // start y position [m]
     let syaw = 10.0_f64.to_radians(); // start yaw angle [rad]
-    let sv = 1.0;   // start speed [m/s]
-    let sa = 0.1;   // start accel [m/s²]
-    let gx = 30.0;  // goal x position [m]
+    let sv = 1.0; // start speed [m/s]
+    let sa = 0.1; // start accel [m/s²]
+    let gx = 30.0; // goal x position [m]
     let gy = -10.0; // goal y position [m]
     let gyaw = 20.0_f64.to_radians(); // goal yaw angle [rad]
-    let gv = 1.0;   // goal speed [m/s]
-    let ga = 0.1;   // goal accel [m/s²]
+    let gv = 1.0; // goal speed [m/s]
+    let ga = 0.1; // goal accel [m/s²]
     let max_accel = 1.0; // max accel [m/s²]
-    let max_jerk = 0.5;  // max jerk [m/s³]
-    let dt = 0.1;   // time tick [s]
+    let max_jerk = 0.5; // max jerk [m/s³]
+    let dt = 0.1; // time tick [s]
 
     let mut planner = QuinticPolynomialsPlanner::new();
 
-    if planner.planning(sx, sy, syaw, sv, sa, gx, gy, gyaw, gv, ga, max_accel, max_jerk, dt) {
+    if planner.planning(
+        sx, sy, syaw, sv, sa, gx, gy, gyaw, gv, ga, max_accel, max_jerk, dt,
+    ) {
         println!("Path found with {} points!", planner.rx.len());
         planner.visualize_path(sx, sy, syaw, gx, gy, gyaw);
         planner.visualize_profiles();

--- a/src/path_planning/quintic_polynomials.rs
+++ b/src/path_planning/quintic_polynomials.rs
@@ -1,3 +1,9 @@
+#![allow(
+    dead_code,
+    clippy::too_many_arguments,
+    clippy::needless_borrows_for_generic_args
+)]
+
 use gnuplot::{AxesCommon, Caption, Color, Figure};
 use std::f64::consts::PI;
 
@@ -236,8 +242,8 @@ impl QuinticPolynomialsPlanner {
         );
 
         // Plot start and goal positions
-        axes.points(&[sx], &[sy], &[Caption("Start"), Color("green")]);
-        axes.points(&[gx], &[gy], &[Caption("Goal"), Color("blue")]);
+        axes.points([sx], [sy], &[Caption("Start"), Color("green")]);
+        axes.points([gx], [gy], &[Caption("Goal"), Color("blue")]);
 
         // Plot arrows for start and goal orientations
         let arrow_length = 2.0;
@@ -317,6 +323,12 @@ impl QuinticPolynomialsPlanner {
             .unwrap();
 
         println!("Profile plots saved to img/path_planning/");
+    }
+}
+
+impl Default for QuinticPolynomialsPlanner {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/path_planning/reeds_shepp_path.rs
+++ b/src/path_planning/reeds_shepp_path.rs
@@ -71,9 +71,9 @@ fn polar(x: f64, y: f64) -> (f64, f64) {
 
 fn left_straight_left(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Vec<char>) {
     let (u, t) = polar(x - phi.sin(), y - 1.0 + phi.cos());
-    if 0.0 <= t && t <= PI {
+    if (0.0..=PI).contains(&t) {
         let v = mod2pi(phi - t);
-        if 0.0 <= v && v <= PI {
+        if (0.0..=PI).contains(&v) {
             return (true, vec![t, u, v], vec!['L', 'S', 'L']);
         }
     }
@@ -164,7 +164,7 @@ fn left_x_right_left_x_right(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Vec<c
     let (u1, theta) = polar(zeta, eeta);
     let u2 = (20.0 - u1 * u1) / 16.0;
 
-    if 0.0 <= u2 && u2 <= 1.0 {
+    if (0.0..=1.0).contains(&u2) {
         let u = u2.acos();
         let a = (2.0 * u.sin() / u1).asin();
         let t = mod2pi(theta + a + PI / 2.0);

--- a/src/path_planning/reeds_shepp_path.rs
+++ b/src/path_planning/reeds_shepp_path.rs
@@ -4,7 +4,7 @@
 //         Videh Patel(@videh25) : Added the missing RS paths
 //         Rust implementation
 
-use gnuplot::{Figure, Caption, Color, AxesCommon};
+use gnuplot::{AxesCommon, Caption, Color, Figure};
 use std::f64::consts::PI;
 
 #[derive(Debug, Clone)]
@@ -79,7 +79,7 @@ fn left_straight_right(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Vec<char>) 
         let theta = (2.0_f64).atan2(u);
         let t = mod2pi(t1 + theta);
         let v = mod2pi(t - phi);
-        
+
         if t >= 0.0 && v >= 0.0 {
             return (true, vec![t, u, v], vec!['L', 'S', 'R']);
         }
@@ -91,7 +91,7 @@ fn left_x_right_x_left(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Vec<char>) 
     let zeta = x - phi.sin();
     let eeta = y - 1.0 + phi.cos();
     let (u1, theta) = polar(zeta, eeta);
-    
+
     if u1 <= 4.0 {
         let a = (0.25 * u1).acos();
         let t = mod2pi(a + theta + PI / 2.0);
@@ -106,7 +106,7 @@ fn left_x_right_left(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Vec<char>) {
     let zeta = x - phi.sin();
     let eeta = y - 1.0 + phi.cos();
     let (u1, theta) = polar(zeta, eeta);
-    
+
     if u1 <= 4.0 {
         let a = (0.25 * u1).acos();
         let t = mod2pi(a + theta + PI / 2.0);
@@ -121,7 +121,7 @@ fn left_right_x_left(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Vec<char>) {
     let zeta = x - phi.sin();
     let eeta = y - 1.0 + phi.cos();
     let (u1, theta) = polar(zeta, eeta);
-    
+
     if u1 <= 4.0 {
         let u = (1.0 - u1 * u1 * 0.125).acos();
         let a = (2.0 * u.sin() / u1).asin();
@@ -136,7 +136,7 @@ fn left_right_x_left_right(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Vec<cha
     let zeta = x + phi.sin();
     let eeta = y - 1.0 - phi.cos();
     let (u1, theta) = polar(zeta, eeta);
-    
+
     if u1 <= 2.0 {
         let a = ((u1 + 2.0) * 0.25).acos();
         let t = mod2pi(theta + a + PI / 2.0);
@@ -154,7 +154,7 @@ fn left_x_right_left_x_right(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Vec<c
     let eeta = y - 1.0 - phi.cos();
     let (u1, theta) = polar(zeta, eeta);
     let u2 = (20.0 - u1 * u1) / 16.0;
-    
+
     if 0.0 <= u2 && u2 <= 1.0 {
         let u = u2.acos();
         let a = (2.0 * u.sin() / u1).asin();
@@ -171,7 +171,7 @@ fn left_x_right90_straight_left(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Ve
     let zeta = x - phi.sin();
     let eeta = y - 1.0 + phi.cos();
     let (u1, theta) = polar(zeta, eeta);
-    
+
     if u1 >= 2.0 {
         let u = (u1 * u1 - 4.0).sqrt() - 2.0;
         let a = (2.0_f64).atan2((u1 * u1 - 4.0).sqrt());
@@ -188,7 +188,7 @@ fn left_straight_right90_x_left(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Ve
     let zeta = x - phi.sin();
     let eeta = y - 1.0 + phi.cos();
     let (u1, theta) = polar(zeta, eeta);
-    
+
     if u1 >= 2.0 {
         let u = (u1 * u1 - 4.0).sqrt() - 2.0;
         let a = ((u1 * u1 - 4.0).sqrt()).atan2(2.0);
@@ -205,7 +205,7 @@ fn left_x_right90_straight_right(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, V
     let zeta = x + phi.sin();
     let eeta = y - 1.0 - phi.cos();
     let (u1, theta) = polar(zeta, eeta);
-    
+
     if u1 >= 2.0 {
         let t = mod2pi(theta + PI / 2.0);
         let u = u1 - 2.0;
@@ -221,7 +221,7 @@ fn left_straight_left90_x_right(x: f64, y: f64, phi: f64) -> (bool, Vec<f64>, Ve
     let zeta = x + phi.sin();
     let eeta = y - 1.0 - phi.cos();
     let (u1, theta) = polar(zeta, eeta);
-    
+
     if u1 >= 2.0 {
         let t = mod2pi(theta);
         let u = u1 - 2.0;
@@ -237,14 +237,18 @@ fn left_x_right90_straight_left90_x_right(x: f64, y: f64, phi: f64) -> (bool, Ve
     let zeta = x + phi.sin();
     let eeta = y - 1.0 - phi.cos();
     let (u1, theta) = polar(zeta, eeta);
-    
+
     if u1 >= 4.0 {
         let u = (u1 * u1 - 4.0).sqrt() - 4.0;
         let a = (2.0_f64).atan2((u1 * u1 - 4.0).sqrt());
         let t = mod2pi(theta + a + PI / 2.0);
         let v = mod2pi(t - phi);
         if t >= 0.0 && v >= 0.0 {
-            return (true, vec![t, -PI / 2.0, -u, -PI / 2.0, v], vec!['L', 'R', 'S', 'L', 'R']);
+            return (
+                true,
+                vec![t, -PI / 2.0, -u, -PI / 2.0, v],
+                vec!['L', 'R', 'S', 'L', 'R'],
+            );
         }
     }
     (false, Vec::new(), Vec::new())
@@ -255,13 +259,14 @@ fn timeflip(travel_distances: Vec<f64>) -> Vec<f64> {
 }
 
 fn reflect(steering_directions: Vec<char>) -> Vec<char> {
-    steering_directions.iter().map(|&dirn| {
-        match dirn {
+    steering_directions
+        .iter()
+        .map(|&dirn| match dirn {
             'L' => 'R',
             'R' => 'L',
             _ => 'S',
-        }
-    }).collect()
+        })
+        .collect()
 }
 
 fn set_path(paths: &mut Vec<Path>, lengths: Vec<f64>, ctypes: Vec<char>, step_size: f64) {
@@ -269,7 +274,7 @@ fn set_path(paths: &mut Vec<Path>, lengths: Vec<f64>, ctypes: Vec<char>, step_si
     path.ctypes = ctypes;
     path.lengths = lengths;
     path.l = path.lengths.iter().map(|x| x.abs()).sum();
-    
+
     // Check if same path exists
     for existing_path in paths.iter() {
         let type_is_same = existing_path.ctypes == path.ctypes;
@@ -278,12 +283,12 @@ fn set_path(paths: &mut Vec<Path>, lengths: Vec<f64>, ctypes: Vec<char>, step_si
             return; // Same path found, do not insert
         }
     }
-    
+
     // Check path is long enough
     if path.l <= step_size {
         return; // Too short, do not insert
     }
-    
+
     paths.push(path);
 }
 
@@ -296,56 +301,70 @@ fn generate_path(q0: [f64; 3], q1: [f64; 3], max_curvature: f64, step_size: f64)
     let x = (c * dx + s * dy) * max_curvature;
     let y = (-s * dx + c * dy) * max_curvature;
     let step_size = step_size * max_curvature;
-    
+
     let mut paths = Vec::new();
-    
+
     let path_functions: Vec<fn(f64, f64, f64) -> (bool, Vec<f64>, Vec<char>)> = vec![
-        left_straight_left, left_straight_right,
-        left_x_right_x_left, left_x_right_left, left_right_x_left,
-        left_right_x_left_right, left_x_right_left_x_right,
-        left_x_right90_straight_left, left_x_right90_straight_right,
-        left_straight_right90_x_left, left_straight_left90_x_right,
+        left_straight_left,
+        left_straight_right,
+        left_x_right_x_left,
+        left_x_right_left,
+        left_right_x_left,
+        left_right_x_left_right,
+        left_x_right_left_x_right,
+        left_x_right90_straight_left,
+        left_x_right90_straight_right,
+        left_straight_right90_x_left,
+        left_straight_left90_x_right,
         left_x_right90_straight_left90_x_right,
     ];
-    
+
     for path_func in path_functions {
         // Original
         let (flag, travel_distances, steering_dirns) = path_func(x, y, dth);
         if flag {
             let min_dist = 0.1 * travel_distances.iter().map(|d| d.abs()).sum::<f64>();
-            let valid = travel_distances.iter().all(|&d| d.abs() >= min_dist || d.abs() >= step_size);
+            let valid = travel_distances
+                .iter()
+                .all(|&d| d.abs() >= min_dist || d.abs() >= step_size);
             if valid {
                 set_path(&mut paths, travel_distances, steering_dirns, step_size);
             }
         }
-        
+
         // Timeflip
         let (flag, travel_distances, steering_dirns) = path_func(-x, y, -dth);
         if flag {
             let min_dist = 0.1 * travel_distances.iter().map(|d| d.abs()).sum::<f64>();
-            let valid = travel_distances.iter().all(|&d| d.abs() >= min_dist || d.abs() >= step_size);
+            let valid = travel_distances
+                .iter()
+                .all(|&d| d.abs() >= min_dist || d.abs() >= step_size);
             if valid {
                 let travel_distances = timeflip(travel_distances);
                 set_path(&mut paths, travel_distances, steering_dirns, step_size);
             }
         }
-        
+
         // Reflect
         let (flag, travel_distances, steering_dirns) = path_func(x, -y, -dth);
         if flag {
             let min_dist = 0.1 * travel_distances.iter().map(|d| d.abs()).sum::<f64>();
-            let valid = travel_distances.iter().all(|&d| d.abs() >= min_dist || d.abs() >= step_size);
+            let valid = travel_distances
+                .iter()
+                .all(|&d| d.abs() >= min_dist || d.abs() >= step_size);
             if valid {
                 let steering_dirns = reflect(steering_dirns);
                 set_path(&mut paths, travel_distances, steering_dirns, step_size);
             }
         }
-        
+
         // Timeflip + Reflect
         let (flag, travel_distances, steering_dirns) = path_func(-x, -y, dth);
         if flag {
             let min_dist = 0.1 * travel_distances.iter().map(|d| d.abs()).sum::<f64>();
-            let valid = travel_distances.iter().all(|&d| d.abs() >= min_dist || d.abs() >= step_size);
+            let valid = travel_distances
+                .iter()
+                .all(|&d| d.abs() >= min_dist || d.abs() >= step_size);
             if valid {
                 let travel_distances = timeflip(travel_distances);
                 let steering_dirns = reflect(steering_dirns);
@@ -353,18 +372,18 @@ fn generate_path(q0: [f64; 3], q1: [f64; 3], max_curvature: f64, step_size: f64)
             }
         }
     }
-    
+
     paths
 }
 
 fn calc_interpolate_dists_list(lengths: &[f64], step_size: f64) -> Vec<Vec<f64>> {
     let mut interpolate_dists_list = Vec::new();
-    
+
     for &length in lengths {
         let d_dist = if length >= 0.0 { step_size } else { -step_size };
         let mut interp_dists = Vec::new();
         let mut current = 0.0;
-        
+
         while (length >= 0.0 && current < length) || (length < 0.0 && current > length) {
             interp_dists.push(current);
             current += d_dist;
@@ -372,12 +391,19 @@ fn calc_interpolate_dists_list(lengths: &[f64], step_size: f64) -> Vec<Vec<f64>>
         interp_dists.push(length);
         interpolate_dists_list.push(interp_dists);
     }
-    
+
     interpolate_dists_list
 }
 
-fn interpolate(dist: f64, length: f64, mode: char, max_curvature: f64, 
-               origin_x: f64, origin_y: f64, origin_yaw: f64) -> (f64, f64, f64, i32) {
+fn interpolate(
+    dist: f64,
+    length: f64,
+    mode: char,
+    max_curvature: f64,
+    origin_x: f64,
+    origin_y: f64,
+    origin_yaw: f64,
+) -> (f64, f64, f64, i32) {
     if mode == 'S' {
         let x = origin_x + dist / max_curvature * origin_yaw.cos();
         let y = origin_y + dist / max_curvature * origin_yaw.sin();
@@ -387,41 +413,53 @@ fn interpolate(dist: f64, length: f64, mode: char, max_curvature: f64,
         let ldx = dist.sin() / max_curvature;
         let ldy;
         let yaw;
-        
+
         if mode == 'L' {
             ldy = (1.0 - dist.cos()) / max_curvature;
             yaw = origin_yaw + dist;
-        } else { // 'R'
+        } else {
+            // 'R'
             ldy = (1.0 - dist.cos()) / -max_curvature;
             yaw = origin_yaw - dist;
         }
-        
+
         let gdx = (-origin_yaw).cos() * ldx + (-origin_yaw).sin() * ldy;
         let gdy = -(-origin_yaw).sin() * ldx + (-origin_yaw).cos() * ldy;
         let x = origin_x + gdx;
         let y = origin_y + gdy;
-        
+
         (x, y, yaw, if length > 0.0 { 1 } else { -1 })
     }
 }
 
-fn generate_local_course(lengths: &[f64], modes: &[char], max_curvature: f64, step_size: f64) 
-    -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<i32>) {
+fn generate_local_course(
+    lengths: &[f64],
+    modes: &[char],
+    max_curvature: f64,
+    step_size: f64,
+) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<i32>) {
     let interpolate_dists_list = calc_interpolate_dists_list(lengths, step_size * max_curvature);
-    
+
     let mut origin_x = 0.0;
     let mut origin_y = 0.0;
     let mut origin_yaw = 0.0;
-    
+
     let mut xs = Vec::new();
     let mut ys = Vec::new();
     let mut yaws = Vec::new();
     let mut directions = Vec::new();
-    
+
     for ((interp_dists, &mode), &length) in interpolate_dists_list.iter().zip(modes).zip(lengths) {
         for &dist in interp_dists {
-            let (x, y, yaw, direction) = interpolate(dist, length, mode, max_curvature, 
-                                                   origin_x, origin_y, origin_yaw);
+            let (x, y, yaw, direction) = interpolate(
+                dist,
+                length,
+                mode,
+                max_curvature,
+                origin_x,
+                origin_y,
+                origin_yaw,
+            );
             xs.push(x);
             ys.push(y);
             yaws.push(yaw);
@@ -433,51 +471,77 @@ fn generate_local_course(lengths: &[f64], modes: &[char], max_curvature: f64, st
             origin_yaw = yaws[yaws.len() - 1];
         }
     }
-    
+
     (xs, ys, yaws, directions)
 }
 
-fn calc_paths(sx: f64, sy: f64, syaw: f64, gx: f64, gy: f64, gyaw: f64, 
-              maxc: f64, step_size: f64) -> Vec<Path> {
+fn calc_paths(
+    sx: f64,
+    sy: f64,
+    syaw: f64,
+    gx: f64,
+    gy: f64,
+    gyaw: f64,
+    maxc: f64,
+    step_size: f64,
+) -> Vec<Path> {
     let q0 = [sx, sy, syaw];
     let q1 = [gx, gy, gyaw];
-    
+
     let mut paths = generate_path(q0, q1, maxc, step_size);
-    
+
     for path in &mut paths {
-        let (xs, ys, yaws, directions) = generate_local_course(&path.lengths, &path.ctypes, maxc, step_size);
-        
+        let (xs, ys, yaws, directions) =
+            generate_local_course(&path.lengths, &path.ctypes, maxc, step_size);
+
         // Convert to global coordinate
-        path.x = xs.iter().zip(ys.iter()).map(|(&ix, &iy)| {
-            (-q0[2]).cos() * ix + (-q0[2]).sin() * iy + q0[0]
-        }).collect();
-        
-        path.y = xs.iter().zip(ys.iter()).map(|(&ix, &iy)| {
-            -(-q0[2]).sin() * ix + (-q0[2]).cos() * iy + q0[1]
-        }).collect();
-        
+        path.x = xs
+            .iter()
+            .zip(ys.iter())
+            .map(|(&ix, &iy)| (-q0[2]).cos() * ix + (-q0[2]).sin() * iy + q0[0])
+            .collect();
+
+        path.y = xs
+            .iter()
+            .zip(ys.iter())
+            .map(|(&ix, &iy)| -(-q0[2]).sin() * ix + (-q0[2]).cos() * iy + q0[1])
+            .collect();
+
         path.yaw = yaws.iter().map(|&yaw| pi_2_pi(yaw + q0[2])).collect();
         path.directions = directions;
         path.lengths = path.lengths.iter().map(|&length| length / maxc).collect();
         path.l = path.l / maxc;
     }
-    
+
     paths
 }
 
-pub fn reeds_shepp_path_planning(sx: f64, sy: f64, syaw: f64, gx: f64, gy: f64, gyaw: f64, 
-                                maxc: f64, step_size: f64) -> Option<(Vec<f64>, Vec<f64>, Vec<f64>, Vec<char>, Vec<f64>)> {
+pub fn reeds_shepp_path_planning(
+    sx: f64,
+    sy: f64,
+    syaw: f64,
+    gx: f64,
+    gy: f64,
+    gyaw: f64,
+    maxc: f64,
+    step_size: f64,
+) -> Option<(Vec<f64>, Vec<f64>, Vec<f64>, Vec<char>, Vec<f64>)> {
     let paths = calc_paths(sx, sy, syaw, gx, gy, gyaw, maxc, step_size);
-    
+
     if paths.is_empty() {
         return None;
     }
-    
+
     // Find minimum cost path
     let best_path = paths.iter().min_by(|a, b| a.l.partial_cmp(&b.l).unwrap())?;
-    
-    Some((best_path.x.clone(), best_path.y.clone(), best_path.yaw.clone(), 
-          best_path.ctypes.clone(), best_path.lengths.clone()))
+
+    Some((
+        best_path.x.clone(),
+        best_path.y.clone(),
+        best_path.yaw.clone(),
+        best_path.ctypes.clone(),
+        best_path.lengths.clone(),
+    ))
 }
 
 pub struct ReedsSheppPlanner {
@@ -498,82 +562,109 @@ impl ReedsSheppPlanner {
             lengths: Vec::new(),
         }
     }
-    
-    pub fn planning(&mut self, sx: f64, sy: f64, syaw: f64, gx: f64, gy: f64, gyaw: f64, 
-                   max_curvature: f64, step_size: f64) -> bool {
-        if let Some((x, y, yaw, modes, lengths)) = reeds_shepp_path_planning(
-            sx, sy, syaw, gx, gy, gyaw, max_curvature, step_size) {
+
+    pub fn planning(
+        &mut self,
+        sx: f64,
+        sy: f64,
+        syaw: f64,
+        gx: f64,
+        gy: f64,
+        gyaw: f64,
+        max_curvature: f64,
+        step_size: f64,
+    ) -> bool {
+        if let Some((x, y, yaw, modes, lengths)) =
+            reeds_shepp_path_planning(sx, sy, syaw, gx, gy, gyaw, max_curvature, step_size)
+        {
             self.path_x = x;
             self.path_y = y;
             self.path_yaw = yaw;
             self.modes = modes;
             self.lengths = lengths;
-            println!("Reeds-Shepp path generated with {} points", self.path_x.len());
+            println!(
+                "Reeds-Shepp path generated with {} points",
+                self.path_x.len()
+            );
             true
         } else {
             println!("Failed to generate Reeds-Shepp path");
             false
         }
     }
-    
+
     pub fn visualize(&self, sx: f64, sy: f64, syaw: f64, gx: f64, gy: f64, gyaw: f64) {
         if self.path_x.is_empty() {
             println!("No path to visualize");
             return;
         }
-        
+
         let mut fg = Figure::new();
         let axes = fg.axes2d();
-        
+
         // Plot path
-        axes.lines(&self.path_x, &self.path_y, &[Caption("Reeds-Shepp Path"), Color("blue")]);
-        
+        axes.lines(
+            &self.path_x,
+            &self.path_y,
+            &[Caption("Reeds-Shepp Path"), Color("blue")],
+        );
+
         // Plot start and goal arrows
         let arrow_length = 0.5;
         let start_arrow_x = vec![sx, sx + arrow_length * syaw.cos()];
         let start_arrow_y = vec![sy, sy + arrow_length * syaw.sin()];
         let goal_arrow_x = vec![gx, gx + arrow_length * gyaw.cos()];
         let goal_arrow_y = vec![gy, gy + arrow_length * gyaw.sin()];
-        
-        axes.lines(&start_arrow_x, &start_arrow_y, &[Caption("Start"), Color("red")]);
-        axes.lines(&goal_arrow_x, &goal_arrow_y, &[Caption("Goal"), Color("green")]);
-        
+
+        axes.lines(
+            &start_arrow_x,
+            &start_arrow_y,
+            &[Caption("Start"), Color("red")],
+        );
+        axes.lines(
+            &goal_arrow_x,
+            &goal_arrow_y,
+            &[Caption("Goal"), Color("green")],
+        );
+
         axes.set_title("Reeds-Shepp Path Planning", &[])
             .set_x_label("X [m]", &[])
             .set_y_label("Y [m]", &[])
             .set_aspect_ratio(gnuplot::AutoOption::Fix(1.0));
-        
+
         let output_path = "img/path_planning/reeds_shepp_result.png";
         fg.save_to_png(output_path, 800, 600).unwrap();
         println!("Plot saved to: {}", output_path);
-        
+
         fg.show().unwrap();
     }
 }
 
 fn main() {
     println!("Reeds Shepp path planner start!!");
-    
+
     let start_x = -1.0;
     let start_y = -4.0;
     let start_yaw = (-20.0_f64).to_radians();
-    
+
     let end_x = 5.0;
     let end_y = 5.0;
     let end_yaw = (25.0_f64).to_radians();
-    
+
     let curvature = 0.1;
     let step_size = 0.05;
-    
+
     let mut planner = ReedsSheppPlanner::new();
-    
-    if planner.planning(start_x, start_y, start_yaw, end_x, end_y, end_yaw, curvature, step_size) {
+
+    if planner.planning(
+        start_x, start_y, start_yaw, end_x, end_y, end_yaw, curvature, step_size,
+    ) {
         println!("Path modes: {:?}", planner.modes);
         println!("Path lengths: {:?}", planner.lengths);
         planner.visualize(start_x, start_y, start_yaw, end_x, end_y, end_yaw);
     } else {
         println!("Failed to generate path");
     }
-    
+
     println!("Reeds Shepp path planner finish!!");
 }

--- a/src/path_planning/reeds_shepp_path.rs
+++ b/src/path_planning/reeds_shepp_path.rs
@@ -1,3 +1,12 @@
+#![allow(
+    dead_code,
+    clippy::needless_borrows_for_generic_args,
+    clippy::new_without_default,
+    clippy::type_complexity,
+    clippy::too_many_arguments,
+    clippy::assign_op_pattern
+)]
+
 // Reeds-Shepp Path Planner
 //
 // Author: Atsushi Sakai(@Atsushi_twi)

--- a/src/path_planning/rrt.rs
+++ b/src/path_planning/rrt.rs
@@ -110,7 +110,7 @@ pub struct RRTPlanner {
     play_area: Option<AreaBounds>,
     rand_area: AreaBounds,
     node_list: Vec<RRTNode>,
-    start: RRTNode,
+    _start: RRTNode,
     goal: RRTNode,
 }
 
@@ -128,7 +128,7 @@ impl RRTPlanner {
             play_area,
             rand_area,
             node_list: Vec::new(),
-            start: RRTNode::new(0.0, 0.0),
+            _start: RRTNode::new(0.0, 0.0),
             goal: RRTNode::new(0.0, 0.0),
         }
     }
@@ -308,7 +308,7 @@ impl PathPlanner for RRTPlanner {
             play_area: self.play_area.clone(),
             rand_area: self.rand_area.clone(),
             node_list: vec![RRTNode::new(start.x, start.y)],
-            start: RRTNode::new(start.x, start.y),
+            _start: RRTNode::new(start.x, start.y),
             goal: RRTNode::new(goal.x, goal.y),
         };
 

--- a/src/path_planning/rrt.rs
+++ b/src/path_planning/rrt.rs
@@ -5,7 +5,7 @@
 
 use rand::Rng;
 
-use crate::common::{Point2D, Path2D, PathPlanner, RoboticsError};
+use crate::common::{Path2D, PathPlanner, Point2D, RoboticsError};
 
 /// Internal node for RRT tree
 #[derive(Debug, Clone)]
@@ -44,7 +44,12 @@ pub struct AreaBounds {
 
 impl AreaBounds {
     pub fn new(xmin: f64, xmax: f64, ymin: f64, ymax: f64) -> Self {
-        AreaBounds { xmin, xmax, ymin, ymax }
+        AreaBounds {
+            xmin,
+            xmax,
+            ymin,
+            ymax,
+        }
     }
 
     pub fn from_array(area: [f64; 4]) -> Self {
@@ -165,9 +170,7 @@ impl RRTPlanner {
 
         match self.plan(start_pt, goal_pt) {
             Ok(path) => {
-                let result: Vec<[f64; 2]> = path.points.iter()
-                    .map(|p| [p.x, p.y])
-                    .collect();
+                let result: Vec<[f64; 2]> = path.points.iter().map(|p| [p.x, p.y]).collect();
                 Some(result)
             }
             Err(_) => None,
@@ -262,8 +265,11 @@ impl RRTPlanner {
 
     fn check_if_outside_play_area(&self, node: &RRTNode) -> bool {
         if let Some(ref play_area) = self.play_area {
-            if node.x < play_area.xmin || node.x > play_area.xmax ||
-               node.y < play_area.ymin || node.y > play_area.ymax {
+            if node.x < play_area.xmin
+                || node.x > play_area.xmax
+                || node.y < play_area.ymin
+                || node.y > play_area.ymax
+            {
                 return false;
             }
         }
@@ -320,7 +326,8 @@ impl PathPlanner for RRTPlanner {
 
                 let last = planner.node_list.last().unwrap();
                 if planner.calc_dist_to_goal(last.x, last.y) <= planner.config.expand_dis {
-                    let final_node = planner.steer(last, &planner.goal.clone(), planner.config.expand_dis);
+                    let final_node =
+                        planner.steer(last, &planner.goal.clone(), planner.config.expand_dis);
                     if planner.check_collision(&final_node) {
                         return Ok(planner.generate_final_course(planner.node_list.len() - 1));
                     }
@@ -328,7 +335,9 @@ impl PathPlanner for RRTPlanner {
             }
         }
 
-        Err(RoboticsError::PlanningError("RRT: Cannot find path within max iterations".to_string()))
+        Err(RoboticsError::PlanningError(
+            "RRT: Cannot find path within max iterations".to_string(),
+        ))
     }
 }
 

--- a/src/path_planning/rrt.rs
+++ b/src/path_planning/rrt.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 //! RRT (Rapidly-exploring Random Tree) path planning algorithm
 //!
 //! Sampling-based path planning algorithm that builds a tree by

--- a/src/path_planning/rrt_star.rs
+++ b/src/path_planning/rrt_star.rs
@@ -1,6 +1,6 @@
-use gnuplot::{AxesCommon, Caption, Color, Figure};
+#![allow(dead_code, clippy::too_many_arguments)]
+
 use rand::Rng;
-use std::f64::consts::PI;
 use std::io::Write;
 
 // RRT* planner parameters

--- a/src/path_planning/rrt_star.rs
+++ b/src/path_planning/rrt_star.rs
@@ -1,6 +1,6 @@
-use std::f64::consts::PI;
+use gnuplot::{AxesCommon, Caption, Color, Figure};
 use rand::Rng;
-use gnuplot::{Figure, Caption, Color, AxesCommon};
+use std::f64::consts::PI;
 use std::io::Write;
 
 // RRT* planner parameters
@@ -74,24 +74,24 @@ impl RRTStar {
 
     pub fn planning(&mut self) -> Option<Vec<[f64; 2]>> {
         self.node_list = vec![self.start.clone()];
-        
+
         for i in 0..self.max_iter {
             if i % 100 == 0 {
                 println!("Iter: {}, number of nodes: {}", i, self.node_list.len());
             }
-            
+
             let rnd_node = self.get_random_node();
             let nearest_ind = self.get_nearest_node_index(&rnd_node);
             let mut new_node = self.steer(nearest_ind, &rnd_node);
-            
+
             if let Some(ref mut node) = new_node {
                 let near_node = &self.node_list[nearest_ind];
                 node.cost = near_node.cost + self.calc_distance(near_node, node);
-                
+
                 if self.check_collision_free(node) {
                     let near_inds = self.find_near_nodes(node);
                     let node_with_updated_parent = self.choose_parent(node.clone(), &near_inds);
-                    
+
                     if let Some(updated_node) = node_with_updated_parent {
                         let new_index = self.node_list.len();
                         self.node_list.push(updated_node);
@@ -99,7 +99,7 @@ impl RRTStar {
                     } else {
                         self.node_list.push(node.clone());
                     }
-                    
+
                     if !self.search_until_max_iter {
                         if let Some(last_index) = self.search_best_goal_node() {
                             return Some(self.generate_final_course(last_index));
@@ -108,18 +108,18 @@ impl RRTStar {
                 }
             }
         }
-        
+
         println!("Reached max iteration");
         if let Some(last_index) = self.search_best_goal_node() {
             return Some(self.generate_final_course(last_index));
         }
-        
+
         None
     }
 
     fn get_random_node(&self) -> Node {
         let mut rng = rand::thread_rng();
-        
+
         if rng.gen_range(0..100) > self.goal_sample_rate {
             Node::new(
                 rng.gen_range(self.min_rand..self.max_rand),
@@ -133,7 +133,7 @@ impl RRTStar {
     fn get_nearest_node_index(&self, rnd_node: &Node) -> usize {
         let mut min_dist = f64::INFINITY;
         let mut nearest_ind = 0;
-        
+
         for (i, node) in self.node_list.iter().enumerate() {
             let dist = self.calc_distance(node, rnd_node);
             if dist < min_dist {
@@ -141,37 +141,37 @@ impl RRTStar {
                 nearest_ind = i;
             }
         }
-        
+
         nearest_ind
     }
 
     fn steer(&self, from_ind: usize, to_node: &Node) -> Option<Node> {
         let from_node = &self.node_list[from_ind];
         let (dist, theta) = self.calc_distance_and_angle(from_node, to_node);
-        
+
         let extend_length = if dist > self.expand_dis {
             self.expand_dis
         } else {
             dist
         };
-        
+
         let mut new_node = Node::new(
             from_node.x + extend_length * theta.cos(),
             from_node.y + extend_length * theta.sin(),
         );
         new_node.parent = Some(from_ind);
-        
+
         Some(new_node)
     }
 
     fn check_collision_free(&self, node: &Node) -> bool {
         if let Some(parent_ind) = node.parent {
             let parent = &self.node_list[parent_ind];
-            
+
             for &(ox, oy, size) in &self.obstacle_list {
                 let dx_list = self.get_path_x(parent, node);
                 let dy_list = self.get_path_y(parent, node);
-                
+
                 for (&dx, &dy) in dx_list.iter().zip(dy_list.iter()) {
                     let d = (dx - ox).powi(2) + (dy - oy).powi(2);
                     if d <= (size + self.robot_radius).powi(2) {
@@ -186,7 +186,7 @@ impl RRTStar {
     fn get_path_x(&self, from_node: &Node, to_node: &Node) -> Vec<f64> {
         let (dist, theta) = self.calc_distance_and_angle(from_node, to_node);
         let n_expand = (dist / self.path_resolution).floor() as i32;
-        
+
         (0..=n_expand)
             .map(|i| from_node.x + self.path_resolution * i as f64 * theta.cos())
             .collect()
@@ -195,7 +195,7 @@ impl RRTStar {
     fn get_path_y(&self, from_node: &Node, to_node: &Node) -> Vec<f64> {
         let (dist, theta) = self.calc_distance_and_angle(from_node, to_node);
         let n_expand = (dist / self.path_resolution).floor() as i32;
-        
+
         (0..=n_expand)
             .map(|i| from_node.y + self.path_resolution * i as f64 * theta.sin())
             .collect()
@@ -205,7 +205,7 @@ impl RRTStar {
         let nnode = self.node_list.len() + 1;
         let r = self.connect_circle_dist * ((nnode as f64).ln() / nnode as f64).sqrt();
         let r = r.min(self.expand_dis);
-        
+
         self.node_list
             .iter()
             .enumerate()
@@ -224,42 +224,43 @@ impl RRTStar {
         if near_inds.is_empty() {
             return None;
         }
-        
+
         let mut costs = Vec::new();
         for &i in near_inds {
             let near_node = &self.node_list[i];
             let mut t_node = Node::new(new_node.x, new_node.y);
             t_node.parent = Some(i);
-            
+
             if self.check_collision_free(&t_node) {
                 costs.push(self.calc_new_cost(near_node, &new_node));
             } else {
                 costs.push(f64::INFINITY);
             }
         }
-        
+
         let min_cost = costs.iter().fold(f64::INFINITY, |a, &b| a.min(b));
-        
+
         if min_cost == f64::INFINITY {
             return None;
         }
-        
+
         let min_ind = costs.iter().position(|&x| x == min_cost)?;
         let parent_ind = near_inds[min_ind];
-        
+
         let mut result_node = Node::new(new_node.x, new_node.y);
         result_node.parent = Some(parent_ind);
         result_node.cost = min_cost;
-        
+
         Some(result_node)
     }
 
     fn search_best_goal_node(&self) -> Option<usize> {
-        let dist_to_goal_list: Vec<f64> = self.node_list
+        let dist_to_goal_list: Vec<f64> = self
+            .node_list
             .iter()
             .map(|n| self.calc_dist_to_goal(n.x, n.y))
             .collect();
-        
+
         let goal_inds: Vec<usize> = dist_to_goal_list
             .iter()
             .enumerate()
@@ -271,7 +272,7 @@ impl RRTStar {
                 }
             })
             .collect();
-        
+
         let safe_goal_inds: Vec<usize> = goal_inds
             .into_iter()
             .filter(|&goal_ind| {
@@ -280,20 +281,21 @@ impl RRTStar {
                 self.check_collision_free(&t_node)
             })
             .collect();
-        
+
         if safe_goal_inds.is_empty() {
             return None;
         }
-        
+
         let safe_goal_costs: Vec<f64> = safe_goal_inds
             .iter()
             .map(|&i| {
-                self.node_list[i].cost + self.calc_dist_to_goal(self.node_list[i].x, self.node_list[i].y)
+                self.node_list[i].cost
+                    + self.calc_dist_to_goal(self.node_list[i].x, self.node_list[i].y)
             })
             .collect();
-        
+
         let min_cost = safe_goal_costs.iter().fold(f64::INFINITY, |a, &b| a.min(b));
-        
+
         safe_goal_inds
             .into_iter()
             .zip(safe_goal_costs)
@@ -305,14 +307,14 @@ impl RRTStar {
         for &i in near_inds {
             let near_node = self.node_list[i].clone();
             let new_node = &self.node_list[new_node_ind];
-            
+
             let mut edge_node = Node::new(near_node.x, near_node.y);
             edge_node.parent = Some(new_node_ind);
             edge_node.cost = self.calc_new_cost(new_node, &near_node);
-            
+
             let no_collision = self.check_collision_free(&edge_node);
             let improved_cost = near_node.cost > edge_node.cost;
-            
+
             if no_collision && improved_cost {
                 // Update parent references
                 for node in &mut self.node_list {
@@ -334,11 +336,12 @@ impl RRTStar {
 
     fn propagate_cost_to_leaves(&mut self, parent_ind: usize) {
         let parent_node = self.node_list[parent_ind].clone();
-        
+
         for i in 0..self.node_list.len() {
             if let Some(node_parent) = self.node_list[i].parent {
                 if node_parent == parent_ind {
-                    self.node_list[i].cost = self.calc_new_cost(&parent_node, &self.node_list[i].clone());
+                    self.node_list[i].cost =
+                        self.calc_new_cost(&parent_node, &self.node_list[i].clone());
                     self.propagate_cost_to_leaves(i);
                 }
             }
@@ -348,13 +351,13 @@ impl RRTStar {
     fn generate_final_course(&self, goal_ind: usize) -> Vec<[f64; 2]> {
         let mut path = vec![[self.end.x, self.end.y]];
         let mut node = &self.node_list[goal_ind];
-        
+
         while let Some(parent_ind) = node.parent {
             path.push([node.x, node.y]);
             node = &self.node_list[parent_ind];
         }
         path.push([node.x, node.y]);
-        
+
         path.reverse();
         path
     }
@@ -514,17 +517,17 @@ fn main() {
     ];
 
     let mut rrt_star = RRTStar::new(
-        (0.0, 0.0),    // start
-        (6.0, 10.0),   // goal
+        (0.0, 0.0),  // start
+        (6.0, 10.0), // goal
         obstacle_list,
-        (-2.0, 15.0),  // rand_area
-        2.0,           // expand_dis
-        0.5,           // path_resolution
-        20,            // goal_sample_rate
-        1000,          // max_iter (increased)
-        50.0,          // connect_circle_dist
-        true,          // search_until_max_iter
-        0.3,           // robot_radius
+        (-2.0, 15.0), // rand_area
+        2.0,          // expand_dis
+        0.5,          // path_resolution
+        20,           // goal_sample_rate
+        1000,         // max_iter (increased)
+        50.0,         // connect_circle_dist
+        true,         // search_until_max_iter
+        0.3,          // robot_radius
     );
 
     if let Some(path) = rrt_star.planning() {

--- a/src/path_planning/state_lattice/mod.rs
+++ b/src/path_planning/state_lattice/mod.rs
@@ -35,15 +35,13 @@
 //! - "State Space Sampling of Feasible Motions for High-Performance Mobile Robot Navigation"
 
 pub mod motion_model;
-pub mod trajectory_generator;
 pub mod state_lattice_planner;
+pub mod trajectory_generator;
 
 // Re-exports
 pub use motion_model::{MotionModel, MotionModelConfig, VehicleState};
+pub use state_lattice_planner::{StateLattice, StateLatticeConfig, TargetPose, Trajectory};
 pub use trajectory_generator::{
     LookupTable, LookupTableEntry, TargetState, TrajectoryGenerator, TrajectoryGeneratorConfig,
     TrajectoryParams,
-};
-pub use state_lattice_planner::{
-    StateLattice, StateLatticeConfig, TargetPose, Trajectory,
 };

--- a/src/path_planning/state_lattice/motion_model.rs
+++ b/src/path_planning/state_lattice/motion_model.rs
@@ -243,7 +243,7 @@ mod tests {
     #[test]
     fn test_generate_trajectory_straight() {
         let model = MotionModel::with_defaults();
-        let (x, y, yaw) = model.generate_trajectory(1.0, 0.0, 0.0, 0.0);
+        let (x, y, _yaw) = model.generate_trajectory(1.0, 0.0, 0.0, 0.0);
 
         // Straight line should have y ≈ 0
         assert!(x.len() > 1);

--- a/src/path_planning/state_lattice/state_lattice_planner.rs
+++ b/src/path_planning/state_lattice/state_lattice_planner.rs
@@ -289,7 +289,8 @@ impl StateLattice {
                 // Sample headings
                 for j in 0..config.nh {
                     let yaw = if config.nh > 1 {
-                        config.a_min + (config.a_max - config.a_min) * j as f64 / (config.nh - 1) as f64
+                        config.a_min
+                            + (config.a_max - config.a_min) * j as f64 / (config.nh - 1) as f64
                     } else {
                         angle
                     };
@@ -410,10 +411,10 @@ impl StateLattice {
                 let goal_x = dx;
                 let goal_y = dy;
 
-                let a_cost = (a_final_x * scale - goal_x).powi(2)
-                    + (a_final_y * scale - goal_y).powi(2);
-                let b_cost = (b_final_x * scale - goal_x).powi(2)
-                    + (b_final_y * scale - goal_y).powi(2);
+                let a_cost =
+                    (a_final_x * scale - goal_x).powi(2) + (a_final_y * scale - goal_y).powi(2);
+                let b_cost =
+                    (b_final_x * scale - goal_x).powi(2) + (b_final_y * scale - goal_y).powi(2);
 
                 a_cost
                     .partial_cmp(&b_cost)

--- a/src/path_planning/state_lattice/state_lattice_planner.rs
+++ b/src/path_planning/state_lattice/state_lattice_planner.rs
@@ -7,14 +7,11 @@
 //! - PythonRobotics State Lattice Planner by Atsushi Sakai
 //! - "State Space Sampling of Feasible Motions for High-Performance Mobile Robot Navigation"
 
-use std::f64::consts::PI;
-
 use crate::common::{error::RoboticsError, Path2D, Point2D};
 
 use super::motion_model::{normalize_angle, MotionModel, MotionModelConfig};
 use super::trajectory_generator::{
-    LookupTable, LookupTableEntry, TargetState, TrajectoryGenerator, TrajectoryGeneratorConfig,
-    TrajectoryParams,
+    LookupTable, TargetState, TrajectoryGenerator, TrajectoryGeneratorConfig, TrajectoryParams,
 };
 use nalgebra::Vector3;
 
@@ -202,7 +199,6 @@ impl StateLattice {
         for i in 0..config.ns {
             // Bias distribution toward goal angle
             let t = i as f64 / (config.ns - 1).max(1) as f64;
-            let bias = 0.5 + 0.5 * (PI * t).cos(); // More samples near edges and center
             let angle = config.a_min + (config.a_max - config.a_min) * t;
 
             // Weight toward goal angle
@@ -272,7 +268,6 @@ impl StateLattice {
 
         for &angle in angle_samples {
             // Sample at different distances
-            let p_range = config.p_max - config.p_min;
             for i in 0..3 {
                 // 3 distance samples per angle
                 let p = if i == 0 {

--- a/src/path_planning/state_lattice/trajectory_generator.rs
+++ b/src/path_planning/state_lattice/trajectory_generator.rs
@@ -12,6 +12,7 @@ use super::motion_model::MotionModel;
 /// - km: middle curvature
 /// - kf: final curvature
 pub type TrajectoryParams = Vector3<f64>;
+pub type GeneratedTrajectory = (Vec<f64>, Vec<f64>, Vec<f64>, TrajectoryParams);
 
 /// Target state: [x, y, yaw]
 pub type TargetState = Vector3<f64>;
@@ -217,7 +218,7 @@ impl TrajectoryGenerator {
         &self,
         target: &TargetState,
         init_params: &TrajectoryParams,
-    ) -> Option<(Vec<f64>, Vec<f64>, Vec<f64>, TrajectoryParams)> {
+    ) -> Option<GeneratedTrajectory> {
         let params = self.optimize(target, init_params)?;
         let (x, y, yaw) = self.generate(&params);
         Some((x, y, yaw, params))

--- a/src/path_planning/state_lattice/trajectory_generator.rs
+++ b/src/path_planning/state_lattice/trajectory_generator.rs
@@ -55,7 +55,10 @@ impl TrajectoryGenerator {
     }
 
     pub fn with_defaults() -> Self {
-        Self::new(MotionModel::with_defaults(), TrajectoryGeneratorConfig::default())
+        Self::new(
+            MotionModel::with_defaults(),
+            TrajectoryGeneratorConfig::default(),
+        )
     }
 
     /// Set initial curvature
@@ -75,9 +78,12 @@ impl TrajectoryGenerator {
 
     /// Calculate difference between current trajectory endpoint and target
     fn calc_diff(&self, params: &TrajectoryParams, target: &TargetState) -> Vector3<f64> {
-        let (x_final, y_final, yaw_final) =
-            self.motion_model
-                .generate_trajectory_final_state(params[0], self.config.k0, params[1], params[2]);
+        let (x_final, y_final, yaw_final) = self.motion_model.generate_trajectory_final_state(
+            params[0],
+            self.config.k0,
+            params[1],
+            params[2],
+        );
 
         Vector3::new(
             x_final - target[0],
@@ -231,7 +237,14 @@ pub struct LookupTableEntry {
 
 impl LookupTableEntry {
     pub fn new(x: f64, y: f64, yaw: f64, s: f64, km: f64, kf: f64) -> Self {
-        Self { x, y, yaw, s, km, kf }
+        Self {
+            x,
+            y,
+            yaw,
+            s,
+            km,
+            kf,
+        }
     }
 
     /// Get target state from entry
@@ -307,9 +320,12 @@ impl LookupTable {
         for &s in &s_values {
             for &km in &k_values {
                 for &kf in &k_values {
-                    let (x_final, y_final, yaw_final) =
-                        generator.motion_model.generate_trajectory_final_state(s, 0.0, km, kf);
-                    entries.push(LookupTableEntry::new(x_final, y_final, yaw_final, s, km, kf));
+                    let (x_final, y_final, yaw_final) = generator
+                        .motion_model
+                        .generate_trajectory_final_state(s, 0.0, km, kf);
+                    entries.push(LookupTableEntry::new(
+                        x_final, y_final, yaw_final, s, km, kf,
+                    ));
                 }
             }
         }
@@ -319,13 +335,11 @@ impl LookupTable {
 
     /// Find nearest entry to target state
     pub fn find_nearest(&self, target: &TargetState) -> Option<&LookupTableEntry> {
-        self.entries
-            .iter()
-            .min_by(|a, b| {
-                a.distance_to(target)
-                    .partial_cmp(&b.distance_to(target))
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
+        self.entries.iter().min_by(|a, b| {
+            a.distance_to(target)
+                .partial_cmp(&b.distance_to(target))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
     }
 
     /// Add entry to table

--- a/src/path_planning/state_lattice/trajectory_generator.rs
+++ b/src/path_planning/state_lattice/trajectory_generator.rs
@@ -315,8 +315,6 @@ impl LookupTable {
         // Generate entries for various arc lengths and curvatures
         let s_values = [1.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0];
         let k_values = [-0.2, -0.1, -0.05, 0.0, 0.05, 0.1, 0.2];
-        let yaw_targets = [-1.0, -0.5, 0.0, 0.5, 1.0];
-
         for &s in &s_values {
             for &km in &k_values {
                 for &kf in &k_values {
@@ -379,14 +377,13 @@ impl Default for LookupTable {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::f64::consts::PI;
 
     #[test]
     fn test_trajectory_generator_straight() {
         let generator = TrajectoryGenerator::with_defaults();
         let params = Vector3::new(5.0, 0.0, 0.0); // s=5, km=0, kf=0
 
-        let (x, y, yaw) = generator.generate(&params);
+        let (x, y, _yaw) = generator.generate(&params);
 
         assert!(x.len() > 1);
         // Should be approximately straight line

--- a/src/path_planning/theta_star.rs
+++ b/src/path_planning/theta_star.rs
@@ -12,10 +12,10 @@
 //! Reference: Nash, A., Daniel, K., Koenig, S., & Felner, A. (2007).
 //! "Theta*: Any-Angle Path Planning on Grids"
 
-use std::collections::{HashMap, BinaryHeap};
 use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
 
-use crate::common::{Point2D, Path2D, PathPlanner, RoboticsError};
+use crate::common::{Path2D, PathPlanner, Point2D, RoboticsError};
 use crate::utils::{GridMap, Node};
 
 /// Configuration for Theta* planner
@@ -60,7 +60,10 @@ impl PartialEq for PriorityNode {
 impl Ord for PriorityNode {
     fn cmp(&self, other: &Self) -> Ordering {
         // Reverse ordering for min-heap behavior
-        other.priority.partial_cmp(&self.priority).unwrap_or(Ordering::Equal)
+        other
+            .priority
+            .partial_cmp(&self.priority)
+            .unwrap_or(Ordering::Equal)
     }
 }
 
@@ -87,7 +90,11 @@ impl ThetaStarPlanner {
         let grid_map = GridMap::new(ox, oy, config.resolution, config.robot_radius);
         let motion = Self::get_motion_model();
 
-        ThetaStarPlanner { grid_map, config, motion }
+        ThetaStarPlanner {
+            grid_map,
+            config,
+            motion,
+        }
     }
 
     /// Create from obstacle x/y vectors with default config
@@ -117,8 +124,7 @@ impl ThetaStarPlanner {
     }
 
     fn calc_heuristic(&self, n1_x: i32, n1_y: i32, n2_x: i32, n2_y: i32) -> f64 {
-        self.config.heuristic_weight
-            * (((n1_x - n2_x).pow(2) + (n1_y - n2_y).pow(2)) as f64).sqrt()
+        self.config.heuristic_weight * (((n1_x - n2_x).pow(2) + (n1_y - n2_y).pow(2)) as f64).sqrt()
     }
 
     fn get_motion_model() -> Vec<(i32, i32, f64)> {
@@ -266,7 +272,8 @@ impl PathPlanner for ThetaStarPlanner {
                     // Check line-of-sight from parent to neighbor
                     if self.line_of_sight(parent_node.x, parent_node.y, new_x, new_y) {
                         // Path 2: Connect directly to grandparent
-                        let dist = self.euclidean_distance(parent_node.x, parent_node.y, new_x, new_y);
+                        let dist =
+                            self.euclidean_distance(parent_node.x, parent_node.y, new_x, new_y);
                         let cost = parent_node.cost + dist;
                         (cost, Some(p_idx))
                     } else {
@@ -283,7 +290,10 @@ impl PathPlanner for ThetaStarPlanner {
                 };
 
                 // Check if this path is better than existing path
-                let existing_g = g_values.get(&new_grid_index).copied().unwrap_or(f64::INFINITY);
+                let existing_g = g_values
+                    .get(&new_grid_index)
+                    .copied()
+                    .unwrap_or(f64::INFINITY);
                 if new_cost < existing_g {
                     g_values.insert(new_grid_index, new_cost);
 
@@ -318,10 +328,14 @@ mod tests {
 
         // Boundary
         for i in 0..21 {
-            ox.push(i as f64); oy.push(0.0);
-            ox.push(i as f64); oy.push(20.0);
-            ox.push(0.0); oy.push(i as f64);
-            ox.push(20.0); oy.push(i as f64);
+            ox.push(i as f64);
+            oy.push(0.0);
+            ox.push(i as f64);
+            oy.push(20.0);
+            ox.push(0.0);
+            oy.push(i as f64);
+            ox.push(20.0);
+            oy.push(i as f64);
         }
 
         // Internal obstacle (vertical wall)
@@ -367,7 +381,8 @@ mod tests {
         let (ox, oy) = create_simple_obstacles();
 
         let theta_planner = ThetaStarPlanner::from_obstacles(&ox, &oy, 1.0, 0.5);
-        let a_star_planner = crate::path_planning::a_star::AStarPlanner::from_obstacles(&ox, &oy, 1.0, 0.5);
+        let a_star_planner =
+            crate::path_planning::a_star::AStarPlanner::from_obstacles(&ox, &oy, 1.0, 0.5);
 
         let start = Point2D::new(2.0, 2.0);
         let goal = Point2D::new(18.0, 18.0);
@@ -381,9 +396,12 @@ mod tests {
         let a_star_length = a_star_path.total_length();
 
         // Theta* should produce path length <= A* path length
-        assert!(theta_length <= a_star_length + 0.1,
+        assert!(
+            theta_length <= a_star_length + 0.1,
             "Theta* path ({}) should not be significantly longer than A* path ({})",
-            theta_length, a_star_length);
+            theta_length,
+            a_star_length
+        );
     }
 
     #[test]

--- a/src/path_planning/theta_star.rs
+++ b/src/path_planning/theta_star.rs
@@ -359,7 +359,7 @@ mod tests {
         assert!(result.is_ok());
 
         let path = result.unwrap();
-        assert!(path.len() > 0);
+        assert!(!path.is_empty());
     }
 
     #[test]
@@ -371,7 +371,7 @@ mod tests {
         assert!(result.is_some());
 
         let (rx, ry) = result.unwrap();
-        assert!(rx.len() > 0);
+        assert!(!rx.is_empty());
         assert_eq!(rx.len(), ry.len());
     }
 

--- a/src/path_planning/voronoi_road_map.rs
+++ b/src/path_planning/voronoi_road_map.rs
@@ -1,12 +1,13 @@
+#![allow(dead_code)]
+
 // Voronoi Road-Map path planning
 // author: Atsushi Sakai (@Atsushi_twi)
 //         Ryohei Sasaki (@rsasaki0109)
 //         Rust port
 
 use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
-use rand::Rng;
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::{BinaryHeap, HashMap};
 
 // Parameters
 const N_KNN: usize = 10; // number of edges per node
@@ -129,10 +130,14 @@ fn compute_voronoi_vertices(
             let dist_i = ((mx - ox[i]).powi(2) + (my - oy[i]).powi(2)).sqrt();
             let dist_j = ((mx - ox[j]).powi(2) + (my - oy[j]).powi(2)).sqrt();
 
-            if dist_i > robot_radius * 1.5 && dist_j > robot_radius * 1.5 {
-                if mx > min_x && mx < max_x && my > min_y && my < max_y {
-                    vertices.push((mx, my));
-                }
+            if dist_i > robot_radius * 1.5
+                && dist_j > robot_radius * 1.5
+                && mx > min_x
+                && mx < max_x
+                && my > min_y
+                && my < max_y
+            {
+                vertices.push((mx, my));
             }
         }
     }
@@ -198,7 +203,6 @@ pub struct VoronoiPlanner {
     sample_x: Vec<f64>,
     sample_y: Vec<f64>,
     road_map: Vec<Vec<usize>>,
-    obstacle_tree: KDTree,
 }
 
 impl VoronoiPlanner {
@@ -238,7 +242,6 @@ impl VoronoiPlanner {
             sample_x,
             sample_y,
             road_map,
-            obstacle_tree,
         }
     }
 
@@ -516,8 +519,8 @@ fn main() {
             ],
         )
         .points(
-            &[start.0],
-            &[start.1],
+            [start.0],
+            [start.1],
             &[
                 Caption("Start"),
                 Color("blue"),
@@ -526,8 +529,8 @@ fn main() {
             ],
         )
         .points(
-            &[goal.0],
-            &[goal.1],
+            [goal.0],
+            [goal.1],
             &[
                 Caption("Goal"),
                 Color("red"),

--- a/src/path_planning/voronoi_road_map.rs
+++ b/src/path_planning/voronoi_road_map.rs
@@ -3,10 +3,10 @@
 //         Ryohei Sasaki (@rsasaki0109)
 //         Rust port
 
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
 use rand::Rng;
-use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::cmp::Ordering;
-use gnuplot::{Figure, Caption, Color, AxesCommon, PointSymbol, PointSize};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 
 // Parameters
 const N_KNN: usize = 10; // number of edges per node
@@ -52,7 +52,10 @@ impl Eq for QueueItem {}
 
 impl Ord for QueueItem {
     fn cmp(&self, other: &Self) -> Ordering {
-        other.cost.partial_cmp(&self.cost).unwrap_or(Ordering::Equal)
+        other
+            .cost
+            .partial_cmp(&self.cost)
+            .unwrap_or(Ordering::Equal)
     }
 }
 
@@ -73,7 +76,8 @@ impl KDTree {
     }
 
     fn query_knn(&self, x: f64, y: f64, k: usize) -> Vec<(usize, f64)> {
-        let mut distances: Vec<(usize, f64)> = self.points
+        let mut distances: Vec<(usize, f64)> = self
+            .points
             .iter()
             .enumerate()
             .map(|(i, (px, py))| {
@@ -97,7 +101,15 @@ impl KDTree {
 
 /// Simple Voronoi diagram computation using Fortune's algorithm approximation
 /// This is a simplified version that extracts vertices from obstacle positions
-fn compute_voronoi_vertices(ox: &[f64], oy: &[f64], min_x: f64, max_x: f64, min_y: f64, max_y: f64, robot_radius: f64) -> Vec<(f64, f64)> {
+fn compute_voronoi_vertices(
+    ox: &[f64],
+    oy: &[f64],
+    min_x: f64,
+    max_x: f64,
+    min_y: f64,
+    max_y: f64,
+    robot_radius: f64,
+) -> Vec<(f64, f64)> {
     let mut vertices = Vec::new();
     let n = ox.len();
 
@@ -132,7 +144,9 @@ fn compute_voronoi_vertices(ox: &[f64], oy: &[f64], min_x: f64, max_x: f64, min_
                 if let Some((cx, cy)) = circumcenter(ox[i], oy[i], ox[j], oy[j], ox[k], oy[k]) {
                     // Check if circumcenter is inside bounds and far from obstacles
                     if cx > min_x && cx < max_x && cy > min_y && cy < max_y {
-                        let min_dist = ox.iter().zip(oy.iter())
+                        let min_dist = ox
+                            .iter()
+                            .zip(oy.iter())
                             .map(|(&px, &py)| ((cx - px).powi(2) + (cy - py).powi(2)).sqrt())
                             .fold(f64::INFINITY, f64::min);
 
@@ -148,9 +162,9 @@ fn compute_voronoi_vertices(ox: &[f64], oy: &[f64], min_x: f64, max_x: f64, min_
     // Remove duplicates
     let mut unique_vertices = Vec::new();
     for (x, y) in vertices {
-        let is_dup = unique_vertices.iter().any(|(vx, vy): &(f64, f64)| {
-            ((x - vx).powi(2) + (y - vy).powi(2)).sqrt() < 1.0
-        });
+        let is_dup = unique_vertices
+            .iter()
+            .any(|(vx, vy): &(f64, f64)| ((x - vx).powi(2) + (y - vy).powi(2)).sqrt() < 1.0);
         if !is_dup {
             unique_vertices.push((x, y));
         }
@@ -167,8 +181,14 @@ fn circumcenter(x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64) -> Option<
         return None; // Collinear points
     }
 
-    let ux = ((x1 * x1 + y1 * y1) * (y2 - y3) + (x2 * x2 + y2 * y2) * (y3 - y1) + (x3 * x3 + y3 * y3) * (y1 - y2)) / d;
-    let uy = ((x1 * x1 + y1 * y1) * (x3 - x2) + (x2 * x2 + y2 * y2) * (x1 - x3) + (x3 * x3 + y3 * y3) * (x2 - x1)) / d;
+    let ux = ((x1 * x1 + y1 * y1) * (y2 - y3)
+        + (x2 * x2 + y2 * y2) * (y3 - y1)
+        + (x3 * x3 + y3 * y3) * (y1 - y2))
+        / d;
+    let uy = ((x1 * x1 + y1 * y1) * (x3 - x2)
+        + (x2 * x2 + y2 * y2) * (x1 - x3)
+        + (x3 * x3 + y3 * y3) * (x2 - x1))
+        / d;
 
     Some((ux, uy))
 }
@@ -199,7 +219,8 @@ impl VoronoiPlanner {
         let max_y = oy.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
 
         // Get Voronoi vertices as sample points
-        let voronoi_vertices = compute_voronoi_vertices(ox, oy, min_x, max_x, min_y, max_y, robot_radius);
+        let voronoi_vertices =
+            compute_voronoi_vertices(ox, oy, min_x, max_x, min_y, max_y, robot_radius);
 
         let mut sample_x: Vec<f64> = voronoi_vertices.iter().map(|(x, _)| *x).collect();
         let mut sample_y: Vec<f64> = voronoi_vertices.iter().map(|(_, y)| *y).collect();
@@ -211,11 +232,7 @@ impl VoronoiPlanner {
         sample_y.push(goal.1);
 
         // Generate road map
-        let road_map = Self::generate_road_map(
-            &sample_x, &sample_y,
-            robot_radius,
-            &obstacle_tree,
-        );
+        let road_map = Self::generate_road_map(&sample_x, &sample_y, robot_radius, &obstacle_tree);
 
         VoronoiPlanner {
             sample_x,
@@ -233,7 +250,11 @@ impl VoronoiPlanner {
         obstacle_tree: &KDTree,
     ) -> Vec<Vec<usize>> {
         let sample_tree = KDTree::new(
-            sample_x.iter().zip(sample_y.iter()).map(|(&x, &y)| (x, y)).collect()
+            sample_x
+                .iter()
+                .zip(sample_y.iter())
+                .map(|(&x, &y)| (x, y))
+                .collect(),
         );
 
         let mut road_map: Vec<Vec<usize>> = vec![Vec::new(); sample_x.len()];
@@ -250,12 +271,8 @@ impl VoronoiPlanner {
                     continue;
                 }
 
-                if !Self::is_collision(
-                    x, y,
-                    sample_x[j], sample_y[j],
-                    robot_radius,
-                    obstacle_tree,
-                ) {
+                if !Self::is_collision(x, y, sample_x[j], sample_y[j], robot_radius, obstacle_tree)
+                {
                     road_map[i].push(j);
                 }
             }
@@ -266,8 +283,10 @@ impl VoronoiPlanner {
 
     /// Check if path between two points collides with obstacles
     fn is_collision(
-        x1: f64, y1: f64,
-        x2: f64, y2: f64,
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
         robot_radius: f64,
         obstacle_tree: &KDTree,
     ) -> bool {
@@ -306,7 +325,8 @@ impl VoronoiPlanner {
         let start_idx = n - 2;
         let goal_idx = n - 1;
 
-        let mut nodes: Vec<Node> = self.sample_x
+        let mut nodes: Vec<Node> = self
+            .sample_x
             .iter()
             .zip(self.sample_y.iter())
             .map(|(&x, &y)| Node::new(x, y))
@@ -315,7 +335,10 @@ impl VoronoiPlanner {
         nodes[start_idx].cost = 0.0;
 
         let mut open_set = BinaryHeap::new();
-        open_set.push(QueueItem { cost: 0.0, index: start_idx });
+        open_set.push(QueueItem {
+            cost: 0.0,
+            index: start_idx,
+        });
 
         let mut closed_set: HashMap<usize, bool> = HashMap::new();
 
@@ -449,7 +472,6 @@ fn main() {
     let (sample_x, sample_y) = planner.get_samples();
     let edges = planner.get_edges();
 
-
     // Prepare edge data as disconnected line segments using NaN separator
     let mut edge_x = Vec::new();
     let mut edge_y = Vec::new();
@@ -473,10 +495,46 @@ fn main() {
         axes.lines(&edge_x, &edge_y, &[Color("gray")]);
 
         // Draw obstacles and samples
-        axes.points(&ox, &oy, &[Caption("Obstacles"), Color("black"), PointSymbol('.'), PointSize(0.5)])
-            .points(sample_x, sample_y, &[Caption("Voronoi Vertices"), Color("cyan"), PointSymbol('o'), PointSize(1.0)])
-            .points(&[start.0], &[start.1], &[Caption("Start"), Color("blue"), PointSymbol('O'), PointSize(2.0)])
-            .points(&[goal.0], &[goal.1], &[Caption("Goal"), Color("red"), PointSymbol('O'), PointSize(2.0)]);
+        axes.points(
+            &ox,
+            &oy,
+            &[
+                Caption("Obstacles"),
+                Color("black"),
+                PointSymbol('.'),
+                PointSize(0.5),
+            ],
+        )
+        .points(
+            sample_x,
+            sample_y,
+            &[
+                Caption("Voronoi Vertices"),
+                Color("cyan"),
+                PointSymbol('o'),
+                PointSize(1.0),
+            ],
+        )
+        .points(
+            &[start.0],
+            &[start.1],
+            &[
+                Caption("Start"),
+                Color("blue"),
+                PointSymbol('O'),
+                PointSize(2.0),
+            ],
+        )
+        .points(
+            &[goal.0],
+            &[goal.1],
+            &[
+                Caption("Goal"),
+                Color("red"),
+                PointSymbol('O'),
+                PointSize(2.0),
+            ],
+        );
 
         // Draw path
         if let Some((path_x, path_y)) = &path {
@@ -491,7 +549,8 @@ fn main() {
         fig.show_and_keep_running().unwrap();
     }
 
-    fig.save_to_svg("./img/path_planning/voronoi_road_map.svg", 640, 480).unwrap();
+    fig.save_to_svg("./img/path_planning/voronoi_road_map.svg", 640, 480)
+        .unwrap();
     fig.close();
     println!("Plot saved to ./img/path_planning/voronoi_road_map.svg");
 

--- a/src/path_tracking/cgmres_nmpc.rs
+++ b/src/path_tracking/cgmres_nmpc.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::too_many_arguments, clippy::type_complexity)]
+
 // Nonlinear MPC simulation with CGMRES (Continuation GMRES)
 //
 // author: Atsushi Sakai (@Atsushi_twi)

--- a/src/path_tracking/cgmres_nmpc.rs
+++ b/src/path_tracking/cgmres_nmpc.rs
@@ -98,7 +98,16 @@ impl NMPCSimulatorSystem {
         u_2s: &[f64],
         n: usize,
         dt: f64,
-    ) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
+    ) -> (
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+    ) {
         // Forward prediction using state equations
         let (x_s, y_s, yaw_s, v_s) = self.calc_predict_states(x, y, yaw, v, u_1s, u_2s, n, dt);
 
@@ -230,12 +239,12 @@ impl NMPCControllerCGMRES {
         let input_num = 6;
 
         NMPCControllerCGMRES {
-            zeta: 100.0,  // Original value
+            zeta: 100.0, // Original value
             ht: 0.01,
             tf: 3.0,
             alpha: 0.5,
             n,
-            threshold: 0.001,  // Same as Python
+            threshold: 0.001, // Same as Python
             input_num,
             max_iteration: input_num * n,
 
@@ -438,8 +447,18 @@ impl NMPCControllerCGMRES {
                 draw_2_i[k] = vs[(k * self.input_num + 5, i)] * self.ht;
             }
 
-            let u_1s_i: Vec<f64> = self.u_1s.iter().zip(&du_1_i).map(|(&u, &d)| u + d).collect();
-            let u_2s_i: Vec<f64> = self.u_2s.iter().zip(&du_2_i).map(|(&u, &d)| u + d).collect();
+            let u_1s_i: Vec<f64> = self
+                .u_1s
+                .iter()
+                .zip(&du_1_i)
+                .map(|(&u, &d)| u + d)
+                .collect();
+            let u_2s_i: Vec<f64> = self
+                .u_2s
+                .iter()
+                .zip(&du_2_i)
+                .map(|(&u, &d)| u + d)
+                .collect();
 
             let (_, _, _, v_s_i, _, _, lam_3s_i, lam_4s_i) =
                 self.simulator.calc_predict_and_adjoint_state(
@@ -576,8 +595,10 @@ impl NMPCControllerCGMRES {
                         for k in 0..self.n {
                             du_1_tmp[k] = du_1_i[k] + update_val[k * self.input_num];
                             du_2_tmp[k] = du_2_i[k] + update_val[k * self.input_num + 1];
-                            ddummy_u_1_tmp[k] = ddummy_u_1_i[k] + update_val[k * self.input_num + 2];
-                            ddummy_u_2_tmp[k] = ddummy_u_2_i[k] + update_val[k * self.input_num + 3];
+                            ddummy_u_1_tmp[k] =
+                                ddummy_u_1_i[k] + update_val[k * self.input_num + 2];
+                            ddummy_u_2_tmp[k] =
+                                ddummy_u_2_i[k] + update_val[k * self.input_num + 3];
                             draw_1_tmp[k] = draw_1_i[k] + update_val[k * self.input_num + 4];
                             draw_2_tmp[k] = draw_2_i[k] + update_val[k * self.input_num + 5];
                         }
@@ -597,9 +618,14 @@ impl NMPCControllerCGMRES {
         }
 
         // Update inputs (only if converged)
-        if let (Some(du1), Some(du2), Some(dd1), Some(dd2), Some(dr1), Some(dr2)) =
-            (du_1_new, du_2_new, ddummy_u_1_new, ddummy_u_2_new, draw_1_new, draw_2_new)
-        {
+        if let (Some(du1), Some(du2), Some(dd1), Some(dd2), Some(dr1), Some(dr2)) = (
+            du_1_new,
+            du_2_new,
+            ddummy_u_1_new,
+            ddummy_u_2_new,
+            draw_1_new,
+            draw_2_new,
+        ) {
             for i in 0..self.n {
                 self.u_1s[i] += du1[i] * self.ht;
                 self.u_2s[i] += du2[i] * self.ht;
@@ -764,7 +790,10 @@ fn save_trajectory_svg(
     writeln!(
         file,
         r#"<line x1="{}" y1="{}" x2="{}" y2="{}" stroke="black" stroke-width="1"/>"#,
-        margin, margin, margin, height - margin
+        margin,
+        margin,
+        margin,
+        height - margin
     )?;
 
     // Trajectory
@@ -856,8 +885,7 @@ pub fn main() {
     for i in 1..iteration_num {
         let time = (i as f64) * dt;
 
-        let (u_1s, u_2s) =
-            controller.calc_input(plant.x, plant.y, plant.yaw, plant.v, time);
+        let (u_1s, u_2s) = controller.calc_input(plant.x, plant.y, plant.yaw, plant.v, time);
 
         plant.update_state(u_1s[0], u_2s[0], dt);
 

--- a/src/path_tracking/lqr_steer_control.rs
+++ b/src/path_tracking/lqr_steer_control.rs
@@ -6,9 +6,9 @@
 //! author: Atsushi Sakai (@Atsushi_twi)
 //!         Ryohei Sasaki (@rsasaki0109)
 
+use crate::common::{ControlInput, Path2D, PathTracker, Point2D, State2D};
+use nalgebra::{Matrix1, Matrix1x4, Matrix4, Vector4};
 use std::f64::consts::PI;
-use nalgebra::{Matrix1, Matrix4, Vector4, Matrix1x4};
-use crate::common::{Point2D, Path2D, State2D, ControlInput, PathTracker};
 
 /// Vehicle state for LQR controller
 #[derive(Debug, Clone, Copy)]
@@ -23,7 +23,14 @@ pub struct LQRVehicleState {
 
 impl LQRVehicleState {
     pub fn new(x: f64, y: f64, yaw: f64, v: f64, wheelbase: f64, max_steer: f64) -> Self {
-        LQRVehicleState { x, y, yaw, v, wheelbase, max_steer }
+        LQRVehicleState {
+            x,
+            y,
+            yaw,
+            v,
+            wheelbase,
+            max_steer,
+        }
     }
 
     pub fn update(&mut self, a: f64, mut delta: f64, dt: f64) {
@@ -228,7 +235,12 @@ impl LQRSteerController {
     }
 
     /// Solve Discrete Algebraic Riccati Equation
-    fn solve_dare(a: Matrix4<f64>, b: Vector4<f64>, q: Matrix4<f64>, r: Matrix1<f64>) -> Matrix4<f64> {
+    fn solve_dare(
+        a: Matrix4<f64>,
+        b: Vector4<f64>,
+        q: Matrix4<f64>,
+        r: Matrix1<f64>,
+    ) -> Matrix4<f64> {
         let mut x = q;
         let max_iter = 150;
         let eps = 0.01;
@@ -236,9 +248,8 @@ impl LQRSteerController {
         for _ in 0..max_iter {
             let bt_x_b = b.transpose() * x * b;
             let inv = (r + bt_x_b).try_inverse().unwrap_or(Matrix1::identity());
-            let xn = a.transpose() * x * a
-                - a.transpose() * x * b * inv * b.transpose() * x * a
-                + q;
+            let xn =
+                a.transpose() * x * a - a.transpose() * x * b * inv * b.transpose() * x * a + q;
 
             if (xn - x).abs().max() < eps {
                 break;
@@ -293,9 +304,17 @@ impl LQRSteerController {
         // State error vector
         let x_err = Vector4::new(
             e,
-            if dt > 0.0 { (e - self.prev_error) / dt } else { 0.0 },
+            if dt > 0.0 {
+                (e - self.prev_error) / dt
+            } else {
+                0.0
+            },
             th_e,
-            if dt > 0.0 { (th_e - self.prev_theta_error) / dt } else { 0.0 },
+            if dt > 0.0 {
+                (th_e - self.prev_theta_error) / dt
+            } else {
+                0.0
+            },
         );
 
         // Feed-forward + feedback
@@ -335,7 +354,12 @@ impl LQRSteerController {
     }
 
     /// Legacy planning interface
-    pub fn planning(&mut self, waypoints: Vec<(f64, f64)>, target_speed: f64, ds: f64) -> Option<Vec<(f64, f64)>> {
+    pub fn planning(
+        &mut self,
+        waypoints: Vec<(f64, f64)>,
+        target_speed: f64,
+        ds: f64,
+    ) -> Option<Vec<(f64, f64)>> {
         if waypoints.len() < 2 {
             return None;
         }
@@ -347,7 +371,10 @@ impl LQRSteerController {
 
         // Set path
         let path = Path2D::from_points(
-            cx.iter().zip(cy.iter()).map(|(&x, &y)| Point2D::new(x, y)).collect()
+            cx.iter()
+                .zip(cy.iter())
+                .map(|(&x, &y)| Point2D::new(x, y))
+                .collect(),
         );
         self.path_yaw = cyaw;
         self.path_curvature = ck;
@@ -356,7 +383,10 @@ impl LQRSteerController {
 
         // Simulate tracking
         let mut state = LQRVehicleState::new(
-            0.0, 0.0, 0.0, 0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
             self.config.wheelbase,
             self.config.max_steer,
         );
@@ -406,7 +436,8 @@ impl PathTracker for LQRSteerController {
         let (target_idx, _) = self.calc_target_index(&vehicle_state);
         let target_v = self.get_target_speed(target_idx);
 
-        let v = current_state.v + self.compute_acceleration(target_v, current_state.v) * self.config.dt;
+        let v =
+            current_state.v + self.compute_acceleration(target_v, current_state.v) * self.config.dt;
         let omega = v * delta.tan() / self.config.wheelbase;
 
         ControlInput::new(v, omega)
@@ -421,7 +452,11 @@ impl PathTracker for LQRSteerController {
 
 // Cubic spline helper functions for legacy interface
 
-fn calc_spline_course(x: &[f64], y: &[f64], ds: f64) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
+fn calc_spline_course(
+    x: &[f64],
+    y: &[f64],
+    ds: f64,
+) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
     let sp = CubicSpline2D::new(x, y);
     let mut s = 0.0;
     let mut course_x = Vec::new();
@@ -492,7 +527,13 @@ impl CubicSpline {
             d[j] = (c[j + 1] - c[j]) / (3.0 * h[j]);
         }
 
-        CubicSpline { a, b, c, d, x: x.to_vec() }
+        CubicSpline {
+            a,
+            b,
+            c,
+            d,
+            x: x.to_vec(),
+        }
     }
 
     fn calc(&self, t: f64) -> f64 {
@@ -632,11 +673,7 @@ mod tests {
     #[test]
     fn test_lqr_planning() {
         let mut controller = LQRSteerController::with_defaults();
-        let waypoints = vec![
-            (0.0, 0.0),
-            (5.0, 0.0),
-            (10.0, 0.0),
-        ];
+        let waypoints = vec![(0.0, 0.0), (5.0, 0.0), (10.0, 0.0)];
 
         let result = controller.planning(waypoints, 2.0, 0.5);
         assert!(result.is_some());

--- a/src/path_tracking/lqr_steer_control.rs
+++ b/src/path_tracking/lqr_steer_control.rs
@@ -183,7 +183,7 @@ impl LQRSteerController {
         for i in 0..n {
             if i < n - 1 && i < self.path_yaw.len() - 1 {
                 let dyaw = (self.path_yaw[i + 1] - self.path_yaw[i]).abs();
-                if PI / 4.0 <= dyaw && dyaw < PI / 2.0 {
+                if (PI / 4.0..PI / 2.0).contains(&dyaw) {
                     direction *= -1.0;
                     profile.push(0.0);
                 } else {
@@ -452,11 +452,7 @@ impl PathTracker for LQRSteerController {
 
 // Cubic spline helper functions for legacy interface
 
-fn calc_spline_course(
-    x: &[f64],
-    y: &[f64],
-    ds: f64,
-) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
+fn calc_spline_course(x: &[f64], y: &[f64], ds: f64) -> SplineCourse {
     let sp = CubicSpline2D::new(x, y);
     let mut s = 0.0;
     let mut course_x = Vec::new();
@@ -489,6 +485,8 @@ struct CubicSpline {
     x: Vec<f64>,
 }
 
+type SplineCourse = (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>);
+
 impl CubicSpline {
     fn new(x: &[f64], y: &[f64]) -> Self {
         let n = x.len();
@@ -502,9 +500,7 @@ impl CubicSpline {
         let mut c = vec![0.0; n];
         let mut d = vec![0.0; n];
 
-        for i in 0..n {
-            a[i] = y[i];
-        }
+        a[..n].copy_from_slice(&y[..n]);
 
         let mut alpha = vec![0.0; n - 1];
         for i in 1..n - 1 {
@@ -677,7 +673,7 @@ mod tests {
 
         let result = controller.planning(waypoints, 2.0, 0.5);
         assert!(result.is_some());
-        assert!(result.unwrap().len() > 0);
+        assert!(!result.unwrap().is_empty());
     }
 
     #[test]

--- a/src/path_tracking/mod.rs
+++ b/src/path_tracking/mod.rs
@@ -15,6 +15,7 @@ pub use pure_pursuit::VehicleState as PurePursuitVehicleState;
 pub use stanley_controller::{StanleyController, StanleyConfig};
 pub use stanley_controller::VehicleState as StanleyVehicleState;
 pub use lqr_steer_control::{LQRSteerController, LQRSteerConfig, LQRVehicleState};
+pub use move_to_pose::{MoveToPoseConfig, MoveToPoseController, MoveToPoseResult};
 pub use rear_wheel_feedback::{RearWheelFeedbackController, RearWheelFeedbackConfig};
 pub use rear_wheel_feedback::VehicleState as RearWheelFeedbackVehicleState;
 pub use mpc::*;

--- a/src/path_tracking/mod.rs
+++ b/src/path_tracking/mod.rs
@@ -12,7 +12,6 @@ pub mod stanley_controller;
 // Re-export main controllers with explicit types to avoid name conflicts
 pub use lqr_steer_control::{LQRSteerConfig, LQRSteerController, LQRVehicleState};
 pub use move_to_pose::{MoveToPoseConfig, MoveToPoseController, MoveToPoseResult};
-pub use mpc::*;
 pub use pure_pursuit::VehicleState as PurePursuitVehicleState;
 pub use pure_pursuit::{PurePursuitConfig, PurePursuitController};
 pub use rear_wheel_feedback::VehicleState as RearWheelFeedbackVehicleState;

--- a/src/path_tracking/mod.rs
+++ b/src/path_tracking/mod.rs
@@ -1,21 +1,21 @@
 // Path Tracking algorithms module
 
-pub mod pure_pursuit;
-pub mod stanley_controller;
-pub mod lqr_steer_control;
-pub mod move_to_pose;
-pub mod model_predictive_trajectory_generator;
-pub mod mpc;
-pub mod rear_wheel_feedback;
 pub mod cgmres_nmpc;
+pub mod lqr_steer_control;
+pub mod model_predictive_trajectory_generator;
+pub mod move_to_pose;
+pub mod mpc;
+pub mod pure_pursuit;
+pub mod rear_wheel_feedback;
+pub mod stanley_controller;
 
 // Re-export main controllers with explicit types to avoid name conflicts
-pub use pure_pursuit::{PurePursuitController, PurePursuitConfig};
-pub use pure_pursuit::VehicleState as PurePursuitVehicleState;
-pub use stanley_controller::{StanleyController, StanleyConfig};
-pub use stanley_controller::VehicleState as StanleyVehicleState;
-pub use lqr_steer_control::{LQRSteerController, LQRSteerConfig, LQRVehicleState};
+pub use lqr_steer_control::{LQRSteerConfig, LQRSteerController, LQRVehicleState};
 pub use move_to_pose::{MoveToPoseConfig, MoveToPoseController, MoveToPoseResult};
-pub use rear_wheel_feedback::{RearWheelFeedbackController, RearWheelFeedbackConfig};
-pub use rear_wheel_feedback::VehicleState as RearWheelFeedbackVehicleState;
 pub use mpc::*;
+pub use pure_pursuit::VehicleState as PurePursuitVehicleState;
+pub use pure_pursuit::{PurePursuitConfig, PurePursuitController};
+pub use rear_wheel_feedback::VehicleState as RearWheelFeedbackVehicleState;
+pub use rear_wheel_feedback::{RearWheelFeedbackConfig, RearWheelFeedbackController};
+pub use stanley_controller::VehicleState as StanleyVehicleState;
+pub use stanley_controller::{StanleyConfig, StanleyController};

--- a/src/path_tracking/model_predictive_trajectory_generator.rs
+++ b/src/path_tracking/model_predictive_trajectory_generator.rs
@@ -1,5 +1,5 @@
 // https://github.com/AtsushiSakai/PythonRobotics/tree/master/PathPlanning/ModelPredictiveTrajectoryGenerator
-// 
+//
 // Model trajectory generator
 //
 // author: Atsushi Sakai(@Atsushi_twi)
@@ -8,21 +8,19 @@ extern crate nalgebra;
 
 use plotlib::page::Page;
 use plotlib::repr::Plot;
-use plotlib::view::ContinuousView;
 use plotlib::style::LineStyle;
+use plotlib::view::ContinuousView;
 
+fn pi2pi(mut angle: f64) -> f64 {
+    while angle > std::f64::consts::PI {
+        angle -= 2. * std::f64::consts::PI
+    }
 
-fn pi2pi(mut angle: f64) -> f64
-    {
-        while angle > std::f64::consts::PI {
-            angle -= 2. * std::f64::consts::PI
-        } 
-
-        while angle < -std::f64::consts::PI {
-            angle += 2. * std::f64::consts::PI
-        }    
-        angle
-    }   
+    while angle < -std::f64::consts::PI {
+        angle += 2. * std::f64::consts::PI
+    }
+    angle
+}
 
 struct State {
     x: f64,
@@ -33,44 +31,50 @@ struct State {
 }
 
 impl State {
-    fn new(x:(f64,f64,f64,f64), l: f64)-> State{
+    fn new(x: (f64, f64, f64, f64), l: f64) -> State {
         State {
-          x: x.0, y: x.1,
-          yaw: x.2, v: x.3,
-          l: l
+            x: x.0,
+            y: x.1,
+            yaw: x.2,
+            v: x.3,
+            l: l,
         }
-      }
-    
+    }
+
     fn update(&mut self, v: f64, delta: f64, dt: f64) {
         self.v = v;
         self.x += self.v * (self.yaw).cos() * dt;
         self.y += self.v * (self.yaw).sin() * dt;
         self.yaw += self.v / self.l * (delta).tan() * dt;
         self.yaw = pi2pi(self.yaw);
-        
-      }
+    }
 }
 
-fn generate_trajectory(p: (f64, f64, f64), k0: f64, ds: f64, v: f64, l: f64) -> (Vec<(f64, f64)>, Vec<f64>)
-{
+fn generate_trajectory(
+    p: (f64, f64, f64),
+    k0: f64,
+    ds: f64,
+    v: f64,
+    l: f64,
+) -> (Vec<(f64, f64)>, Vec<f64>) {
     let s = p.0;
     let km = p.1;
     let kf = p.2;
 
     let n = (s / ds) as usize;
-    let time = s / v; 
+    let time = s / v;
 
     let tk = (0., time / 2., time);
     let kk = (k0, km, kf);
     let coef = quad_interp(tk, kk);
 
-    let init_x = (0., 0., 0., 0.); // [x, y, yaw, v] 
+    let init_x = (0., 0., 0., 0.); // [x, y, yaw, v]
     let mut state: State = State::new(init_x, l);
     let mut c = vec![(state.x, state.y)];
     let mut cyaw = vec![(state.yaw)];
 
     let dt = time / (n as f64);
-    for i in 0..n-1 {
+    for i in 0..n - 1 {
         let x = (i as f64) * dt;
         let ikp = coef.0 * x * x + coef.1 * x + coef.2;
         state.update(v, ikp, dt);
@@ -80,24 +84,23 @@ fn generate_trajectory(p: (f64, f64, f64), k0: f64, ds: f64, v: f64, l: f64) -> 
     (c, cyaw)
 }
 
-fn generate_last_state(p: (f64, f64, f64), k0: f64, ds: f64, v: f64, l: f64) -> ((f64, f64), f64)
-{   
+fn generate_last_state(p: (f64, f64, f64), k0: f64, ds: f64, v: f64, l: f64) -> ((f64, f64), f64) {
     let s = p.0;
     let km = p.1;
     let kf = p.2;
 
     let n = (s / ds) as usize;
-    let time = s / v; 
+    let time = s / v;
 
     let tk = (0., time / 2., time);
     let kk = (k0, km, kf);
     let coef = quad_interp(tk, kk);
 
-    let init_x = (0., 0., 0., 0.); // [x, y, yaw, v] 
+    let init_x = (0., 0., 0., 0.); // [x, y, yaw, v]
     let mut state: State = State::new(init_x, l);
 
     let dt = time / (n as f64);
-    for i in 0..n-1 {
+    for i in 0..n - 1 {
         let t = (i as f64) * dt;
         let ikp = coef.0 * t * t + coef.1 * t + coef.2;
         state.update(v, ikp, dt);
@@ -105,30 +108,28 @@ fn generate_last_state(p: (f64, f64, f64), k0: f64, ds: f64, v: f64, l: f64) -> 
     ((state.x, state.y), state.yaw)
 }
 
-fn quad_interp(x: (f64, f64, f64), y: (f64, f64, f64)) -> (f64, f64, f64)
-{
-    let mat = nalgebra::Matrix3::new(
-        x.0 * x.0, x.0, 1.,
-        x.1 * x.1, x.1, 1.,
-        x.2 * x.2, x.2, 1.);
-    let vec = nalgebra::Vector3::new(
-        y.0 , y.1, y.2);
+fn quad_interp(x: (f64, f64, f64), y: (f64, f64, f64)) -> (f64, f64, f64) {
+    let mat = nalgebra::Matrix3::new(x.0 * x.0, x.0, 1., x.1 * x.1, x.1, 1., x.2 * x.2, x.2, 1.);
+    let vec = nalgebra::Vector3::new(y.0, y.1, y.2);
 
     let coef = mat.try_inverse().unwrap() * vec;
 
     (coef[0], coef[1], coef[2])
 }
 
-fn calc_diff(target: &State, x:(f64, f64, f64))-> nalgebra::Vector3<f64>{
-    nalgebra::Vector3::new(
-        target.x - x.0,
-        target.y - x.1,
-        pi2pi(target.yaw - x.2))
+fn calc_diff(target: &State, x: (f64, f64, f64)) -> nalgebra::Vector3<f64> {
+    nalgebra::Vector3::new(target.x - x.0, target.y - x.1, pi2pi(target.yaw - x.2))
 }
 
-fn calc_j(target: &State, p: nalgebra::Vector3<f64>, h: nalgebra::Vector3<f64>, k0: f64, ds: f64, v: f64, l: f64)
--> nalgebra::Matrix3<f64>
-{
+fn calc_j(
+    target: &State,
+    p: nalgebra::Vector3<f64>,
+    h: nalgebra::Vector3<f64>,
+    k0: f64,
+    ds: f64,
+    v: f64,
+    l: f64,
+) -> nalgebra::Matrix3<f64> {
     let (mut xp, mut yawp) = generate_last_state((p[0] + h[0], p[1], p[2]), k0, ds, v, l);
     let mut dp = calc_diff(&target, (xp.0, xp.1, yawp));
     let (mut xn, mut yawn) = generate_last_state((p[0] - h[0], p[1], p[2]), k0, ds, v, l);
@@ -156,21 +157,25 @@ fn calc_j(target: &State, p: nalgebra::Vector3<f64>, h: nalgebra::Vector3<f64>, 
     let d3 = (dp - dn) / (2. * h[2]);
 
     let j = nalgebra::Matrix3::new(
-        d1[0], d2[0], d3[0],
-        d1[1], d2[1], d3[1],
-        d1[2], d2[2], d3[2]);
+        d1[0], d2[0], d3[0], d1[1], d2[1], d3[1], d1[2], d2[2], d3[2],
+    );
     j
 }
 
-fn selection_learning_param(p: nalgebra::Vector3<f64>, k0: f64, ds: f64, v: f64, l: f64, target: &State)
--> f64
-{
+fn selection_learning_param(
+    p: nalgebra::Vector3<f64>,
+    k0: f64,
+    ds: f64,
+    v: f64,
+    l: f64,
+    target: &State,
+) -> f64 {
     let mut mincost = std::f64::MAX;
     let mut mina = 1.0;
     let maxa = 2.0;
     let da = 0.5;
     let na = ((maxa - mina) / da) as usize;
-    for i in 0..na-1 {
+    for i in 0..na - 1 {
         let a = mina + (na as f64) * (i as f64);
         let tp = p + a * p;
         let pair = generate_last_state((tp[0], tp[1], tp[2]), k0, ds, v, l);
@@ -187,76 +192,72 @@ fn selection_learning_param(p: nalgebra::Vector3<f64>, k0: f64, ds: f64, v: f64,
 }
 
 fn optimize_trajectory(
-    target: State, mut p: nalgebra::Vector3<f64>, h: nalgebra::Vector3<f64>,
-    k0: f64, ds: f64, v: f64, l: f64, max_iter: usize, cost_th: f64)
--> (Vec<(f64, f64)>, Vec<f64>, nalgebra::Vector3<f64>)
-{
+    target: State,
+    mut p: nalgebra::Vector3<f64>,
+    h: nalgebra::Vector3<f64>,
+    k0: f64,
+    ds: f64,
+    v: f64,
+    l: f64,
+    max_iter: usize,
+    cost_th: f64,
+) -> (Vec<(f64, f64)>, Vec<f64>, nalgebra::Vector3<f64>) {
     let mut xc: Vec<(f64, f64)> = vec![(0., 0.)];
     let mut yawc: Vec<f64> = vec![0.];
-    for _i in 0..max_iter-1 {
+    for _i in 0..max_iter - 1 {
         let pair = generate_trajectory((p[0], p[1], p[2]), k0, ds, v, l);
         xc = pair.0;
         yawc = pair.1;
-        let dc = calc_diff(&target, (xc[xc.len()-1].0, xc[xc.len()-1].1, yawc[xc.len()-1]));
-        let cost = dc.norm(); 
+        let dc = calc_diff(
+            &target,
+            (xc[xc.len() - 1].0, xc[xc.len() - 1].1, yawc[xc.len() - 1]),
+        );
+        let cost = dc.norm();
         if cost <= cost_th {
             println!("path is ok");
-            break
+            break;
         }
 
         let j = calc_j(&target, p, h, k0, ds, v, l);
-        let dp = - j.try_inverse().unwrap() * dc;
+        let dp = -j.try_inverse().unwrap() * dc;
         let alpha = selection_learning_param(p, k0, ds, v, l, &target);
 
         p += alpha * dp;
-        
     }
     (xc, yawc, p)
 }
 
 fn test_optimize_trajectory() {
-
     let max_iter = 100;
-    let h = nalgebra::Vector3::new(
-        0.5,
-        0.02,
-        0.02);
+    let h = nalgebra::Vector3::new(0.5, 0.02, 0.02);
     let cost_th = 0.1;
 
     let k0 = 0.;
-    let l = 1.0;  // wheel base
+    let l = 1.0; // wheel base
     let ds = 0.1; // course distanse
     let v = 10.0 / 3.6; // velocity [m/s]
 
-    let init_x = (5., 2., 90./180. * std::f64::consts::PI, 0.); // [x, y, yaw, v] 
+    let init_x = (5., 2., 90. / 180. * std::f64::consts::PI, 0.); // [x, y, yaw, v]
     let target = State::new(init_x, l);
-    
-    let init_p = nalgebra::Vector3::new(
-        6.,
-        0.,
-        0.);
-    
+
+    let init_p = nalgebra::Vector3::new(6., 0., 0.);
+
     let tmp = optimize_trajectory(target, init_p, h, k0, ds, v, l, max_iter, cost_th);
     let xc = tmp.0;
 
-    let s1: Plot = Plot::new(xc).line_style(
-        LineStyle::new() 
-            .colour("#35C788"),
-      );
+    let s1: Plot = Plot::new(xc).line_style(LineStyle::new().colour("#35C788"));
 
     let v = ContinuousView::new()
-      .add(s1)
-      .x_range( 0., 6.)
-      .y_range(-1., 3.)
-      .x_label("x [m]")
-      .y_label("y [m]");
+        .add(s1)
+        .x_range(0., 6.)
+        .y_range(-1., 3.)
+        .x_label("x [m]")
+        .y_label("y [m]");
 
-      Page::single(&v).save("./img/model_predictive_trajectory_generator.svg").unwrap();
+    Page::single(&v)
+        .save("./img/model_predictive_trajectory_generator.svg")
+        .unwrap();
 }
-
-
-
-
 
 fn main() {
     test_optimize_trajectory();

--- a/src/path_tracking/model_predictive_trajectory_generator.rs
+++ b/src/path_tracking/model_predictive_trajectory_generator.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::too_many_arguments)]
+
 // https://github.com/AtsushiSakai/PythonRobotics/tree/master/PathPlanning/ModelPredictiveTrajectoryGenerator
 //
 // Model trajectory generator
@@ -37,7 +39,7 @@ impl State {
             y: x.1,
             yaw: x.2,
             v: x.3,
-            l: l,
+            l,
         }
     }
 
@@ -131,35 +133,34 @@ fn calc_j(
     l: f64,
 ) -> nalgebra::Matrix3<f64> {
     let (mut xp, mut yawp) = generate_last_state((p[0] + h[0], p[1], p[2]), k0, ds, v, l);
-    let mut dp = calc_diff(&target, (xp.0, xp.1, yawp));
+    let mut dp = calc_diff(target, (xp.0, xp.1, yawp));
     let (mut xn, mut yawn) = generate_last_state((p[0] - h[0], p[1], p[2]), k0, ds, v, l);
-    let mut dn = calc_diff(&target, (xn.0, xn.1, yawn));
+    let mut dn = calc_diff(target, (xn.0, xn.1, yawn));
     let d1 = (dp - dn) / (2. * h[0]);
 
     let mut pair = generate_last_state((p[0], p[1] + h[1], p[2]), k0, ds, v, l);
     xp = pair.0;
     yawp = pair.1;
-    dp = calc_diff(&target, (xp.0, xp.1, yawp));
+    dp = calc_diff(target, (xp.0, xp.1, yawp));
     pair = generate_last_state((p[0], p[1] - h[1], p[2]), k0, ds, v, l);
     xn = pair.0;
     yawn = pair.1;
-    dn = calc_diff(&target, (xn.0, xn.1, yawn));
+    dn = calc_diff(target, (xn.0, xn.1, yawn));
     let d2 = (dp - dn) / (2. * h[1]);
 
     pair = generate_last_state((p[0], p[1], p[2] + h[2]), k0, ds, v, l);
     xp = pair.0;
     yawp = pair.1;
-    dp = calc_diff(&target, (xp.0, xp.1, yawp));
+    dp = calc_diff(target, (xp.0, xp.1, yawp));
     pair = generate_last_state((p[0], p[1], p[2] - h[2]), k0, ds, v, l);
     xn = pair.0;
     yawn = pair.1;
-    dn = calc_diff(&target, (xn.0, xn.1, yawn));
+    dn = calc_diff(target, (xn.0, xn.1, yawn));
     let d3 = (dp - dn) / (2. * h[2]);
 
-    let j = nalgebra::Matrix3::new(
+    nalgebra::Matrix3::new(
         d1[0], d2[0], d3[0], d1[1], d2[1], d3[1], d1[2], d2[2], d3[2],
-    );
-    j
+    )
 }
 
 fn selection_learning_param(
@@ -170,7 +171,7 @@ fn selection_learning_param(
     l: f64,
     target: &State,
 ) -> f64 {
-    let mut mincost = std::f64::MAX;
+    let mut mincost = f64::MAX;
     let mut mina = 1.0;
     let maxa = 2.0;
     let da = 0.5;
@@ -181,7 +182,7 @@ fn selection_learning_param(
         let pair = generate_last_state((tp[0], tp[1], tp[2]), k0, ds, v, l);
         let xc = pair.0;
         let yawc = pair.1;
-        let dc = calc_diff(&target, (xc.0, xc.1, yawc));
+        let dc = calc_diff(target, (xc.0, xc.1, yawc));
         let cost = dc.norm();
         if cost <= mincost && a != 0. {
             mina = a;

--- a/src/path_tracking/move_to_pose.rs
+++ b/src/path_tracking/move_to_pose.rs
@@ -200,8 +200,8 @@ pub fn demo_move_to_pose() {
         let traj_x = path.x_coords();
         let traj_y = path.y_coords();
         axes.lines(&traj_x, &traj_y, &[Caption("Trajectory"), Color("green")]);
-        axes.points(&[start.x], &[start.y], &[Caption("Start"), Color("blue")]);
-        axes.points(&[goal.x], &[goal.y], &[Caption("Goal"), Color("red")]);
+        axes.points([start.x], [start.y], &[Caption("Start"), Color("blue")]);
+        axes.points([goal.x], [goal.y], &[Caption("Goal"), Color("red")]);
 
         let arrow_start_x = vec![start.x, start.x + start.yaw.cos()];
         let arrow_start_y = vec![start.y, start.y + start.yaw.sin()];

--- a/src/path_tracking/move_to_pose.rs
+++ b/src/path_tracking/move_to_pose.rs
@@ -1,39 +1,157 @@
-// 
+//
 // Move to specified pose
 // Author: Daniel Ingram (daniel-s-ingram)
 //         Atsushi Sakai(@Atsushi_twi)
-//         Ryohei Sasaki(@rsasaki0109) 
+//         Ryohei Sasaki(@rsasaki0109)
 // P. I. Corke, "Robotics, Vision & Control", Springer 2017, ISBN 978-3-319-54413-7
-use gnuplot::{Figure, Caption, Color, AxesCommon};
+use crate::common::{ControlInput, Path2D, Point2D, Pose2D};
+use gnuplot::{AxesCommon, Caption, Color, Figure};
 use std::f64::consts::PI;
 
-fn move_to_pose(
-    x_start: (f64, f64, f64), x_goal: (f64, f64, f64), kp: (f64, f64, f64), dt: f64)
--> Vec<(f64, f64)>
-{
-    let mut x = x_start;
-    let mut x_diff = (x_goal.0 - x.0, x_goal.1 - x.1);
-    let mut rho = ((x_diff.0).powi(2) + (x_diff.1).powi(2)).sqrt();
-    let mut x_traj = vec![(x.0, x.1)];
-    while rho > 0.001 {
-        x_diff = (x_goal.0 - x.0, x_goal.1 - x.1);
-        rho = ((x_diff.0).powi(2) + (x_diff.1).powi(2)).sqrt();
-        let alpha = normalize_angle((x_diff.1).atan2(x_diff.0) - x.2);
-        let beta = normalize_angle(x_goal.2 - x.2 - alpha);
-        let mut v = kp.0 * rho;
-        let w = kp.1 * alpha + kp.2 * beta;
-        if alpha > PI / 2.0 || alpha < -PI / 2.0 {
-            v = -v;
-        }
-        x.2 = x.2 + w * dt;
-        x.0 = x.0 + v * (x.2).cos() * dt;
-        x.1 = x.1 + v * (x.2).sin() * dt;
-        x_traj.push((x.0, x.1));
-    }
-    x_traj
+#[derive(Debug, Clone, Copy)]
+pub struct MoveToPoseConfig {
+    pub kp_rho: f64,
+    pub kp_alpha: f64,
+    pub kp_beta: f64,
+    pub dt: f64,
+    pub goal_tolerance: f64,
+    pub yaw_tolerance: f64,
+    pub max_steps: usize,
 }
 
-fn normalize_angle(mut angle: f64) -> f64 {
+impl Default for MoveToPoseConfig {
+    fn default() -> Self {
+        Self {
+            kp_rho: 9.0,
+            kp_alpha: 15.0,
+            kp_beta: -3.0,
+            dt: 0.01,
+            goal_tolerance: 0.001,
+            yaw_tolerance: 0.05,
+            max_steps: 10_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MoveToPoseStep {
+    pub pose: Pose2D,
+    pub control: ControlInput,
+    pub distance_to_goal: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct MoveToPoseResult {
+    pub steps: Vec<MoveToPoseStep>,
+    pub converged: bool,
+}
+
+impl MoveToPoseResult {
+    pub fn final_pose(&self) -> Pose2D {
+        self.steps
+            .last()
+            .map(|step| step.pose)
+            .unwrap_or_else(Pose2D::origin)
+    }
+
+    pub fn iterations(&self) -> usize {
+        self.steps.len().saturating_sub(1)
+    }
+
+    pub fn path(&self) -> Path2D {
+        Path2D::from_points(
+            self.steps
+                .iter()
+                .map(|step| Point2D::new(step.pose.x, step.pose.y))
+                .collect(),
+        )
+    }
+}
+
+pub struct MoveToPoseController {
+    config: MoveToPoseConfig,
+}
+
+impl MoveToPoseController {
+    pub fn new(config: MoveToPoseConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn config(&self) -> MoveToPoseConfig {
+        self.config
+    }
+
+    pub fn simulate(&self, start: Pose2D, goal: Pose2D) -> MoveToPoseResult {
+        let mut pose = start;
+        let mut steps = vec![MoveToPoseStep {
+            pose,
+            control: ControlInput::zero(),
+            distance_to_goal: distance_to_goal(pose, goal),
+        }];
+
+        for _ in 0..self.config.max_steps {
+            let distance = distance_to_goal(pose, goal);
+            let yaw_error = normalize_angle(goal.yaw - pose.yaw).abs();
+            if distance <= self.config.goal_tolerance && yaw_error <= self.config.yaw_tolerance {
+                return MoveToPoseResult {
+                    steps,
+                    converged: true,
+                };
+            }
+
+            let control = self.compute_control(pose, goal);
+            pose = integrate_pose(pose, control, self.config.dt);
+            steps.push(MoveToPoseStep {
+                pose,
+                control,
+                distance_to_goal: distance_to_goal(pose, goal),
+            });
+        }
+
+        MoveToPoseResult {
+            steps,
+            converged: false,
+        }
+    }
+
+    pub fn planning(
+        &self,
+        start: (f64, f64, f64),
+        goal: (f64, f64, f64),
+    ) -> Vec<(f64, f64)> {
+        self.simulate(
+            Pose2D::new(start.0, start.1, start.2),
+            Pose2D::new(goal.0, goal.1, goal.2),
+        )
+        .path()
+        .points
+        .into_iter()
+        .map(|point| (point.x, point.y))
+        .collect()
+    }
+
+    fn compute_control(&self, pose: Pose2D, goal: Pose2D) -> ControlInput {
+        let x_diff = goal.x - pose.x;
+        let y_diff = goal.y - pose.y;
+        let rho = (x_diff.powi(2) + y_diff.powi(2)).sqrt();
+        let alpha = normalize_angle(y_diff.atan2(x_diff) - pose.yaw);
+        let beta = normalize_angle(goal.yaw - pose.yaw - alpha);
+
+        let mut v = self.config.kp_rho * rho;
+        if !(-PI / 2.0..=PI / 2.0).contains(&alpha) {
+            v = -v;
+        }
+
+        let omega = self.config.kp_alpha * alpha + self.config.kp_beta * beta;
+        ControlInput::new(v, omega)
+    }
+}
+
+pub fn move_to_pose(start: Pose2D, goal: Pose2D, config: MoveToPoseConfig) -> MoveToPoseResult {
+    MoveToPoseController::new(config).simulate(start, goal)
+}
+
+pub fn normalize_angle(mut angle: f64) -> f64 {
     while angle > PI {
         angle -= 2.0 * PI;
     }
@@ -43,44 +161,67 @@ fn normalize_angle(mut angle: f64) -> f64 {
     angle
 }
 
-fn main() {
-    // Create output directory
-    std::fs::create_dir_all("img/path_tracking").unwrap();
+fn integrate_pose(pose: Pose2D, control: ControlInput, dt: f64) -> Pose2D {
+    let yaw = normalize_angle(pose.yaw + control.omega * dt);
+    Pose2D::new(
+        pose.x + control.v * yaw.cos() * dt,
+        pose.y + control.v * yaw.sin() * dt,
+        yaw,
+    )
+}
 
-    let x_start = (0.0, 0.0, 0.0);
-    let x_goal = (10.0, 10.0, -1.5 * PI);
-    // [kp_rho, kp_alpha, kp_beta]
-    let kp = (9. , 15., -3.);
-    let dt = 0.01;
-    let x_traj = move_to_pose(x_start, x_goal, kp, dt);
+fn distance_to_goal(pose: Pose2D, goal: Pose2D) -> f64 {
+    ((goal.x - pose.x).powi(2) + (goal.y - pose.y).powi(2)).sqrt()
+}
+
+pub fn demo_move_to_pose() {
+    std::fs::create_dir_all("img/path_tracking").unwrap_or_default();
+
+    let start = Pose2D::origin();
+    let goal = Pose2D::new(10.0, 10.0, -1.5 * PI);
+    let result = move_to_pose(start, goal, MoveToPoseConfig::default());
+    let path = result.path();
 
     println!("Starting Move to Pose...");
-    
+    println!(
+        "Converged: {}, iterations: {}, final pose: ({:.3}, {:.3}, {:.3})",
+        result.converged,
+        result.iterations(),
+        result.final_pose().x,
+        result.final_pose().y,
+        result.final_pose().yaw
+    );
+
     let mut fg = Figure::new();
     {
-        let axes = fg.axes2d()
+        let axes = fg
+            .axes2d()
             .set_title("Move to Pose", &[])
             .set_x_label("x [m]", &[])
             .set_y_label("y [m]", &[])
             .set_aspect_ratio(gnuplot::AutoOption::Fix(1.0));
 
-        // Plot trajectory
-        let traj_x: Vec<f64> = x_traj.iter().map(|p| p.0).collect();
-        let traj_y: Vec<f64> = x_traj.iter().map(|p| p.1).collect();
+        let traj_x = path.x_coords();
+        let traj_y = path.y_coords();
         axes.lines(&traj_x, &traj_y, &[Caption("Trajectory"), Color("green")]);
+        axes.points(&[start.x], &[start.y], &[Caption("Start"), Color("blue")]);
+        axes.points(&[goal.x], &[goal.y], &[Caption("Goal"), Color("red")]);
 
-        // Plot start and goal positions
-        axes.points(&[x_start.0], &[x_start.1], &[Caption("Start"), Color("blue")]);
-        axes.points(&[x_goal.0], &[x_goal.1], &[Caption("Goal"), Color("red")]);
-        
-        // Plot orientation arrows
-        let arrow_start_x = vec![x_start.0, x_start.0 + x_start.2.cos()];
-        let arrow_start_y = vec![x_start.1, x_start.1 + x_start.2.sin()];
-        axes.lines(&arrow_start_x, &arrow_start_y, &[Caption("Start Orientation"), Color("blue")]);
-        
-        let arrow_goal_x = vec![x_goal.0, x_goal.0 + x_goal.2.cos()];
-        let arrow_goal_y = vec![x_goal.1, x_goal.1 + x_goal.2.sin()];
-        axes.lines(&arrow_goal_x, &arrow_goal_y, &[Caption("Goal Orientation"), Color("red")]);
+        let arrow_start_x = vec![start.x, start.x + start.yaw.cos()];
+        let arrow_start_y = vec![start.y, start.y + start.yaw.sin()];
+        axes.lines(
+            &arrow_start_x,
+            &arrow_start_y,
+            &[Caption("Start Orientation"), Color("blue")],
+        );
+
+        let arrow_goal_x = vec![goal.x, goal.x + goal.yaw.cos()];
+        let arrow_goal_y = vec![goal.y, goal.y + goal.yaw.sin()];
+        axes.lines(
+            &arrow_goal_x,
+            &arrow_goal_y,
+            &[Caption("Goal Orientation"), Color("red")],
+        );
     }
 
     let output_path = "img/path_tracking/move_to_pose.png";
@@ -88,5 +229,38 @@ fn main() {
     fg.show().unwrap();
     println!("Move to pose visualization saved to: {}", output_path);
     println!("Move to Pose complete!");
+}
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_angle_wraps_to_pi_range() {
+        let wrapped = normalize_angle(3.5 * PI);
+        assert!((-PI..=PI).contains(&wrapped));
+    }
+
+    #[test]
+    fn test_move_to_pose_converges() {
+        let start = Pose2D::origin();
+        let goal = Pose2D::new(5.0, 5.0, -PI / 2.0);
+
+        let result = move_to_pose(start, goal, MoveToPoseConfig::default());
+        let final_pose = result.final_pose();
+
+        assert!(result.converged);
+        assert!((final_pose.x - goal.x).abs() < 0.05);
+        assert!((final_pose.y - goal.y).abs() < 0.05);
+        assert!(normalize_angle(final_pose.yaw - goal.yaw).abs() < 0.05);
+    }
+
+    #[test]
+    fn test_move_to_pose_returns_non_empty_path() {
+        let controller = MoveToPoseController::new(MoveToPoseConfig::default());
+        let path = controller.planning((0.0, 0.0, 0.0), (2.0, 1.0, 0.0));
+
+        assert!(path.len() > 1);
+        assert_eq!(path.first().copied(), Some((0.0, 0.0)));
+    }
 }

--- a/src/path_tracking/move_to_pose.rs
+++ b/src/path_tracking/move_to_pose.rs
@@ -114,11 +114,7 @@ impl MoveToPoseController {
         }
     }
 
-    pub fn planning(
-        &self,
-        start: (f64, f64, f64),
-        goal: (f64, f64, f64),
-    ) -> Vec<(f64, f64)> {
+    pub fn planning(&self, start: (f64, f64, f64), goal: (f64, f64, f64)) -> Vec<(f64, f64)> {
         self.simulate(
             Pose2D::new(start.0, start.1, start.2),
             Pose2D::new(goal.0, goal.1, goal.2),

--- a/src/path_tracking/mpc.rs
+++ b/src/path_tracking/mpc.rs
@@ -6,8 +6,8 @@
 // Note: This is a simplified MPC implementation without a QP solver.
 // Uses iterative linearization and gradient descent.
 
-use nalgebra::{Matrix4, Vector4, Matrix4x2, Vector2, DMatrix, DVector};
-use gnuplot::{Figure, Caption, Color, AxesCommon, PointSymbol, PointSize};
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
+use nalgebra::{DMatrix, DVector, Matrix4, Matrix4x2, Vector2, Vector4};
 use std::f64::consts::PI;
 
 // Vehicle parameters
@@ -87,21 +87,41 @@ fn angle_diff(a: f64, b: f64) -> f64 {
 }
 
 /// Get linearized state-space matrices at operating point
-fn get_linear_model_matrix(v: f64, phi: f64, delta: f64) -> (Matrix4<f64>, Matrix4x2<f64>, Vector4<f64>) {
+fn get_linear_model_matrix(
+    v: f64,
+    phi: f64,
+    delta: f64,
+) -> (Matrix4<f64>, Matrix4x2<f64>, Vector4<f64>) {
     // A matrix (state transition)
     let a = Matrix4::new(
-        1.0, 0.0, DT * phi.cos(), -DT * v * phi.sin(),
-        0.0, 1.0, DT * phi.sin(), DT * v * phi.cos(),
-        0.0, 0.0, 1.0, 0.0,
-        0.0, 0.0, DT * delta.tan() / WB, 1.0,
+        1.0,
+        0.0,
+        DT * phi.cos(),
+        -DT * v * phi.sin(),
+        0.0,
+        1.0,
+        DT * phi.sin(),
+        DT * v * phi.cos(),
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        DT * delta.tan() / WB,
+        1.0,
     );
 
     // B matrix (control input)
     let b = Matrix4x2::new(
-        0.0, 0.0,
-        0.0, 0.0,
-        DT, 0.0,
-        0.0, DT * v / (WB * delta.cos().powi(2)),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        DT,
+        0.0,
+        0.0,
+        DT * v / (WB * delta.cos().powi(2)),
     );
 
     // C vector (constant term for linearization offset)
@@ -155,7 +175,13 @@ impl CubicSpline1D {
             d[j] = (c[j + 1] - c[j]) / (3.0 * h[j]);
         }
 
-        CubicSpline1D { x: x.to_vec(), a, b, c, d }
+        CubicSpline1D {
+            x: x.to_vec(),
+            a,
+            b,
+            c,
+            d,
+        }
     }
 
     fn calc(&self, t: f64) -> f64 {
@@ -218,7 +244,11 @@ impl CubicSpline2D {
 }
 
 /// Calculate reference trajectory for MPC horizon
-fn calc_ref_trajectory(state: &State, csp: &CubicSpline2D, ref_s: &mut f64) -> (Vec<Vector4<f64>>, Vec<f64>) {
+fn calc_ref_trajectory(
+    state: &State,
+    csp: &CubicSpline2D,
+    ref_s: &mut f64,
+) -> (Vec<Vector4<f64>>, Vec<f64>) {
     let mut xref = Vec::with_capacity(T + 1);
     let mut sref = Vec::with_capacity(T + 1);
 
@@ -254,11 +284,7 @@ fn calc_ref_trajectory(state: &State, csp: &CubicSpline2D, ref_s: &mut f64) -> (
 }
 
 /// Simplified MPC solver using gradient descent
-fn mpc_solve(
-    state: &State,
-    xref: &[Vector4<f64>],
-    u_prev: &[Vector2<f64>],
-) -> Vec<Vector2<f64>> {
+fn mpc_solve(state: &State, xref: &[Vector4<f64>], u_prev: &[Vector2<f64>]) -> Vec<Vector2<f64>> {
     let mut u = u_prev.to_vec();
     if u.len() < T {
         u.resize(T, Vector2::zeros());
@@ -300,10 +326,12 @@ fn mpc_solve(
             // Control rate penalty
             let mut grad_rate = Vector2::zeros();
             if i > 0 {
-                grad_rate += nalgebra::Matrix2::from_diagonal(&Vector2::new(RD[0], RD[1])) * (u[i] - u[i - 1]);
+                grad_rate += nalgebra::Matrix2::from_diagonal(&Vector2::new(RD[0], RD[1]))
+                    * (u[i] - u[i - 1]);
             }
             if i < T - 1 {
-                grad_rate -= nalgebra::Matrix2::from_diagonal(&Vector2::new(RD[0], RD[1])) * (u[i + 1] - u[i]);
+                grad_rate -= nalgebra::Matrix2::from_diagonal(&Vector2::new(RD[0], RD[1]))
+                    * (u[i + 1] - u[i]);
             }
 
             du[i] = grad_state + grad_control + grad_rate;
@@ -412,15 +440,36 @@ fn main() {
             }
 
             fig.axes2d()
-                .set_title(&format!("MPC Path Tracking - Speed: {:.2} m/s", state.v), &[])
+                .set_title(
+                    &format!("MPC Path Tracking - Speed: {:.2} m/s", state.v),
+                    &[],
+                )
                 .set_x_label("x [m]", &[])
                 .set_y_label("y [m]", &[])
                 .set_aspect_ratio(gnuplot::AutoOption::Fix(1.0))
                 .lines(&cx, &cy, &[Caption("Reference"), Color("gray")])
                 .lines(&hist_x, &hist_y, &[Caption("Trajectory"), Color("blue")])
                 .lines(&pred_x, &pred_y, &[Caption("Prediction"), Color("green")])
-                .points(&[state.x], &[state.y], &[Caption("Vehicle"), Color("red"), PointSymbol('*'), PointSize(3.0)])
-                .points(&[goal_x], &[goal_y], &[Caption("Goal"), Color("magenta"), PointSymbol('O'), PointSize(2.0)]);
+                .points(
+                    &[state.x],
+                    &[state.y],
+                    &[
+                        Caption("Vehicle"),
+                        Color("red"),
+                        PointSymbol('*'),
+                        PointSize(3.0),
+                    ],
+                )
+                .points(
+                    &[goal_x],
+                    &[goal_y],
+                    &[
+                        Caption("Goal"),
+                        Color("magenta"),
+                        PointSymbol('O'),
+                        PointSize(2.0),
+                    ],
+                );
 
             fig.show_and_keep_running().unwrap();
         }
@@ -445,9 +494,19 @@ fn main() {
         .set_aspect_ratio(gnuplot::AutoOption::Fix(1.0))
         .lines(&cx, &cy, &[Caption("Reference"), Color("gray")])
         .lines(&hist_x, &hist_y, &[Caption("Trajectory"), Color("blue")])
-        .points(&[goal_x], &[goal_y], &[Caption("Goal"), Color("magenta"), PointSymbol('O'), PointSize(2.0)]);
+        .points(
+            &[goal_x],
+            &[goal_y],
+            &[
+                Caption("Goal"),
+                Color("magenta"),
+                PointSymbol('O'),
+                PointSize(2.0),
+            ],
+        );
 
-    fig.save_to_svg("./img/path_tracking/mpc.svg", 640, 480).unwrap();
+    fig.save_to_svg("./img/path_tracking/mpc.svg", 640, 480)
+        .unwrap();
     println!("Plot saved to ./img/path_tracking/mpc.svg");
 
     println!("Done!");

--- a/src/path_tracking/mpc.rs
+++ b/src/path_tracking/mpc.rs
@@ -49,7 +49,7 @@ impl State {
         State { x, y, v, yaw }
     }
 
-    fn to_vector(&self) -> Vector4<f64> {
+    fn to_vector(self) -> Vector4<f64> {
         Vector4::new(self.x, self.y, self.v, self.yaw)
     }
 
@@ -300,7 +300,7 @@ fn mpc_solve(state: &State, xref: &[Vector4<f64>], u_prev: &[Vector2<f64>]) -> V
         }
 
         // Backward pass - compute gradients
-        let mut du = vec![Vector2::zeros(); T];
+        let mut du = [Vector2::zeros(); T];
 
         for i in 0..T {
             // Calculate state error with proper angle wrapping for yaw
@@ -417,7 +417,7 @@ fn main() {
         hist_v.push(state.v);
 
         // Visualization
-        if SHOW_ANIMATION && hist_x.len() % 5 == 0 {
+        if SHOW_ANIMATION && hist_x.len().is_multiple_of(5) {
             fig.clear_axes();
 
             // Predicted trajectory

--- a/src/path_tracking/mpc.rs
+++ b/src/path_tracking/mpc.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::needless_borrows_for_generic_args)]
+
 // Model Predictive Control (MPC) for path tracking
 // author: Atsushi Sakai (@Atsushi_twi)
 //         Ryohei Sasaki (@rsasaki0109)
@@ -7,7 +9,7 @@
 // Uses iterative linearization and gradient descent.
 
 use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
-use nalgebra::{DMatrix, DVector, Matrix4, Matrix4x2, Vector2, Vector4};
+use nalgebra::{Matrix4, Matrix4x2, Vector2, Vector4};
 use std::f64::consts::PI;
 
 // Vehicle parameters
@@ -19,8 +21,6 @@ const MIN_SPEED: f64 = -20.0 / 3.6; // min speed (reverse) [m/s]
 const MAX_ACCEL: f64 = 1.0; // max acceleration [m/ss]
 
 // MPC parameters
-const NX: usize = 4; // state dimension [x, y, v, yaw]
-const NU: usize = 2; // control dimension [accel, steer]
 const T: usize = 5; // prediction horizon
 const DT: f64 = 0.2; // time step [s]
 
@@ -51,10 +51,6 @@ impl State {
 
     fn to_vector(&self) -> Vector4<f64> {
         Vector4::new(self.x, self.y, self.v, self.yaw)
-    }
-
-    fn from_vector(v: &Vector4<f64>) -> Self {
-        State::new(v[0], v[1], v[2], v[3])
     }
 
     /// Update state using bicycle model
@@ -147,7 +143,7 @@ struct CubicSpline1D {
 impl CubicSpline1D {
     fn new(x: &[f64], y: &[f64]) -> Self {
         let n = x.len();
-        let mut a = y.to_vec();
+        let a = y.to_vec();
         let mut b = vec![0.0; n];
         let mut c = vec![0.0; n];
         let mut d = vec![0.0; n];
@@ -235,11 +231,6 @@ impl CubicSpline2D {
         let dx = self.sx.calc_d(s);
         let dy = self.sy.calc_d(s);
         dy.atan2(dx)
-    }
-
-    fn calc_curvature(&self, _s: f64) -> f64 {
-        // Simplified curvature calculation
-        0.0
     }
 }
 
@@ -451,8 +442,8 @@ fn main() {
                 .lines(&hist_x, &hist_y, &[Caption("Trajectory"), Color("blue")])
                 .lines(&pred_x, &pred_y, &[Caption("Prediction"), Color("green")])
                 .points(
-                    &[state.x],
-                    &[state.y],
+                    [state.x],
+                    [state.y],
                     &[
                         Caption("Vehicle"),
                         Color("red"),
@@ -461,8 +452,8 @@ fn main() {
                     ],
                 )
                 .points(
-                    &[goal_x],
-                    &[goal_y],
+                    [goal_x],
+                    [goal_y],
                     &[
                         Caption("Goal"),
                         Color("magenta"),
@@ -495,8 +486,8 @@ fn main() {
         .lines(&cx, &cy, &[Caption("Reference"), Color("gray")])
         .lines(&hist_x, &hist_y, &[Caption("Trajectory"), Color("blue")])
         .points(
-            &[goal_x],
-            &[goal_y],
+            [goal_x],
+            [goal_y],
             &[
                 Caption("Goal"),
                 Color("magenta"),

--- a/src/path_tracking/pure_pursuit.rs
+++ b/src/path_tracking/pure_pursuit.rs
@@ -3,7 +3,7 @@
 //! A geometric path tracking controller that computes the steering angle
 //! to follow a reference path by looking ahead to a target point.
 
-use crate::common::{Point2D, Path2D, State2D, ControlInput, PathTracker};
+use crate::common::{ControlInput, Path2D, PathTracker, Point2D, State2D};
 
 /// Vehicle state for Pure Pursuit
 #[derive(Debug, Clone, Copy)]
@@ -21,7 +21,15 @@ impl VehicleState {
     pub fn new(x: f64, y: f64, yaw: f64, v: f64, wheelbase: f64) -> Self {
         let rear_x = x - (wheelbase / 2.0) * yaw.cos();
         let rear_y = y - (wheelbase / 2.0) * yaw.sin();
-        VehicleState { x, y, yaw, v, rear_x, rear_y, wheelbase }
+        VehicleState {
+            x,
+            y,
+            yaw,
+            v,
+            rear_x,
+            rear_y,
+            wheelbase,
+        }
     }
 
     pub fn update(&mut self, a: f64, delta: f64, dt: f64) {
@@ -151,16 +159,12 @@ impl PurePursuitController {
             Some(prev_idx) => {
                 // Search from previous index
                 let mut idx = prev_idx;
-                let mut dist = state.calc_distance(
-                    self.path.points[idx].x,
-                    self.path.points[idx].y
-                );
+                let mut dist =
+                    state.calc_distance(self.path.points[idx].x, self.path.points[idx].y);
 
                 while idx + 1 < self.path.len() {
-                    let next_dist = state.calc_distance(
-                        self.path.points[idx + 1].x,
-                        self.path.points[idx + 1].y
-                    );
+                    let next_dist = state
+                        .calc_distance(self.path.points[idx + 1].x, self.path.points[idx + 1].y);
                     if dist < next_dist {
                         break;
                     }
@@ -208,15 +212,18 @@ impl PurePursuitController {
     }
 
     /// Simulate path tracking (legacy interface)
-    pub fn planning(&mut self, waypoints: Vec<(f64, f64)>, target_speed: f64) -> Option<Vec<(f64, f64)>> {
+    pub fn planning(
+        &mut self,
+        waypoints: Vec<(f64, f64)>,
+        target_speed: f64,
+    ) -> Option<Vec<(f64, f64)>> {
         if waypoints.len() < 2 {
             return None;
         }
 
         // Set path
-        let path = Path2D::from_points(
-            waypoints.iter().map(|&(x, y)| Point2D::new(x, y)).collect()
-        );
+        let path =
+            Path2D::from_points(waypoints.iter().map(|&(x, y)| Point2D::new(x, y)).collect());
         self.set_path(path);
 
         // Initial state
@@ -226,7 +233,7 @@ impl PurePursuitController {
             init_pos.y - 3.0,
             0.0,
             0.0,
-            self.config.wheelbase
+            self.config.wheelbase,
         );
 
         let mut trajectory = vec![(state.x, state.y)];
@@ -263,7 +270,7 @@ impl PathTracker for PurePursuitController {
             current_state.y,
             current_state.yaw,
             current_state.v,
-            self.config.wheelbase
+            self.config.wheelbase,
         );
 
         let delta = self.compute_steering(&vehicle_state);
@@ -311,9 +318,7 @@ mod tests {
     #[test]
     fn test_pure_pursuit_planning() {
         let mut controller = PurePursuitController::with_params(0.1, 2.0, 2.9);
-        let waypoints: Vec<(f64, f64)> = (0..10)
-            .map(|i| (i as f64 * 2.0, 0.0))
-            .collect();
+        let waypoints: Vec<(f64, f64)> = (0..10).map(|i| (i as f64 * 2.0, 0.0)).collect();
 
         let result = controller.planning(waypoints, 5.0);
         assert!(result.is_some());

--- a/src/path_tracking/pure_pursuit.rs
+++ b/src/path_tracking/pure_pursuit.rs
@@ -322,6 +322,6 @@ mod tests {
 
         let result = controller.planning(waypoints, 5.0);
         assert!(result.is_some());
-        assert!(result.unwrap().len() > 0);
+        assert!(!result.unwrap().is_empty());
     }
 }

--- a/src/path_tracking/rear_wheel_feedback.rs
+++ b/src/path_tracking/rear_wheel_feedback.rs
@@ -8,8 +8,8 @@
 //!     - B. Paden, M. Čáp, S. Z. Yong, D. Yershov and E. Frazzoli,
 //!       "A Survey of Motion Planning and Control Techniques Adopted in Self-Driving Vehicles"
 
+use crate::common::{ControlInput, Path2D, PathTracker, Point2D, State2D};
 use std::f64::consts::PI;
-use crate::common::{Point2D, Path2D, State2D, ControlInput, PathTracker};
 
 /// Vehicle state for Rear Wheel Feedback Controller
 #[derive(Debug, Clone, Copy)]
@@ -23,7 +23,13 @@ pub struct VehicleState {
 
 impl VehicleState {
     pub fn new(x: f64, y: f64, yaw: f64, v: f64, wheelbase: f64) -> Self {
-        VehicleState { x, y, yaw, v, wheelbase }
+        VehicleState {
+            x,
+            y,
+            yaw,
+            v,
+            wheelbase,
+        }
     }
 
     /// Update vehicle state using bicycle model kinematics
@@ -277,16 +283,24 @@ impl RearWheelFeedbackController {
         let v_abs = v.abs().max(0.1); // Avoid division by zero
 
         // Handle small heading errors to avoid numerical issues
-        let th_e_safe = if th_e.abs() < 1e-6 { 1e-6 * th_e.signum().max(1.0) } else { th_e };
+        let th_e_safe = if th_e.abs() < 1e-6 {
+            1e-6 * th_e.signum().max(1.0)
+        } else {
+            th_e
+        };
 
         // Rear wheel feedback control formula
         // omega = v * k * cos(th_e) / (1.0 - k * e) - KTH * |v| * th_e - KE * v * sin(th_e) * e / th_e
         let denom = 1.0 - k * e;
-        let denom_safe = if denom.abs() < 0.01 { 0.01 * denom.signum().max(1.0) } else { denom };
+        let denom_safe = if denom.abs() < 0.01 {
+            0.01 * denom.signum().max(1.0)
+        } else {
+            denom
+        };
 
         let omega = v * k * th_e.cos() / denom_safe
-                  - self.config.kth * v_abs * th_e
-                  - self.config.ke * v * th_e.sin() * e / th_e_safe;
+            - self.config.kth * v_abs * th_e
+            - self.config.ke * v * th_e.sin() * e / th_e_safe;
 
         // Compute steering angle
         // delta = atan2(L * omega, v)
@@ -317,7 +331,12 @@ impl RearWheelFeedbackController {
     }
 
     /// Legacy planning interface - simulate path tracking
-    pub fn planning(&mut self, waypoints: Vec<(f64, f64)>, target_speed: f64, ds: f64) -> Option<Vec<(f64, f64)>> {
+    pub fn planning(
+        &mut self,
+        waypoints: Vec<(f64, f64)>,
+        target_speed: f64,
+        ds: f64,
+    ) -> Option<Vec<(f64, f64)>> {
         if waypoints.len() < 2 {
             return None;
         }
@@ -329,7 +348,10 @@ impl RearWheelFeedbackController {
 
         // Set path
         let path = Path2D::from_points(
-            cx.iter().zip(cy.iter()).map(|(&x, &y)| Point2D::new(x, y)).collect()
+            cx.iter()
+                .zip(cy.iter())
+                .map(|(&x, &y)| Point2D::new(x, y))
+                .collect(),
         );
         self.set_path_with_info(path, cyaw, ck);
 
@@ -400,7 +422,11 @@ impl PathTracker for RearWheelFeedbackController {
 
 // Cubic spline helper functions for path generation
 
-fn calc_spline_course(x: &[f64], y: &[f64], ds: f64) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
+fn calc_spline_course(
+    x: &[f64],
+    y: &[f64],
+    ds: f64,
+) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
     let sp = CubicSpline2D::new(x, y);
     let mut s = 0.0;
     let mut course_x = Vec::new();
@@ -471,7 +497,13 @@ impl CubicSpline {
             d[j] = (c[j + 1] - c[j]) / (3.0 * h[j]);
         }
 
-        CubicSpline { a, b, c, d, x: x.to_vec() }
+        CubicSpline {
+            a,
+            b,
+            c,
+            d,
+            x: x.to_vec(),
+        }
     }
 
     fn calc(&self, t: f64) -> f64 {
@@ -658,17 +690,17 @@ mod tests {
         // With positive lateral error and positive heading error,
         // the controller should apply negative steering (turn right)
         // to both correct heading and move back toward the path
-        assert!(steering < 0.0, "Steering should be negative to correct errors, got: {}", steering);
+        assert!(
+            steering < 0.0,
+            "Steering should be negative to correct errors, got: {}",
+            steering
+        );
     }
 
     #[test]
     fn test_rear_wheel_feedback_planning() {
         let mut controller = RearWheelFeedbackController::with_params(1.0, 0.5, 2.9);
-        let waypoints = vec![
-            (0.0, 0.0),
-            (50.0, 0.0),
-            (100.0, 0.0),
-        ];
+        let waypoints = vec![(0.0, 0.0), (50.0, 0.0), (100.0, 0.0)];
 
         let result = controller.planning(waypoints, 5.0, 0.5);
         assert!(result.is_some());
@@ -678,12 +710,7 @@ mod tests {
     #[test]
     fn test_rear_wheel_feedback_curved_path() {
         let mut controller = RearWheelFeedbackController::with_params(1.0, 0.5, 2.9);
-        let waypoints = vec![
-            (0.0, 0.0),
-            (10.0, 0.0),
-            (20.0, 5.0),
-            (30.0, 10.0),
-        ];
+        let waypoints = vec![(0.0, 0.0), (10.0, 0.0), (20.0, 5.0), (30.0, 10.0)];
 
         let result = controller.planning(waypoints, 3.0, 0.5);
         assert!(result.is_some());

--- a/src/path_tracking/rear_wheel_feedback.rs
+++ b/src/path_tracking/rear_wheel_feedback.rs
@@ -422,11 +422,7 @@ impl PathTracker for RearWheelFeedbackController {
 
 // Cubic spline helper functions for path generation
 
-fn calc_spline_course(
-    x: &[f64],
-    y: &[f64],
-    ds: f64,
-) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
+fn calc_spline_course(x: &[f64], y: &[f64], ds: f64) -> SplineCourse {
     let sp = CubicSpline2D::new(x, y);
     let mut s = 0.0;
     let mut course_x = Vec::new();
@@ -459,6 +455,8 @@ struct CubicSpline {
     x: Vec<f64>,
 }
 
+type SplineCourse = (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>);
+
 impl CubicSpline {
     fn new(x: &[f64], y: &[f64]) -> Self {
         let n = x.len();
@@ -472,9 +470,7 @@ impl CubicSpline {
         let mut c = vec![0.0; n];
         let mut d = vec![0.0; n];
 
-        for i in 0..n {
-            a[i] = y[i];
-        }
+        a[..n].copy_from_slice(&y[..n]);
 
         let mut alpha = vec![0.0; n - 1];
         for i in 1..n - 1 {

--- a/src/path_tracking/stanley_controller.rs
+++ b/src/path_tracking/stanley_controller.rs
@@ -312,11 +312,7 @@ impl PathTracker for StanleyController {
 
 // Cubic spline helper functions for legacy interface
 
-fn calc_spline_course(
-    x: &[f64],
-    y: &[f64],
-    ds: f64,
-) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
+fn calc_spline_course(x: &[f64], y: &[f64], ds: f64) -> SplineCourse {
     let sp = CubicSpline2D::new(x, y);
     let mut s = 0.0;
     let mut course_x = Vec::new();
@@ -349,6 +345,8 @@ struct CubicSpline {
     x: Vec<f64>,
 }
 
+type SplineCourse = (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>);
+
 impl CubicSpline {
     fn new(x: &[f64], y: &[f64]) -> Self {
         let n = x.len();
@@ -362,9 +360,7 @@ impl CubicSpline {
         let mut c = vec![0.0; n];
         let mut d = vec![0.0; n];
 
-        for i in 0..n {
-            a[i] = y[i];
-        }
+        a[..n].copy_from_slice(&y[..n]);
 
         let mut alpha = vec![0.0; n - 1];
         for i in 1..n - 1 {
@@ -533,6 +529,6 @@ mod tests {
 
         let result = controller.planning(waypoints, 5.0, 0.5);
         assert!(result.is_some());
-        assert!(result.unwrap().len() > 0);
+        assert!(!result.unwrap().is_empty());
     }
 }

--- a/src/path_tracking/stanley_controller.rs
+++ b/src/path_tracking/stanley_controller.rs
@@ -7,8 +7,8 @@
 //!     - [Stanley: The robot that won the DARPA grand challenge](http://isl.ecst.csuchico.edu/DOCS/darpa2005/DARPA%202005%20Stanley.pdf)
 //!     - [Autonomous Automobile Path Tracking](https://www.ri.cmu.edu/pub_files/2009/2/Automatic_Steering_Methods_for_Autonomous_Automobile_Path_Tracking.pdf)
 
+use crate::common::{ControlInput, Path2D, PathTracker, Point2D, State2D};
 use std::f64::consts::PI;
-use crate::common::{Point2D, Path2D, State2D, ControlInput, PathTracker};
 
 /// Vehicle state for Stanley Controller
 #[derive(Debug, Clone, Copy)]
@@ -22,7 +22,13 @@ pub struct VehicleState {
 
 impl VehicleState {
     pub fn new(x: f64, y: f64, yaw: f64, v: f64, wheelbase: f64) -> Self {
-        VehicleState { x, y, yaw, v, wheelbase }
+        VehicleState {
+            x,
+            y,
+            yaw,
+            v,
+            wheelbase,
+        }
     }
 
     pub fn update(&mut self, a: f64, delta: f64, dt: f64) {
@@ -172,8 +178,8 @@ impl StanleyController {
         let target_point = &self.path.points[min_idx];
         let diff_x = fx - target_point.x;
         let diff_y = fy - target_point.y;
-        let error_front_axle = -(state.yaw + 0.5 * PI).cos() * diff_x
-            - (state.yaw + 0.5 * PI).sin() * diff_y;
+        let error_front_axle =
+            -(state.yaw + 0.5 * PI).cos() * diff_x - (state.yaw + 0.5 * PI).sin() * diff_y;
 
         (min_idx, error_front_axle)
     }
@@ -214,7 +220,12 @@ impl StanleyController {
     }
 
     /// Legacy planning interface
-    pub fn planning(&mut self, waypoints: Vec<(f64, f64)>, target_speed: f64, ds: f64) -> Option<Vec<(f64, f64)>> {
+    pub fn planning(
+        &mut self,
+        waypoints: Vec<(f64, f64)>,
+        target_speed: f64,
+        ds: f64,
+    ) -> Option<Vec<(f64, f64)>> {
         if waypoints.len() < 2 {
             return None;
         }
@@ -226,7 +237,10 @@ impl StanleyController {
 
         // Set path
         let path = Path2D::from_points(
-            cx.iter().zip(cy.iter()).map(|(&x, &y)| Point2D::new(x, y)).collect()
+            cx.iter()
+                .zip(cy.iter())
+                .map(|(&x, &y)| Point2D::new(x, y))
+                .collect(),
         );
         self.set_path_with_yaw(path, cyaw);
 
@@ -298,7 +312,11 @@ impl PathTracker for StanleyController {
 
 // Cubic spline helper functions for legacy interface
 
-fn calc_spline_course(x: &[f64], y: &[f64], ds: f64) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
+fn calc_spline_course(
+    x: &[f64],
+    y: &[f64],
+    ds: f64,
+) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
     let sp = CubicSpline2D::new(x, y);
     let mut s = 0.0;
     let mut course_x = Vec::new();
@@ -369,7 +387,13 @@ impl CubicSpline {
             d[j] = (c[j + 1] - c[j]) / (3.0 * h[j]);
         }
 
-        CubicSpline { a, b, c, d, x: x.to_vec() }
+        CubicSpline {
+            a,
+            b,
+            c,
+            d,
+            x: x.to_vec(),
+        }
     }
 
     fn calc(&self, t: f64) -> f64 {
@@ -505,11 +529,7 @@ mod tests {
     #[test]
     fn test_stanley_planning() {
         let mut controller = StanleyController::with_params(0.5, 2.9);
-        let waypoints = vec![
-            (0.0, 0.0),
-            (50.0, 0.0),
-            (100.0, 0.0),
-        ];
+        let waypoints = vec![(0.0, 0.0), (50.0, 0.0), (100.0, 0.0)];
 
         let result = controller.planning(waypoints, 5.0, 0.5);
         assert!(result.is_some());

--- a/src/slam/ekf_slam.rs
+++ b/src/slam/ekf_slam.rs
@@ -115,17 +115,19 @@ fn jacob_motion(x: &Vector3<f64>, u: &Vector2<f64>) -> (Matrix3<f64>, nalgebra::
 
     // Jacobian with respect to state (G matrix)
     let g = Matrix3::new(
-        1.0, 0.0, -DT * v * yaw.sin(),
-        0.0, 1.0, DT * v * yaw.cos(),
-        0.0, 0.0, 1.0,
+        1.0,
+        0.0,
+        -DT * v * yaw.sin(),
+        0.0,
+        1.0,
+        DT * v * yaw.cos(),
+        0.0,
+        0.0,
+        1.0,
     );
 
     // Jacobian with respect to control (V matrix): 3x2
-    let v_mat = nalgebra::Matrix3x2::new(
-        DT * yaw.cos(), 0.0,
-        DT * yaw.sin(), 0.0,
-        0.0, DT,
-    );
+    let v_mat = nalgebra::Matrix3x2::new(DT * yaw.cos(), 0.0, DT * yaw.sin(), 0.0, 0.0, DT);
 
     (g, v_mat)
 }
@@ -150,16 +152,10 @@ fn jacob_observation(
     let d = d2.sqrt();
 
     // Jacobian with respect to robot pose [x, y, yaw]
-    let h_robot = nalgebra::Matrix2x3::new(
-        -dx / d, -dy / d, 0.0,
-        dy / d2, -dx / d2, -1.0,
-    );
+    let h_robot = nalgebra::Matrix2x3::new(-dx / d, -dy / d, 0.0, dy / d2, -dx / d2, -1.0);
 
     // Jacobian with respect to landmark position [lm_x, lm_y]
-    let h_lm = Matrix2::new(
-        dx / d, dy / d,
-        -dy / d2, dx / d2,
-    );
+    let h_lm = Matrix2::new(dx / d, dy / d, -dy / d2, dx / d2);
 
     (h_robot, h_lm)
 }
@@ -278,10 +274,13 @@ fn calc_innovation(
 
     // Innovation covariance
     let r = get_r();
-    let s = &h_full * &state.p * h_full.transpose()
-        + DMatrix::from_fn(2, 2, |i, j| r[(i, j)]);
+    let s = &h_full * &state.p * h_full.transpose() + DMatrix::from_fn(2, 2, |i, j| r[(i, j)]);
 
-    (y, Matrix2::new(s[(0, 0)], s[(0, 1)], s[(1, 0)], s[(1, 1)]), h_full)
+    (
+        y,
+        Matrix2::new(s[(0, 0)], s[(0, 1)], s[(1, 0)], s[(1, 1)]),
+        h_full,
+    )
 }
 
 /// Search for corresponding landmark using Mahalanobis distance
@@ -348,16 +347,10 @@ fn add_new_landmark(state: &mut EKFSLAMState, z: &Vector2<f64>) {
     let s = (robot_pose[2] + z[1]).sin();
 
     // G_r: Jacobian w.r.t. robot pose [x, y, yaw]
-    let g_r = nalgebra::Matrix2x3::new(
-        1.0, 0.0, -z[0] * s,
-        0.0, 1.0, z[0] * c,
-    );
+    let g_r = nalgebra::Matrix2x3::new(1.0, 0.0, -z[0] * s, 0.0, 1.0, z[0] * c);
 
     // G_z: Jacobian w.r.t. observation [d, angle]
-    let g_z = Matrix2::new(
-        c, -z[0] * s,
-        s, z[0] * c,
-    );
+    let g_z = Matrix2::new(c, -z[0] * s, s, z[0] * c);
 
     // Initial landmark covariance
     let p_rr = state.p.fixed_view::<3, 3>(0, 0);
@@ -402,7 +395,9 @@ fn ekf_slam_update(state: &mut EKFSLAMState, z: &Vector2<f64>, lm_idx: usize) {
 
     // Kalman gain
     let s_dmatrix = DMatrix::from_fn(2, 2, |i, j| s[(i, j)]);
-    let s_inv = s_dmatrix.try_inverse().unwrap_or_else(|| DMatrix::identity(2, 2));
+    let s_inv = s_dmatrix
+        .try_inverse()
+        .unwrap_or_else(|| DMatrix::identity(2, 2));
     let k = &state.p * h_full.transpose() * s_inv;
 
     // State update
@@ -473,7 +468,7 @@ pub fn ekf_slam_known_correspondences(
         state.x = new_x;
 
         let mut new_p = DMatrix::identity(n, n) * 1e6; // Large initial uncertainty
-        // Copy robot covariance
+                                                       // Copy robot covariance
         for i in 0..STATE_SIZE {
             for j in 0..STATE_SIZE {
                 new_p[(i, j)] = state.p[(i, j)];
@@ -543,7 +538,10 @@ fn get_observations(x_true: &Vector3<f64>, landmarks: &[(f64, f64)]) -> Vec<(f64
 }
 
 /// Simulate observations from true robot pose to landmarks (with IDs - known correspondences)
-fn get_observations_with_id(x_true: &Vector3<f64>, landmarks: &[(f64, f64)]) -> Vec<(f64, f64, usize)> {
+fn get_observations_with_id(
+    x_true: &Vector3<f64>,
+    landmarks: &[(f64, f64)],
+) -> Vec<(f64, f64, usize)> {
     let normal = Normal::new(0.0, 1.0).unwrap();
     let r = get_r();
     let mut z = Vec::new();

--- a/src/slam/ekf_slam.rs
+++ b/src/slam/ekf_slam.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 // EKF SLAM (Extended Kalman Filter SLAM)
 // author: Atsushi Sakai (@Atsushi_twi)
 //         Ryohei Sasaki (@rsasaki0109)
@@ -162,7 +164,7 @@ fn jacob_observation(
 
 /// EKF SLAM prediction step
 fn ekf_slam_predict(state: &mut EKFSLAMState, u: &Vector2<f64>) {
-    let n = state.x.len();
+    let _n = state.x.len();
 
     // Get current robot pose
     let robot_pose = state.get_robot_pose();

--- a/src/slam/fastslam1.rs
+++ b/src/slam/fastslam1.rs
@@ -3,9 +3,9 @@
 //         Ryohei Sasaki (@rsasaki0109)
 //         Rust port
 
-use nalgebra::{Matrix2, Matrix2x3, Matrix3x2, Vector2, Vector3, DMatrix, DVector};
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
+use nalgebra::{DMatrix, DVector, Matrix2, Matrix2x3, Matrix3x2, Vector2, Vector3};
 use rand_distr::{Distribution, Normal, Uniform};
-use gnuplot::{Figure, Caption, Color, AxesCommon, PointSymbol, PointSize};
 use std::f64::consts::PI;
 
 // Simulation parameters
@@ -109,10 +109,7 @@ fn compute_jacobian(particle: &Particle, lm_id: usize) -> Matrix2<f64> {
     let d2 = dx * dx + dy * dy;
     let d = d2.sqrt();
 
-    Matrix2::new(
-        dx / d, dy / d,
-        -dy / d2, dx / d2,
-    )
+    Matrix2::new(dx / d, dy / d, -dy / d2, dx / d2)
 }
 
 /// Process noise covariance
@@ -273,14 +270,14 @@ fn fastslam_update(
 
 /// Get best particle (highest weight)
 fn get_best_particle(particles: &[Particle]) -> &Particle {
-    particles.iter().max_by(|a, b| a.weight.partial_cmp(&b.weight).unwrap()).unwrap()
+    particles
+        .iter()
+        .max_by(|a, b| a.weight.partial_cmp(&b.weight).unwrap())
+        .unwrap()
 }
 
 /// Simulate observations
-fn get_observations(
-    x_true: &Vector3<f64>,
-    landmarks: &[(f64, f64)],
-) -> Vec<(f64, f64, usize)> {
+fn get_observations(x_true: &Vector3<f64>, landmarks: &[(f64, f64)]) -> Vec<(f64, f64, usize)> {
     let normal = Normal::new(0.0, 1.0).unwrap();
     let r = get_r();
     let mut z = Vec::new();
@@ -385,20 +382,53 @@ fn main() {
             let p_y: Vec<f64> = particles.iter().map(|p| p.y).collect();
 
             // Estimated landmark positions from best particle
-            let est_lm_x: Vec<f64> = best.landmarks.iter()
+            let est_lm_x: Vec<f64> = best
+                .landmarks
+                .iter()
                 .filter(|lm| lm.cov[(0, 0)] < 100.0)
-                .map(|lm| lm.x).collect();
-            let est_lm_y: Vec<f64> = best.landmarks.iter()
+                .map(|lm| lm.x)
+                .collect();
+            let est_lm_y: Vec<f64> = best
+                .landmarks
+                .iter()
                 .filter(|lm| lm.cov[(0, 0)] < 100.0)
-                .map(|lm| lm.y).collect();
+                .map(|lm| lm.y)
+                .collect();
 
             fig.axes2d()
                 .set_title("FastSLAM 1.0", &[])
                 .set_x_label("x [m]", &[])
                 .set_y_label("y [m]", &[])
-                .points(&lm_x, &lm_y, &[Caption("True Landmarks"), Color("black"), PointSymbol('*'), PointSize(2.0)])
-                .points(&est_lm_x, &est_lm_y, &[Caption("Est. Landmarks"), Color("cyan"), PointSymbol('O'), PointSize(1.5)])
-                .points(&p_x, &p_y, &[Caption("Particles"), Color("gray"), PointSymbol('.'), PointSize(0.5)])
+                .points(
+                    &lm_x,
+                    &lm_y,
+                    &[
+                        Caption("True Landmarks"),
+                        Color("black"),
+                        PointSymbol('*'),
+                        PointSize(2.0),
+                    ],
+                )
+                .points(
+                    &est_lm_x,
+                    &est_lm_y,
+                    &[
+                        Caption("Est. Landmarks"),
+                        Color("cyan"),
+                        PointSymbol('O'),
+                        PointSize(1.5),
+                    ],
+                )
+                .points(
+                    &p_x,
+                    &p_y,
+                    &[
+                        Caption("Particles"),
+                        Color("gray"),
+                        PointSymbol('.'),
+                        PointSize(0.5),
+                    ],
+                )
                 .lines(&true_x, &true_y, &[Caption("True"), Color("blue")])
                 .lines(&dr_x, &dr_y, &[Caption("Dead Reckoning"), Color("yellow")])
                 .lines(&est_x, &est_y, &[Caption("FastSLAM"), Color("green")]);
@@ -422,23 +452,48 @@ fn main() {
     let lm_y: Vec<f64> = landmarks.iter().map(|p| p.1).collect();
 
     let best = get_best_particle(&particles);
-    let est_lm_x: Vec<f64> = best.landmarks.iter()
+    let est_lm_x: Vec<f64> = best
+        .landmarks
+        .iter()
         .filter(|lm| lm.cov[(0, 0)] < 100.0)
-        .map(|lm| lm.x).collect();
-    let est_lm_y: Vec<f64> = best.landmarks.iter()
+        .map(|lm| lm.x)
+        .collect();
+    let est_lm_y: Vec<f64> = best
+        .landmarks
+        .iter()
         .filter(|lm| lm.cov[(0, 0)] < 100.0)
-        .map(|lm| lm.y).collect();
+        .map(|lm| lm.y)
+        .collect();
 
     fig.axes2d()
         .set_title("FastSLAM 1.0", &[])
         .set_x_label("x [m]", &[])
         .set_y_label("y [m]", &[])
-        .points(&lm_x, &lm_y, &[Caption("True Landmarks"), Color("black"), PointSymbol('*'), PointSize(2.0)])
-        .points(&est_lm_x, &est_lm_y, &[Caption("Est. Landmarks"), Color("cyan"), PointSymbol('O'), PointSize(1.5)])
+        .points(
+            &lm_x,
+            &lm_y,
+            &[
+                Caption("True Landmarks"),
+                Color("black"),
+                PointSymbol('*'),
+                PointSize(2.0),
+            ],
+        )
+        .points(
+            &est_lm_x,
+            &est_lm_y,
+            &[
+                Caption("Est. Landmarks"),
+                Color("cyan"),
+                PointSymbol('O'),
+                PointSize(1.5),
+            ],
+        )
         .lines(&true_x, &true_y, &[Caption("True"), Color("blue")])
         .lines(&dr_x, &dr_y, &[Caption("Dead Reckoning"), Color("yellow")])
         .lines(&est_x, &est_y, &[Caption("FastSLAM"), Color("green")]);
 
-    fig.save_to_svg("./img/slam/fastslam1.svg", 640, 480).unwrap();
+    fig.save_to_svg("./img/slam/fastslam1.svg", 640, 480)
+        .unwrap();
     println!("Plot saved to ./img/slam/fastslam1.svg");
 }

--- a/src/slam/fastslam1.rs
+++ b/src/slam/fastslam1.rs
@@ -1,10 +1,12 @@
+#![allow(dead_code)]
+
 // FastSLAM 1.0
 // author: Atsushi Sakai (@Atsushi_twi)
 //         Ryohei Sasaki (@rsasaki0109)
 //         Rust port
 
 use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
-use nalgebra::{DMatrix, DVector, Matrix2, Matrix2x3, Matrix3x2, Vector2, Vector3};
+use nalgebra::{Matrix2, Vector2, Vector3};
 use rand_distr::{Distribution, Normal, Uniform};
 use std::f64::consts::PI;
 

--- a/src/slam/graph_based_slam.rs
+++ b/src/slam/graph_based_slam.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, clippy::too_many_arguments)]
+
 // Graph-based SLAM
 // author: Atsushi Sakai (@Atsushi_twi)
 //         Rust port

--- a/src/slam/graph_based_slam.rs
+++ b/src/slam/graph_based_slam.rs
@@ -6,9 +6,9 @@
 // [A Tutorial on Graph-Based SLAM]
 // http://www2.informatik.uni-freiburg.de/~stachnis/pdf/grisetti10titsmag.pdf
 
-use nalgebra::{Matrix3, Vector3, DMatrix, DVector};
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSize, PointSymbol};
+use nalgebra::{DMatrix, DVector, Matrix3, Vector3};
 use rand_distr::{Distribution, Normal};
-use gnuplot::{Figure, Caption, Color, AxesCommon, PointSymbol, PointSize};
 use std::f64::consts::PI;
 use std::fs::File;
 use std::io::Write;
@@ -36,17 +36,17 @@ const SHOW_ANIMATION: bool = false;
 /// Observation data structure
 #[derive(Clone)]
 struct Observation {
-    d: f64,      // distance
-    angle: f64,  // angle relative to robot
-    phi: f64,    // absolute angle
-    id: usize,   // landmark id
+    d: f64,     // distance
+    angle: f64, // angle relative to robot
+    phi: f64,   // absolute angle
+    id: usize,  // landmark id
 }
 
 /// Edge represents a constraint between two poses
 #[derive(Clone)]
 struct Edge {
-    e: Vector3<f64>,      // error vector
-    omega: Matrix3<f64>,  // information matrix
+    e: Vector3<f64>,     // error vector
+    omega: Matrix3<f64>, // information matrix
     d1: f64,
     d2: f64,
     yaw1: f64,
@@ -99,20 +99,23 @@ fn cal_observation_sigma() -> Matrix3<f64> {
 fn calc_3d_rotational_matrix(angle: f64) -> Matrix3<f64> {
     let c = angle.cos();
     let s = angle.sin();
-    Matrix3::new(
-        c, -s, 0.0,
-        s,  c, 0.0,
-        0.0, 0.0, 1.0,
-    )
+    Matrix3::new(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0)
 }
 
 /// Calculate edge between two poses that observed the same landmark
 fn calc_edge(
-    x1: f64, y1: f64, yaw1: f64,
-    x2: f64, y2: f64, yaw2: f64,
-    d1: f64, angle1: f64,
-    d2: f64, angle2: f64,
-    t1: usize, t2: usize,
+    x1: f64,
+    y1: f64,
+    yaw1: f64,
+    x2: f64,
+    y2: f64,
+    yaw2: f64,
+    d1: f64,
+    angle1: f64,
+    d2: f64,
+    angle2: f64,
+    t1: usize,
+    t2: usize,
 ) -> Edge {
     let mut edge = Edge::new();
 
@@ -175,10 +178,7 @@ fn calc_edges(x_list: &DMatrix<f64>, z_list: &[Option<Vec<Observation>>]) -> (Ve
                     for obs2 in z2 {
                         if obs1.id == obs2.id {
                             let edge = calc_edge(
-                                x1, y1, yaw1,
-                                x2, y2, yaw2,
-                                obs1.d, obs1.angle,
-                                obs2.d, obs2.angle,
+                                x1, y1, yaw1, x2, y2, yaw2, obs1.d, obs1.angle, obs2.d, obs2.angle,
                                 t1, t2,
                             );
 
@@ -202,27 +202,35 @@ fn calc_edges(x_list: &DMatrix<f64>, z_list: &[Option<Vec<Observation>>]) -> (Ve
 fn calc_jacobian(edge: &Edge) -> (Matrix3<f64>, Matrix3<f64>) {
     let t1 = edge.yaw1 + edge.angle1;
     let a = Matrix3::new(
-        -1.0, 0.0, edge.d1 * t1.sin(),
-        0.0, -1.0, -edge.d1 * t1.cos(),
-        0.0, 0.0, 0.0,
+        -1.0,
+        0.0,
+        edge.d1 * t1.sin(),
+        0.0,
+        -1.0,
+        -edge.d1 * t1.cos(),
+        0.0,
+        0.0,
+        0.0,
     );
 
     let t2 = edge.yaw2 + edge.angle2;
     let b = Matrix3::new(
-        1.0, 0.0, -edge.d2 * t2.sin(),
-        0.0, 1.0, edge.d2 * t2.cos(),
-        0.0, 0.0, 0.0,
+        1.0,
+        0.0,
+        -edge.d2 * t2.sin(),
+        0.0,
+        1.0,
+        edge.d2 * t2.cos(),
+        0.0,
+        0.0,
+        0.0,
     );
 
     (a, b)
 }
 
 /// Fill H matrix and b vector for an edge
-fn fill_h_and_b(
-    h: &mut DMatrix<f64>,
-    b: &mut DVector<f64>,
-    edge: &Edge,
-) {
+fn fill_h_and_b(h: &mut DMatrix<f64>, b: &mut DVector<f64>, edge: &Edge) {
     let (a, b_jac) = calc_jacobian(edge);
 
     let id1 = edge.id1 * STATE_SIZE;
@@ -257,10 +265,7 @@ fn fill_h_and_b(
 }
 
 /// Graph-based SLAM optimization
-fn graph_based_slam(
-    x_init: &DMatrix<f64>,
-    hz: &[Option<Vec<Observation>>],
-) -> DMatrix<f64> {
+fn graph_based_slam(x_init: &DMatrix<f64>, hz: &[Option<Vec<Observation>>]) -> DMatrix<f64> {
     println!("start graph based slam");
 
     let mut x_opt = x_init.clone();
@@ -328,7 +333,7 @@ fn motion_model(x: &Vector3<f64>, u: &[f64; 2]) -> Vector3<f64> {
 
 /// Calculate control input
 fn calc_input() -> [f64; 2] {
-    let v = 1.0;        // [m/s]
+    let v = 1.0; // [m/s]
     let yaw_rate = 0.1; // [rad/s]
     [v, yaw_rate]
 }
@@ -339,7 +344,12 @@ fn observation(
     xd: &Vector3<f64>,
     u: &[f64; 2],
     rfid: &[(f64, f64)],
-) -> (Vector3<f64>, Option<Vec<Observation>>, Vector3<f64>, [f64; 2]) {
+) -> (
+    Vector3<f64>,
+    Option<Vec<Observation>>,
+    Vector3<f64>,
+    [f64; 2],
+) {
     let normal = Normal::new(0.0, 1.0).unwrap();
     let mut rng = rand::thread_rng();
 
@@ -386,23 +396,29 @@ fn observation(
 /// Save SVG plot directly without gnuplot dependency
 fn save_svg(
     path: &str,
-    true_x: &[f64], true_y: &[f64],
-    dr_x: &[f64], dr_y: &[f64],
-    opt_x: &[f64], opt_y: &[f64],
-    lm_x: &[f64], lm_y: &[f64],
+    true_x: &[f64],
+    true_y: &[f64],
+    dr_x: &[f64],
+    dr_y: &[f64],
+    opt_x: &[f64],
+    opt_y: &[f64],
+    lm_x: &[f64],
+    lm_y: &[f64],
 ) {
     let width = 640;
     let height = 480;
     let margin = 60.0;
 
     // Calculate bounds
-    let all_x: Vec<f64> = true_x.iter()
+    let all_x: Vec<f64> = true_x
+        .iter()
         .chain(dr_x.iter())
         .chain(opt_x.iter())
         .chain(lm_x.iter())
         .copied()
         .collect();
-    let all_y: Vec<f64> = true_y.iter()
+    let all_y: Vec<f64> = true_y
+        .iter()
         .chain(dr_y.iter())
         .chain(opt_y.iter())
         .chain(lm_y.iter())
@@ -425,12 +441,8 @@ fn save_svg(
     let plot_height = height as f64 - 2.0 * margin;
     let scale = plot_width.min(plot_height) / range;
 
-    let transform_x = |x: f64| -> f64 {
-        margin + plot_width / 2.0 + (x - x_center) * scale
-    };
-    let transform_y = |y: f64| -> f64 {
-        margin + plot_height / 2.0 - (y - y_center) * scale
-    };
+    let transform_x = |x: f64| -> f64 { margin + plot_width / 2.0 + (x - x_center) * scale };
+    let transform_y = |y: f64| -> f64 { margin + plot_height / 2.0 - (y - y_center) * scale };
 
     let mut svg = String::new();
     svg.push_str(&format!(
@@ -450,11 +462,17 @@ fn save_svg(
         let y = margin + (i as f64 / 10.0) * plot_height;
         svg.push_str(&format!(
             r#"<line x1="{}" y1="{}" x2="{}" y2="{}"/>"#,
-            x, margin, x, margin + plot_height
+            x,
+            margin,
+            x,
+            margin + plot_height
         ));
         svg.push_str(&format!(
             r#"<line x1="{}" y1="{}" x2="{}" y2="{}"/>"#,
-            margin, y, margin + plot_width, y
+            margin,
+            y,
+            margin + plot_width,
+            y
         ));
     }
     svg.push_str("</g>\n");
@@ -515,27 +533,39 @@ fn save_svg(
     ));
     svg.push_str(&format!(
         "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" stroke=\"blue\" stroke-width=\"2\"/>",
-        legend_x + 10.0, legend_y + 20.0, legend_x + 40.0, legend_y + 20.0
+        legend_x + 10.0,
+        legend_y + 20.0,
+        legend_x + 40.0,
+        legend_y + 20.0
     ));
     svg.push_str(&format!(
         "<text x=\"{}\" y=\"{}\" font-size=\"12\" font-family=\"sans-serif\">True</text>",
-        legend_x + 50.0, legend_y + 24.0
+        legend_x + 50.0,
+        legend_y + 24.0
     ));
     svg.push_str(&format!(
         "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" stroke=\"#333\" stroke-width=\"1.5\"/>",
-        legend_x + 10.0, legend_y + 40.0, legend_x + 40.0, legend_y + 40.0
+        legend_x + 10.0,
+        legend_y + 40.0,
+        legend_x + 40.0,
+        legend_y + 40.0
     ));
     svg.push_str(&format!(
         "<text x=\"{}\" y=\"{}\" font-size=\"12\" font-family=\"sans-serif\">Dead Reckoning</text>",
-        legend_x + 50.0, legend_y + 44.0
+        legend_x + 50.0,
+        legend_y + 44.0
     ));
     svg.push_str(&format!(
         "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" stroke=\"red\" stroke-width=\"2\"/>",
-        legend_x + 10.0, legend_y + 60.0, legend_x + 40.0, legend_y + 60.0
+        legend_x + 10.0,
+        legend_y + 60.0,
+        legend_x + 40.0,
+        legend_y + 60.0
     ));
     svg.push_str(&format!(
         "<text x=\"{}\" y=\"{}\" font-size=\"12\" font-family=\"sans-serif\">Graph SLAM</text>",
-        legend_x + 50.0, legend_y + 64.0
+        legend_x + 50.0,
+        legend_y + 64.0
     ));
 
     svg.push_str("</svg>\n");
@@ -629,7 +659,16 @@ fn main() {
                     .set_x_label("x [m]", &[])
                     .set_y_label("y [m]", &[])
                     .set_aspect_ratio(gnuplot::Fix(1.0))
-                    .points(&lm_x, &lm_y, &[Caption("Landmarks"), Color("black"), PointSymbol('*'), PointSize(2.0)])
+                    .points(
+                        &lm_x,
+                        &lm_y,
+                        &[
+                            Caption("Landmarks"),
+                            Color("black"),
+                            PointSymbol('*'),
+                            PointSize(2.0),
+                        ],
+                    )
                     .lines(&true_x, &true_y, &[Caption("True"), Color("blue")])
                     .lines(&dr_x, &dr_y, &[Caption("Dead Reckoning"), Color("black")])
                     .lines(&opt_x, &opt_y, &[Caption("Graph SLAM"), Color("red")]);
@@ -669,14 +708,25 @@ fn main() {
         .set_x_label("x [m]", &[])
         .set_y_label("y [m]", &[])
         .set_aspect_ratio(gnuplot::Fix(1.0))
-        .points(&lm_x, &lm_y, &[Caption("Landmarks"), Color("black"), PointSymbol('*'), PointSize(2.0)])
+        .points(
+            &lm_x,
+            &lm_y,
+            &[
+                Caption("Landmarks"),
+                Color("black"),
+                PointSymbol('*'),
+                PointSize(2.0),
+            ],
+        )
         .lines(&true_x, &true_y, &[Caption("True"), Color("blue")])
         .lines(&dr_x, &dr_y, &[Caption("Dead Reckoning"), Color("black")])
         .lines(&opt_x, &opt_y, &[Caption("Graph SLAM"), Color("red")]);
 
     // Save SVG directly without gnuplot dependency
     let svg_path = "./img/slam/graph_based_slam.svg";
-    save_svg(svg_path, &true_x, &true_y, &dr_x, &dr_y, &opt_x, &opt_y, &lm_x, &lm_y);
+    save_svg(
+        svg_path, &true_x, &true_y, &dr_x, &dr_y, &opt_x, &opt_y, &lm_x, &lm_y,
+    );
     println!("Plot saved to {}", svg_path);
 
     // Print final error
@@ -685,8 +735,10 @@ fn main() {
     let opt_final_x = x_opt[(0, x_opt.ncols() - 1)];
     let opt_final_y = x_opt[(1, x_opt.ncols() - 1)];
 
-    let dr_error = ((dr_final[0] - true_final[0]).powi(2) + (dr_final[1] - true_final[1]).powi(2)).sqrt();
-    let opt_error = ((opt_final_x - true_final[0]).powi(2) + (opt_final_y - true_final[1]).powi(2)).sqrt();
+    let dr_error =
+        ((dr_final[0] - true_final[0]).powi(2) + (dr_final[1] - true_final[1]).powi(2)).sqrt();
+    let opt_error =
+        ((opt_final_x - true_final[0]).powi(2) + (opt_final_y - true_final[1]).powi(2)).sqrt();
 
     println!("\nFinal position errors:");
     println!("  Dead Reckoning error: {:.4} m", dr_error);

--- a/src/slam/icp_matching.rs
+++ b/src/slam/icp_matching.rs
@@ -1,18 +1,18 @@
 /*!
  * Iterative Closest Point (ICP) SLAM implementation
- * 
+ *
  * This module implements the ICP algorithm for point cloud registration.
  * It finds the optimal transformation (rotation and translation) between
  * two point sets by iteratively minimizing the distance between corresponding points.
- * 
+ *
  * Ported from PythonRobotics
  * Original authors: Atsushi Sakai (@Atsushi_twi), Göktuğ Karakaşlı, Shamil Gemuev
  */
 
+use gnuplot::{AxesCommon, Caption, Color, Figure, PointSymbol};
 use nalgebra::{DMatrix, DVector, Matrix2, Vector2};
-use gnuplot::{Figure, Caption, Color, PointSymbol, AxesCommon};
-use std::f64;
 use rand::Rng;
+use std::f64;
 
 // ICP parameters
 const EPS: f64 = 0.0001;
@@ -28,69 +28,74 @@ pub struct ICPResult {
 }
 
 /// Main ICP matching function
-/// 
+///
 /// # Arguments
 /// * `previous_points` - Points from the previous frame (2×N or 3×N matrix)
 /// * `current_points` - Points from the current frame (2×N or 3×N matrix)
-/// 
+///
 /// # Returns
 /// * `ICPResult` containing rotation matrix, translation vector, and convergence info
-pub fn icp_matching(
-    previous_points: &DMatrix<f64>,
-    current_points: &DMatrix<f64>,
-) -> ICPResult {
+pub fn icp_matching(previous_points: &DMatrix<f64>, current_points: &DMatrix<f64>) -> ICPResult {
     let mut h_matrix: Option<DMatrix<f64>> = None;
     let mut d_error = f64::INFINITY;
     let mut pre_error = f64::INFINITY;
     let mut count = 0;
     let mut current_pts = current_points.clone();
-    
+
     let mut fg = Figure::new();
-    
+
     while d_error >= EPS {
         count += 1;
-        
+
         if SHOW_ANIMATION && count % 5 == 0 {
             plot_points(&previous_points, &current_pts, &mut fg, count);
         }
-        
+
         let (indexes, error) = nearest_neighbor_association(&previous_points, &current_pts);
         let previous_indexed = select_columns(&previous_points, &indexes);
         let (rt, tt) = svd_motion_estimation(&previous_indexed, &current_pts);
-        
+
         // Update current points: current_points = (Rt @ current_points) + Tt
         let rotated_pts = &rt * &current_pts;
         current_pts = rotated_pts.add_scalar_to_each_column(&tt);
-        
+
         d_error = pre_error - error;
         println!("Iteration {}: Residual = {:.6}", count, error);
-        
+
         if d_error < 0.0 {
-            println!("Not converged... pre_error: {:.6}, d_error: {:.6}, iterations: {}", 
-                     pre_error, d_error, count);
+            println!(
+                "Not converged... pre_error: {:.6}, d_error: {:.6}, iterations: {}",
+                pre_error, d_error, count
+            );
             break;
         }
-        
+
         pre_error = error;
         h_matrix = Some(update_homogeneous_matrix(h_matrix, &rt, &tt));
-        
+
         if d_error <= EPS {
-            println!("Converged! error: {:.6}, d_error: {:.6}, iterations: {}", 
-                     error, d_error, count);
+            println!(
+                "Converged! error: {:.6}, d_error: {:.6}, iterations: {}",
+                error, d_error, count
+            );
             break;
         } else if count >= MAX_ITER {
-            println!("Max iterations reached. error: {:.6}, d_error: {:.6}, iterations: {}", 
-                     error, d_error, count);
+            println!(
+                "Max iterations reached. error: {:.6}, d_error: {:.6}, iterations: {}",
+                error, d_error, count
+            );
             break;
         }
     }
-    
-    let h = h_matrix.unwrap_or_else(|| DMatrix::identity(previous_points.nrows() + 1, previous_points.nrows() + 1));
+
+    let h = h_matrix.unwrap_or_else(|| {
+        DMatrix::identity(previous_points.nrows() + 1, previous_points.nrows() + 1)
+    });
     let dim = previous_points.nrows();
-    
+
     let rotation = h.view((0, 0), (dim, dim)).into_owned();
     let translation = h.column(dim).rows(0, dim).into_owned();
-    
+
     ICPResult {
         rotation,
         translation,
@@ -108,14 +113,14 @@ fn update_homogeneous_matrix(
 ) -> DMatrix<f64> {
     let r_size = r.nrows();
     let mut h = DMatrix::zeros(r_size + 1, r_size + 1);
-    
+
     // Set rotation part
     h.view_mut((0, 0), (r_size, r_size)).copy_from(r);
     // Set translation part
     h.view_mut((0, r_size), (r_size, 1)).copy_from(&t.column(0));
     // Set homogeneous coordinate
     h[(r_size, r_size)] = 1.0;
-    
+
     match h_in {
         None => h,
         Some(h_prev) => &h_prev * &h,
@@ -130,12 +135,12 @@ fn nearest_neighbor_association(
     // Find nearest neighbor associations
     let mut indexes = Vec::with_capacity(current_points.ncols());
     let mut error = 0.0;
-    
+
     for j in 0..current_points.ncols() {
         let current_point = current_points.column(j);
         let mut min_dist = f64::INFINITY;
         let mut best_idx = 0;
-        
+
         for i in 0..previous_points.ncols() {
             let prev_point = previous_points.column(i);
             let dist = (current_point - prev_point).norm();
@@ -147,7 +152,7 @@ fn nearest_neighbor_association(
         indexes.push(best_idx);
         error += min_dist;
     }
-    
+
     (indexes, error)
 }
 
@@ -183,53 +188,53 @@ fn svd_motion_estimation(
     current_points: &DMatrix<f64>,
 ) -> (DMatrix<f64>, DVector<f64>) {
     let n_points = previous_points.ncols();
-    
+
     // Calculate centroids
     let mut pm_x = 0.0;
     let mut pm_y = 0.0;
     let mut cm_x = 0.0;
     let mut cm_y = 0.0;
-    
+
     for j in 0..n_points {
         pm_x += previous_points[(0, j)];
         pm_y += previous_points[(1, j)];
         cm_x += current_points[(0, j)];
         cm_y += current_points[(1, j)];
     }
-    
+
     pm_x /= n_points as f64;
     pm_y /= n_points as f64;
     cm_x /= n_points as f64;
     cm_y /= n_points as f64;
-    
+
     // Shift points to centroids
     let mut p_shift = DMatrix::zeros(2, n_points);
     let mut c_shift = DMatrix::zeros(2, n_points);
-    
+
     for j in 0..n_points {
         p_shift[(0, j)] = previous_points[(0, j)] - pm_x;
         p_shift[(1, j)] = previous_points[(1, j)] - pm_y;
         c_shift[(0, j)] = current_points[(0, j)] - cm_x;
         c_shift[(1, j)] = current_points[(1, j)] - cm_y;
     }
-    
+
     // Calculate cross-covariance matrix W = c_shift * p_shift^T
     let w = &c_shift * p_shift.transpose();
-    
+
     // SVD decomposition
     let svd = w.svd(true, true);
     let u = svd.u.unwrap();
     let v_t = svd.v_t.unwrap();
-    
+
     // Calculate rotation: R = V * U^T
     let r = &v_t.transpose() * &u.transpose();
-    
+
     // Calculate translation: t = pm - R * cm
     let cm_vec = DVector::from_vec(vec![cm_x, cm_y]);
     let pm_vec = DVector::from_vec(vec![pm_x, pm_y]);
     let r_cm = &r * &cm_vec;
     let t = &pm_vec - &r_cm;
-    
+
     (r, t)
 }
 
@@ -241,9 +246,9 @@ fn plot_points(
     iteration: usize,
 ) {
     fg.clear_axes();
-    
+
     let axes = fg.axes2d();
-    
+
     // Extract coordinates for plotting
     let prev_x: Vec<f64> = (0..previous_points.ncols())
         .map(|i| previous_points[(0, i)])
@@ -251,26 +256,38 @@ fn plot_points(
     let prev_y: Vec<f64> = (0..previous_points.ncols())
         .map(|i| previous_points[(1, i)])
         .collect();
-    
+
     let curr_x: Vec<f64> = (0..current_points.ncols())
         .map(|i| current_points[(0, i)])
         .collect();
     let curr_y: Vec<f64> = (0..current_points.ncols())
         .map(|i| current_points[(1, i)])
         .collect();
-    
+
     // Plot previous points in red
-    axes.points(&prev_x, &prev_y, &[Caption("Previous"), Color("red"), PointSymbol('.')]);
-    
+    axes.points(
+        &prev_x,
+        &prev_y,
+        &[Caption("Previous"), Color("red"), PointSymbol('.')],
+    );
+
     // Plot current points in blue
-    axes.points(&curr_x, &curr_y, &[Caption("Current"), Color("blue"), PointSymbol('.')]);
-    
+    axes.points(
+        &curr_x,
+        &curr_y,
+        &[Caption("Current"), Color("blue"), PointSymbol('.')],
+    );
+
     // Plot origin
-    axes.points(&[0.0], &[0.0], &[Caption("Origin"), Color("red"), PointSymbol('x')]);
-    
+    axes.points(
+        &[0.0],
+        &[0.0],
+        &[Caption("Origin"), Color("red"), PointSymbol('x')],
+    );
+
     axes.set_aspect_ratio(gnuplot::AutoOption::Fix(1.0));
     axes.set_title(&format!("ICP Matching - Iteration {}", iteration), &[]);
-    
+
     // Save plot
     let filename = format!("img/slam/icp_iteration_{:03}.png", iteration);
     fg.set_terminal("pngcairo", &filename);
@@ -281,12 +298,12 @@ fn plot_points(
 pub fn generate_2d_points(n_points: usize, field_length: f64) -> DMatrix<f64> {
     let mut rng = rand::thread_rng();
     let mut points = DMatrix::zeros(2, n_points);
-    
+
     for j in 0..n_points {
         points[(0, j)] = (rng.gen::<f64>() - 0.5) * field_length;
         points[(1, j)] = (rng.gen::<f64>() - 0.5) * field_length;
     }
-    
+
     points
 }
 
@@ -299,67 +316,68 @@ pub fn apply_2d_transformation(
     let cos_theta = rotation_angle.cos();
     let sin_theta = rotation_angle.sin();
     let rotation = Matrix2::new(cos_theta, -sin_theta, sin_theta, cos_theta);
-    
+
     let mut transformed = DMatrix::zeros(2, points.ncols());
-    
+
     for j in 0..points.ncols() {
         let point = Vector2::new(points[(0, j)], points[(1, j)]);
         let rotated = rotation * point;
         transformed[(0, j)] = rotated.x + translation.x;
         transformed[(1, j)] = rotated.y + translation.y;
     }
-    
+
     transformed
 }
 
 /// Demo function for 2D ICP matching
 pub fn demo_2d_icp() {
     println!("ICP 2D Matching Demo");
-    
+
     // Create output directory
     std::fs::create_dir_all("img/slam").unwrap_or_default();
-    
+
     // Simulation parameters
     let n_point = 100;
     let field_length = 50.0;
     let motion = Vector2::new(0.5, 2.0);
     let rotation_angle = (-10.0_f64).to_radians();
-    
+
     let n_sim = 3;
-    
+
     for sim in 0..n_sim {
         println!("\n=== Simulation {} ===", sim + 1);
-        
+
         // Generate previous points
         let previous_points = generate_2d_points(n_point, field_length);
-        
+
         // Generate current points by applying known transformation
         let current_points = apply_2d_transformation(&previous_points, &motion, rotation_angle);
-        
+
         // Run ICP matching
         let result = icp_matching(&previous_points, &current_points);
-        
+
         println!("ICP Results:");
         println!("Converged: {}", result.converged);
         println!("Iterations: {}", result.iterations);
         println!("Final error: {:.6}", result.final_error);
         println!("Rotation matrix:\n{}", result.rotation);
         println!("Translation vector:\n{}", result.translation);
-        
+
         // ICP estimates the inverse transform that aligns current_points back to previous_points.
         let expected_rotation = Matrix2::new(
-            rotation_angle.cos(), rotation_angle.sin(),
-            -rotation_angle.sin(), rotation_angle.cos()
+            rotation_angle.cos(),
+            rotation_angle.sin(),
+            -rotation_angle.sin(),
+            rotation_angle.cos(),
         );
         let expected_translation = -expected_rotation * motion;
         println!("Expected rotation:\n{}", expected_rotation);
         println!(
             "Expected translation: [{:.3}, {:.3}]",
-            expected_translation.x,
-            expected_translation.y
+            expected_translation.x, expected_translation.y
         );
     }
-    
+
     // Create summary plot
     create_summary_plot();
 }
@@ -367,22 +385,22 @@ pub fn demo_2d_icp() {
 /// Create a summary visualization
 fn create_summary_plot() {
     let mut fg = Figure::new();
-    
+
     // Generate sample data for summary
     let previous_points = generate_2d_points(200, 30.0);
     let motion = Vector2::new(2.0, 1.5);
     let rotation_angle = (-15.0_f64).to_radians();
     let current_points = apply_2d_transformation(&previous_points, &motion, rotation_angle);
-    
+
     // Run ICP to get final aligned points
     let result = icp_matching(&previous_points, &current_points);
-    
+
     // Apply final transformation for visualization
-    let final_points = (&result.rotation * &current_points)
-        .add_scalar_to_each_column(&result.translation);
-    
+    let final_points =
+        (&result.rotation * &current_points).add_scalar_to_each_column(&result.translation);
+
     let axes = fg.axes2d();
-    
+
     // Extract coordinates
     let prev_x: Vec<f64> = (0..previous_points.ncols())
         .map(|i| previous_points[(0, i)])
@@ -390,36 +408,52 @@ fn create_summary_plot() {
     let prev_y: Vec<f64> = (0..previous_points.ncols())
         .map(|i| previous_points[(1, i)])
         .collect();
-    
+
     let curr_x: Vec<f64> = (0..current_points.ncols())
         .map(|i| current_points[(0, i)])
         .collect();
     let curr_y: Vec<f64> = (0..current_points.ncols())
         .map(|i| current_points[(1, i)])
         .collect();
-    
+
     let final_x: Vec<f64> = (0..final_points.ncols())
         .map(|i| final_points[(0, i)])
         .collect();
     let final_y: Vec<f64> = (0..final_points.ncols())
         .map(|i| final_points[(1, i)])
         .collect();
-    
+
     // Plot all point sets
-    axes.points(&prev_x, &prev_y, &[Caption("Reference"), Color("red"), PointSymbol('.')]);
-    axes.points(&curr_x, &curr_y, &[Caption("Initial"), Color("blue"), PointSymbol('.')]);
-    axes.points(&final_x, &final_y, &[Caption("Aligned"), Color("green"), PointSymbol('.')]);
-    axes.points(&[0.0], &[0.0], &[Caption("Origin"), Color("black"), PointSymbol('x')]);
-    
+    axes.points(
+        &prev_x,
+        &prev_y,
+        &[Caption("Reference"), Color("red"), PointSymbol('.')],
+    );
+    axes.points(
+        &curr_x,
+        &curr_y,
+        &[Caption("Initial"), Color("blue"), PointSymbol('.')],
+    );
+    axes.points(
+        &final_x,
+        &final_y,
+        &[Caption("Aligned"), Color("green"), PointSymbol('.')],
+    );
+    axes.points(
+        &[0.0],
+        &[0.0],
+        &[Caption("Origin"), Color("black"), PointSymbol('x')],
+    );
+
     axes.set_aspect_ratio(gnuplot::AutoOption::Fix(1.0));
     axes.set_title("ICP Matching Result", &[]);
     axes.set_x_label("X [m]", &[]);
     axes.set_y_label("Y [m]", &[]);
-    
+
     // Save summary plot
     fg.set_terminal("pngcairo", "img/slam/icp_summary.png");
     fg.show().unwrap();
-    
+
     println!("\nSummary plot saved to img/slam/icp_summary.png");
     println!("Animation frames saved to img/slam/icp_iteration_*.png");
 }
@@ -441,31 +475,32 @@ mod tests {
 
         points
     }
-    
+
     #[test]
     fn test_icp_simple_translation() {
         let n_points = 50;
         let previous_points = generate_seeded_2d_points(n_points, 20.0, 7);
         let translation = Vector2::new(1.0, 2.0);
         let current_points = apply_2d_transformation(&previous_points, &translation, 0.0);
-        
+
         let result = icp_matching(&previous_points, &current_points);
-        
+
         assert!(result.converged);
         assert!((result.translation[0] + translation.x).abs() < 0.1);
         assert!((result.translation[1] + translation.y).abs() < 0.1);
     }
-    
+
     #[test]
     fn test_icp_rotation_and_translation() {
         let n_points = 50;
         let previous_points = generate_seeded_2d_points(n_points, 20.0, 42);
         let translation = Vector2::new(0.5, 1.5);
         let rotation_angle = 0.2; // ~11.5 degrees
-        let current_points = apply_2d_transformation(&previous_points, &translation, rotation_angle);
-        
+        let current_points =
+            apply_2d_transformation(&previous_points, &translation, rotation_angle);
+
         let result = icp_matching(&previous_points, &current_points);
-        
+
         assert!(result.converged);
         assert!(result.final_error < 1.0);
     }

--- a/src/slam/icp_matching.rs
+++ b/src/slam/icp_matching.rs
@@ -1,3 +1,11 @@
+#![allow(
+    dead_code,
+    clippy::items_after_test_module,
+    clippy::needless_borrows_for_generic_args,
+    clippy::ptr_arg,
+    clippy::legacy_numeric_constants
+)]
+
 /*!
  * Iterative Closest Point (ICP) SLAM implementation
  *
@@ -280,8 +288,8 @@ fn plot_points(
 
     // Plot origin
     axes.points(
-        &[0.0],
-        &[0.0],
+        [0.0],
+        [0.0],
         &[Caption("Origin"), Color("red"), PointSymbol('x')],
     );
 
@@ -440,8 +448,8 @@ fn create_summary_plot() {
         &[Caption("Aligned"), Color("green"), PointSymbol('.')],
     );
     axes.points(
-        &[0.0],
-        &[0.0],
+        [0.0],
+        [0.0],
         &[Caption("Origin"), Color("black"), PointSymbol('x')],
     );
 

--- a/src/slam/icp_matching.rs
+++ b/src/slam/icp_matching.rs
@@ -17,7 +17,7 @@ use rand::Rng;
 // ICP parameters
 const EPS: f64 = 0.0001;
 const MAX_ITER: usize = 100;
-const SHOW_ANIMATION: bool = true;
+const SHOW_ANIMATION: bool = !cfg!(test);
 
 pub struct ICPResult {
     pub rotation: DMatrix<f64>,
@@ -127,15 +127,9 @@ fn nearest_neighbor_association(
     previous_points: &DMatrix<f64>,
     current_points: &DMatrix<f64>,
 ) -> (Vec<usize>, f64) {
-    // Calculate residual error for current association
-    let delta_points = previous_points - current_points;
-    let mut error = 0.0;
-    for j in 0..delta_points.ncols() {
-        error += delta_points.column(j).norm();
-    }
-    
     // Find nearest neighbor associations
     let mut indexes = Vec::with_capacity(current_points.ncols());
+    let mut error = 0.0;
     
     for j in 0..current_points.ncols() {
         let current_point = current_points.column(j);
@@ -151,6 +145,7 @@ fn nearest_neighbor_association(
             }
         }
         indexes.push(best_idx);
+        error += min_dist;
     }
     
     (indexes, error)
@@ -226,8 +221,8 @@ fn svd_motion_estimation(
     let u = svd.u.unwrap();
     let v_t = svd.v_t.unwrap();
     
-    // Calculate rotation: R = (U * V^T)^T = V * U^T
-    let r = (&v_t.transpose() * &u.transpose()).transpose();
+    // Calculate rotation: R = V * U^T
+    let r = &v_t.transpose() * &u.transpose();
     
     // Calculate translation: t = pm - R * cm
     let cm_vec = DVector::from_vec(vec![cm_x, cm_y]);
@@ -351,13 +346,18 @@ pub fn demo_2d_icp() {
         println!("Rotation matrix:\n{}", result.rotation);
         println!("Translation vector:\n{}", result.translation);
         
-        // Compare with ground truth
+        // ICP estimates the inverse transform that aligns current_points back to previous_points.
         let expected_rotation = Matrix2::new(
-            rotation_angle.cos(), -rotation_angle.sin(),
-            rotation_angle.sin(), rotation_angle.cos()
+            rotation_angle.cos(), rotation_angle.sin(),
+            -rotation_angle.sin(), rotation_angle.cos()
         );
+        let expected_translation = -expected_rotation * motion;
         println!("Expected rotation:\n{}", expected_rotation);
-        println!("Expected translation: [{:.3}, {:.3}]", motion.x, motion.y);
+        println!(
+            "Expected translation: [{:.3}, {:.3}]",
+            expected_translation.x,
+            expected_translation.y
+        );
     }
     
     // Create summary plot
@@ -439,8 +439,8 @@ mod tests {
         let result = icp_matching(&previous_points, &current_points);
         
         assert!(result.converged);
-        assert!((result.translation[0] - translation.x).abs() < 0.1);
-        assert!((result.translation[1] - translation.y).abs() < 0.1);
+        assert!((result.translation[0] + translation.x).abs() < 0.1);
+        assert!((result.translation[1] + translation.y).abs() < 0.1);
     }
     
     #[test]

--- a/src/slam/icp_matching.rs
+++ b/src/slam/icp_matching.rs
@@ -428,11 +428,24 @@ fn create_summary_plot() {
 mod tests {
     use super::*;
     use nalgebra::Vector2;
+    use rand::{rngs::StdRng, Rng, SeedableRng};
+
+    fn generate_seeded_2d_points(n_points: usize, field_length: f64, seed: u64) -> DMatrix<f64> {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut points = DMatrix::zeros(2, n_points);
+
+        for j in 0..n_points {
+            points[(0, j)] = (rng.gen::<f64>() - 0.5) * field_length;
+            points[(1, j)] = (rng.gen::<f64>() - 0.5) * field_length;
+        }
+
+        points
+    }
     
     #[test]
     fn test_icp_simple_translation() {
         let n_points = 50;
-        let previous_points = generate_2d_points(n_points, 20.0);
+        let previous_points = generate_seeded_2d_points(n_points, 20.0, 7);
         let translation = Vector2::new(1.0, 2.0);
         let current_points = apply_2d_transformation(&previous_points, &translation, 0.0);
         
@@ -446,7 +459,7 @@ mod tests {
     #[test]
     fn test_icp_rotation_and_translation() {
         let n_points = 50;
-        let previous_points = generate_2d_points(n_points, 20.0);
+        let previous_points = generate_seeded_2d_points(n_points, 20.0, 42);
         let translation = Vector2::new(0.5, 1.5);
         let rotation_angle = 0.2; // ~11.5 degrees
         let current_points = apply_2d_transformation(&previous_points, &translation, rotation_angle);

--- a/src/slam/icp_matching.rs
+++ b/src/slam/icp_matching.rs
@@ -56,11 +56,11 @@ pub fn icp_matching(previous_points: &DMatrix<f64>, current_points: &DMatrix<f64
         count += 1;
 
         if SHOW_ANIMATION && count % 5 == 0 {
-            plot_points(&previous_points, &current_pts, &mut fg, count);
+            plot_points(previous_points, &current_pts, &mut fg, count);
         }
 
-        let (indexes, error) = nearest_neighbor_association(&previous_points, &current_pts);
-        let previous_indexed = select_columns(&previous_points, &indexes);
+        let (indexes, error) = nearest_neighbor_association(previous_points, &current_pts);
+        let previous_indexed = select_columns(previous_points, &indexes);
         let (rt, tt) = svd_motion_estimation(&previous_indexed, &current_pts);
 
         // Update current points: current_points = (Rt @ current_points) + Tt

--- a/src/utils/grid_map_planner.rs
+++ b/src/utils/grid_map_planner.rs
@@ -14,7 +14,12 @@ pub struct Node {
 
 impl Node {
     pub fn new(x: i32, y: i32, cost: f64, parent_index: Option<usize>) -> Self {
-        Node { x, y, cost, parent_index }
+        Node {
+            x,
+            y,
+            cost,
+            parent_index,
+        }
     }
 }
 
@@ -34,12 +39,7 @@ pub fn get_motion_model_8() -> Vec<(i32, i32, f64)> {
 
 /// 4-connected motion model (dx, dy, cost)
 pub fn get_motion_model_4() -> Vec<(i32, i32, f64)> {
-    vec![
-        (1, 0, 1.0),
-        (0, 1, 1.0),
-        (-1, 0, 1.0),
-        (0, -1, 1.0),
-    ]
+    vec![(1, 0, 1.0), (0, 1, 1.0), (-1, 0, 1.0), (0, -1, 1.0)]
 }
 
 /// Occupancy grid map for path planning

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,4 +6,4 @@ pub mod visualization;
 
 pub use grid_map::*;
 pub use grid_map_planner::*;
-pub use visualization::{Visualizer, PathStyle, PointStyle, colors};
+pub use visualization::{colors, PathStyle, PointStyle, Visualizer};

--- a/src/utils/visualization.rs
+++ b/src/utils/visualization.rs
@@ -2,8 +2,8 @@
 //!
 //! Provides a unified interface for plotting using gnuplot.
 
-use gnuplot::{Figure, Caption, Color, PointSymbol, PointSize, LineWidth, AxesCommon, AutoOption};
-use crate::common::{Point2D, Pose2D, Path2D, Obstacles};
+use crate::common::{Obstacles, Path2D, Point2D, Pose2D};
+use gnuplot::{AutoOption, AxesCommon, Caption, Color, Figure, LineWidth, PointSize, PointSymbol};
 
 /// Color palette for consistent styling
 pub mod colors {
@@ -95,8 +95,16 @@ impl PointStyle {
 
 /// Plot command to be rendered
 enum PlotCommand {
-    Path { x: Vec<f64>, y: Vec<f64>, style: PathStyle },
-    Points { x: Vec<f64>, y: Vec<f64>, style: PointStyle },
+    Path {
+        x: Vec<f64>,
+        y: Vec<f64>,
+        style: PathStyle,
+    },
+    Points {
+        x: Vec<f64>,
+        y: Vec<f64>,
+        style: PointStyle,
+    },
 }
 
 /// Main visualizer struct
@@ -171,7 +179,11 @@ impl Visualizer {
     pub fn plot_path(&mut self, path: &Path2D, style: &PathStyle) -> &mut Self {
         let x: Vec<f64> = path.points.iter().map(|p| p.x).collect();
         let y: Vec<f64> = path.points.iter().map(|p| p.y).collect();
-        self.commands.push(PlotCommand::Path { x, y, style: style.clone() });
+        self.commands.push(PlotCommand::Path {
+            x,
+            y,
+            style: style.clone(),
+        });
         self
     }
 
@@ -180,7 +192,7 @@ impl Visualizer {
         self.commands.push(PlotCommand::Path {
             x: x.to_vec(),
             y: y.to_vec(),
-            style: style.clone()
+            style: style.clone(),
         });
         self
     }
@@ -231,7 +243,11 @@ impl Visualizer {
     pub fn plot_points(&mut self, points: &[Point2D], style: &PointStyle) -> &mut Self {
         let x: Vec<f64> = points.iter().map(|p| p.x).collect();
         let y: Vec<f64> = points.iter().map(|p| p.y).collect();
-        self.commands.push(PlotCommand::Points { x, y, style: style.clone() });
+        self.commands.push(PlotCommand::Points {
+            x,
+            y,
+            style: style.clone(),
+        });
         self
     }
 
@@ -277,7 +293,10 @@ impl Visualizer {
 
     /// Plot start position
     pub fn plot_start(&mut self, point: Point2D) -> &mut Self {
-        self.plot_point(point, &PointStyle::new(colors::START, "Start").with_size(1.5))
+        self.plot_point(
+            point,
+            &PointStyle::new(colors::START, "Start").with_size(1.5),
+        )
     }
 
     /// Plot goal position
@@ -294,13 +313,17 @@ impl Visualizer {
     /// Save plot to PNG file
     pub fn save_png(&mut self, path: &str, width: u32, height: u32) -> Result<(), String> {
         self.apply_settings();
-        self.figure.save_to_png(path, width, height).map_err(|e| e.to_string())
+        self.figure
+            .save_to_png(path, width, height)
+            .map_err(|e| e.to_string())
     }
 
     /// Save plot to SVG file
     pub fn save_svg(&mut self, path: &str, width: u32, height: u32) -> Result<(), String> {
         self.apply_settings();
-        self.figure.save_to_svg(path, width, height).map_err(|e| e.to_string())
+        self.figure
+            .save_to_svg(path, width, height)
+            .map_err(|e| e.to_string())
     }
 
     fn apply_settings(&mut self) {
@@ -310,19 +333,27 @@ impl Visualizer {
         for cmd in &self.commands {
             match cmd {
                 PlotCommand::Path { x, y, style } => {
-                    axes.lines(x, y, &[
-                        Caption(&style.caption),
-                        Color(&style.color),
-                        LineWidth(style.line_width),
-                    ]);
+                    axes.lines(
+                        x,
+                        y,
+                        &[
+                            Caption(&style.caption),
+                            Color(&style.color),
+                            LineWidth(style.line_width),
+                        ],
+                    );
                 }
                 PlotCommand::Points { x, y, style } => {
-                    axes.points(x, y, &[
-                        Caption(&style.caption),
-                        Color(&style.color),
-                        PointSymbol(style.symbol),
-                        PointSize(style.size),
-                    ]);
+                    axes.points(
+                        x,
+                        y,
+                        &[
+                            Caption(&style.caption),
+                            Color(&style.color),
+                            PointSymbol(style.symbol),
+                            PointSize(style.size),
+                        ],
+                    );
                 }
             }
         }
@@ -388,8 +419,7 @@ mod tests {
 
     #[test]
     fn test_path_style() {
-        let style = PathStyle::new(colors::RED, "Test Path")
-            .with_line_width(3.0);
+        let style = PathStyle::new(colors::RED, "Test Path").with_line_width(3.0);
         assert_eq!(style.line_width, 3.0);
         assert_eq!(style.color, colors::RED);
     }


### PR DESCRIPTION
## Summary
- stabilize `cargo` all-targets build/test by aligning bin targets, wrappers, imports, and flaky ICP tests
- refactor `move_to_pose` and `state_machine` toward library-first APIs with thin demo bins
- add `aerial_navigation::grid_a_star_3d` and `mission_planning::behavior_tree`
- format the repository with `rustfmt` and prepare the integration branch for review

## Validation
- `cargo test --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -W clippy::all`

## Notes
- this PR includes a repository-wide `rustfmt` commit, so the diff is larger than the feature delta alone
- warnings still remain in existing modules, but the current integration branch is green on the checks above
