### PR TITLE
Trim showcase marketing copy

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -316,22 +316,11 @@ const galleryItems = [
   }
 ];
 
-const repoUrl = "https://github.com/rsasaki0109/rust_robotics";
-const defaultTweet = [
-  "RustRobotics now has a visual showcase wall:",
-  "localization, SLAM, planning, control, mission logic, and aerial navigation in one scrollable page.",
-  "https://rsasaki0109.github.io/rust_robotics/",
-  "#rustlang #robotics #opensource"
-].join("\n");
-
 const galleryGrid = document.getElementById("gallery-grid");
 const filtersRoot = document.getElementById("category-filters");
 const marqueeRoot = document.getElementById("hero-marquee");
 const template = document.getElementById("card-template");
 const galleryCount = document.getElementById("gallery-count");
-const tweetCopy = document.getElementById("tweet-copy");
-const copyPostButton = document.getElementById("copy-post");
-const shareLink = document.getElementById("share-link");
 const visualCount = document.getElementById("visual-count");
 const moduleCount = document.getElementById("module-count");
 
@@ -340,8 +329,6 @@ const stats = {
   modules: 12
 };
 
-tweetCopy.textContent = defaultTweet;
-shareLink.href = `https://twitter.com/intent/tweet?text=${encodeURIComponent(defaultTweet)}`;
 visualCount.textContent = stats.visuals.toString();
 moduleCount.textContent = stats.modules.toString();
 
@@ -437,21 +424,6 @@ function renderMarquee(items) {
 
   marqueeRoot.replaceChildren(...cards);
 }
-
-copyPostButton.addEventListener("click", async () => {
-  try {
-    await navigator.clipboard.writeText(defaultTweet);
-    copyPostButton.textContent = "Copied";
-    window.setTimeout(() => {
-      copyPostButton.textContent = "Copy post text";
-    }, 1400);
-  } catch (error) {
-    copyPostButton.textContent = "Copy failed";
-    window.setTimeout(() => {
-      copyPostButton.textContent = "Copy post text";
-    }, 1400);
-  }
-});
 
 renderMarquee(galleryItems);
 renderFilters(galleryItems);

--- a/docs/assets/social-preview.svg
+++ b/docs/assets/social-preview.svg
@@ -27,7 +27,7 @@
   </g>
   <text x="300" y="150" fill="#ffe082" font-size="26" font-family="IBM Plex Mono, monospace">GitHub Pages showcase</text>
   <text x="300" y="248" fill="#f4ede3" font-size="78" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">Rust robotics demos</text>
-  <text x="300" y="332" fill="#f4ede3" font-size="78" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">that look built for the timeline</text>
+  <text x="300" y="332" fill="#f4ede3" font-size="78" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">in one visual wall</text>
   <text x="300" y="406" fill="#9ab0bf" font-size="28" font-family="Space Grotesk, Arial, sans-serif">Localization. SLAM. Planning. Control. Mission logic. Aerial navigation.</text>
   <g transform="translate(300 458)">
     <rect width="210" height="56" rx="28" fill="rgba(53, 208, 186, 0.16)" stroke="#35d0ba"/>

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,17 +37,16 @@
         <div class="topbar-links">
           <a href="https://github.com/rsasaki0109/rust_robotics" target="_blank" rel="noreferrer">Repository</a>
           <a href="#gallery">Gallery</a>
-          <a href="#share">Post on X</a>
         </div>
       </nav>
 
       <div class="hero-grid">
         <section class="hero-copy">
           <p class="eyebrow">GitHub Pages launch wall</p>
-          <h1>Rust robotics demos that look built for the timeline.</h1>
+          <h1>Rust robotics demos in one visual wall.</h1>
           <p class="hero-text">
             Localization, SLAM, planning, control, mission logic, and aerial navigation,
