### PR TITLE
Use SVG for JPS showcase card

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -95,7 +95,7 @@ const galleryItems = [
   {
     title: "Jump Point Search",
     category: "Path Planning",
-    image: "img/path_planning/jps_result.png",
+    image: "img/path_planning/jps_result.svg",
     command: "cargo run --example jps",
     description: "Aggressive pruning with the same visual clarity as a direct A* comparison."
   },


### PR DESCRIPTION
## Summary
- switch the GitHub Pages JPS card from the stale PNG to the generated SVG
- align the showcase asset with the README reference

## Verification
- checked docs/app.js syntax with node --check
- confirmed both README and docs point to jps_result.svg
- confirmed the live jps_result.svg asset returns HTTP 200