-            all rendered into a dense visual wall you can scroll, share, and point people at in one link.
+            all rendered into a dense visual wall you can browse and use as a front door to the repo.
           </p>
 
           <div class="hero-actions">
@@ -84,24 +83,6 @@
     </header>
 
     <main>
-      <section class="share-card" id="share">
-        <div>
-          <p class="eyebrow">Tweet-ready</p>
-          <h2>Make the repo feel alive before anyone reads the code.</h2>
-          <p>
-            The page is designed as a visual index first: strong thumbnails, short captions,
-            direct run commands, and enough density to look good in a quote post or screenshot.
-          </p>
-        </div>
-        <div class="share-actions">
-          <pre id="tweet-copy"></pre>
-          <div class="share-buttons">
-            <button class="button button-primary" id="copy-post" type="button">Copy post text</button>
-            <a class="button button-secondary" id="share-link" href="https://twitter.com/intent/tweet" target="_blank" rel="noreferrer">Open X intent</a>
-          </div>
-        </div>
-      </section>
-
       <section class="filters">
         <div>
           <p class="eyebrow">Filter the wall</p>
@@ -126,10 +107,10 @@
       <section class="cta-card">
         <div>
           <p class="eyebrow">Next move</p>
-          <h2>Ship this to GitHub Pages, then pin it.</h2>
+          <h2>Ship this to GitHub Pages.</h2>
           <p>
             This page is static and deploys from GitHub Actions. Once it is live, the repo gets a clean public front door
-            that works for social posts, demos, and quick visual proof.
+            that works for demos, sharing, and quick visual proof.
           </p>
         </div>
         <div class="cta-links">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -68,7 +68,6 @@ button {
 }
 
 .hero,
-.share-card,
 .filters,
 .gallery-section,
 .cta-card {
@@ -78,7 +77,6 @@ button {
 
 .topbar,
 .hero-grid,
-.share-card,
 .filters,
 .cta-card {
   backdrop-filter: blur(18px);
@@ -129,8 +127,7 @@ button {
 .section-note,
 .card-description,
 .hero-text,
-.cta-card p,
-.share-card p {
+.cta-card p {
   color: var(--muted);
 }
 
@@ -162,7 +159,6 @@ button {
 }
 
 .hero-copy h1,
-.share-card h2,
 .filters h2,
 .section-heading h2,
 .cta-card h2 {
@@ -184,7 +180,6 @@ button {
 }
 
 .hero-actions,
-.share-buttons,
 .cta-links {
   display: flex;
   flex-wrap: wrap;
@@ -301,7 +296,6 @@ button {
   font-size: 0.92rem;
 }
 
-.share-card,
 .filters,
 .cta-card {
   margin-top: 28px;
@@ -312,30 +306,10 @@ button {
   box-shadow: var(--shadow);
 }
 
-.share-card {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(300px, 420px);
-  gap: 24px;
-}
-
-.share-card h2,
 .filters h2,
 .section-heading h2,
 .cta-card h2 {
   font-size: clamp(2rem, 5vw, 3.6rem);
-}
-
-.share-card pre {
-  margin: 0;
-  padding: 18px;
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.03);
-  color: var(--ink);
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.92rem;
-  line-height: 1.65;
-  white-space: pre-wrap;
 }
 
 .filters {
@@ -514,7 +488,6 @@ button {
 
 @media (max-width: 1100px) {
   .hero-grid,
-  .share-card,
   .filters,
   .cta-card {
     grid-template-columns: 1fr;
@@ -548,7 +521,6 @@ button {
   }
 
   .hero-grid,
-  .share-card,
   .filters,
   .cta-card {
     padding: 22px;


### PR DESCRIPTION
## Summary
- remove the share/tweet promo section from the showcase page
- trim the hero copy and social preview headline
- keep the gallery-focused landing page intact

## Verification
- searched for removed copy and share elements
- checked docs/app.js with node --check
- parsed docs/index.html with Python HTMLParser
