### PR TITLE
Refresh showcase images for CGMRES and state lattice

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -173,7 +173,7 @@ const galleryItems = [
   {
     title: "State Lattice Planner",
     category: "Path Planning",
-    image: "img/path_planning/state_lattice_plan.svg",
+    image: "assets/state-lattice-teaser.svg",
     command: "cargo run --example state_lattice",
     description: "Lattice motion primitives turned into a high-density planner poster."
   },
@@ -237,7 +237,7 @@ const galleryItems = [
   {
     title: "C-GMRES NMPC",
     category: "Path Tracking",
-    image: "img/path_tracking/cgmres_nmpc.svg",
+    image: "assets/cgmres-nmpc-teaser.svg",
     command: "cargo run --bin cgmres_nmpc",
     description: "Nonlinear predictive control with a denser optimization feel."
   },

--- a/docs/assets/cgmres-nmpc-teaser.svg
+++ b/docs/assets/cgmres-nmpc-teaser.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" role="img" aria-labelledby="title desc">
+  <title id="title">C-GMRES NMPC teaser</title>
+  <desc id="desc">A showcase-friendly nonlinear model predictive control trajectory card.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#08111a"/>
+      <stop offset="100%" stop-color="#0f1d2c"/>
+    </linearGradient>
+    <linearGradient id="path" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ff7a18"/>
+      <stop offset="100%" stop-color="#ffd166"/>
+    </linearGradient>
+    <linearGradient id="horizon" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#35d0ba"/>
+      <stop offset="100%" stop-color="#8af0dc"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="900" rx="34" fill="url(#bg)"/>
+  <g opacity="0.14">
+    <circle cx="180" cy="160" r="140" fill="#ff7a18"/>
+    <circle cx="1020" cy="200" r="180" fill="#35d0ba"/>
+  </g>
+  <text x="80" y="118" fill="#f4ede3" font-size="68" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">C-GMRES NMPC</text>
+  <text x="80" y="164" fill="#9ab0bf" font-size="26" font-family="IBM Plex Mono, monospace">cargo run --bin cgmres_nmpc</text>
+  <g transform="translate(80 220)">
+    <rect width="1040" height="560" rx="28" fill="#ffffff"/>
+    <rect x="76" y="54" width="888" height="432" rx="12" fill="#f8f5ef" stroke="#d8d1c6"/>
+    <g stroke="#d8d1c6" stroke-width="2">
+      <line x1="76" y1="486" x2="964" y2="486"/>
+      <line x1="76" y1="378" x2="964" y2="378"/>
+      <line x1="76" y1="270" x2="964" y2="270"/>
+      <line x1="76" y1="162" x2="964" y2="162"/>
+      <line x1="76" y1="54" x2="76" y2="486"/>
+      <line x1="298" y1="54" x2="298" y2="486"/>
+      <line x1="520" y1="54" x2="520" y2="486"/>
+      <line x1="742" y1="54" x2="742" y2="486"/>
+      <line x1="964" y1="54" x2="964" y2="486"/>
+    </g>
+    <g stroke="#8af0dc" stroke-width="4" stroke-linecap="round" opacity="0.55">
+      <path d="M198 420 C260 360, 332 326, 410 308"/>
+      <path d="M198 420 C280 390, 362 366, 452 346"/>
+      <path d="M198 420 C304 404, 410 396, 516 390"/>
+      <path d="M198 420 C308 428, 420 438, 544 454"/>
+      <path d="M198 420 C290 454, 382 482, 482 520"/>
+    </g>
+    <path d="M198 420 C250 372, 312 335, 378 314 C448 292, 526 286, 606 296 C688 307, 768 337, 844 378" fill="none" stroke="url(#path)" stroke-width="18" stroke-linecap="round"/>
+    <circle cx="198" cy="420" r="18" fill="#2563eb"/>
+    <circle cx="844" cy="378" r="18" fill="#16a34a"/>
+    <circle cx="606" cy="296" r="10" fill="#ff7a18"/>
+    <g fill="#1f2937" font-size="26" font-family="IBM Plex Mono, monospace">
+      <text x="170" y="456">start</text>
+      <text x="858" y="386">goal</text>
+      <text x="614" y="284">turn</text>
+    </g>
+    <g fill="#1f2937" font-size="24" font-family="IBM Plex Mono, monospace">
+      <text x="86" y="528">x [m]</text>
+      <text x="964" y="528" text-anchor="end">prediction horizon fan + closed-loop path</text>
+    </g>
+    <g transform="translate(86 548)">
+      <rect width="350" height="74" rx="18" fill="#f4f0e8" stroke="#d8d1c6"/>
+      <line x1="26" y1="37" x2="88" y2="37" stroke="url(#path)" stroke-width="10" stroke-linecap="round"/>
+      <text x="106" y="45" fill="#1f2937" font-size="24" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">trajectory</text>
+      <line x1="204" y1="37" x2="258" y2="37" stroke="#8af0dc" stroke-width="6" stroke-linecap="round"/>
+      <text x="274" y="45" fill="#1f2937" font-size="24" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">prediction</text>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/state-lattice-teaser.svg
+++ b/docs/assets/state-lattice-teaser.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" role="img" aria-labelledby="title desc">
+  <title id="title">State lattice teaser</title>
+  <desc id="desc">A showcase-friendly state lattice planner card with multiple candidate trajectories.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#08111a"/>
+      <stop offset="100%" stop-color="#112031"/>
+    </linearGradient>
+    <linearGradient id="chosen" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ff7a18"/>
+      <stop offset="100%" stop-color="#ffd166"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="900" rx="34" fill="url(#bg)"/>
+  <g opacity="0.12">
+    <circle cx="210" cy="190" r="150" fill="#35d0ba"/>
+    <circle cx="1000" cy="740" r="180" fill="#ff7a18"/>
+  </g>
+  <text x="80" y="118" fill="#f4ede3" font-size="68" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">State Lattice Planner</text>
+  <text x="80" y="164" fill="#9ab0bf" font-size="26" font-family="IBM Plex Mono, monospace">cargo run --example state_lattice</text>
+  <g transform="translate(80 220)">
+    <rect width="1040" height="560" rx="28" fill="#ffffff"/>
+    <rect x="70" y="54" width="900" height="430" rx="14" fill="#f8f5ef" stroke="#d8d1c6"/>
+    <g stroke="#d8d1c6" stroke-width="2">
+      <line x1="70" y1="140" x2="970" y2="140"/>
+      <line x1="70" y1="248" x2="970" y2="248"/>
+      <line x1="70" y1="356" x2="970" y2="356"/>
+      <line x1="70" y1="464" x2="970" y2="464"/>
+      <line x1="205" y1="54" x2="205" y2="484"/>
+      <line x1="385" y1="54" x2="385" y2="484"/>
+      <line x1="565" y1="54" x2="565" y2="484"/>
+      <line x1="745" y1="54" x2="745" y2="484"/>
+      <line x1="925" y1="54" x2="925" y2="484"/>
+    </g>
+    <g stroke="#cbd5e1" stroke-width="5" fill="none" stroke-linecap="round">
+      <path d="M140 420 C260 350, 360 310, 500 290 C620 272, 770 278, 920 332"/>
+      <path d="M140 420 C270 378, 386 350, 532 344 C664 338, 790 362, 920 414"/>
+      <path d="M140 420 C286 418, 426 424, 576 444 C704 462, 820 486, 920 520"/>
+      <path d="M140 420 C250 310, 370 226, 524 178 C678 132, 816 126, 920 156"/>
+      <path d="M140 420 C246 446, 340 470, 454 520 C602 584, 760 636, 920 664"/>
+      <path d="M140 420 C248 394, 338 372, 444 316 C536 266, 608 206, 684 134"/>
+    </g>
+    <path d="M140 420 C250 356, 358 314, 496 286 C628 260, 766 268, 920 326" fill="none" stroke="url(#chosen)" stroke-width="18" stroke-linecap="round"/>
+    <circle cx="140" cy="420" r="18" fill="#2563eb"/>
+    <circle cx="920" cy="326" r="18" fill="#16a34a"/>
+    <g fill="#1f2937" font-size="26" font-family="IBM Plex Mono, monospace">
+      <text x="116" y="456">start</text>
+      <text x="938" y="334">goal</text>
+    </g>
+    <g transform="translate(86 514)">
+      <rect width="440" height="76" rx="18" fill="#f4f0e8" stroke="#d8d1c6"/>
+      <line x1="24" y1="38" x2="90" y2="38" stroke="url(#chosen)" stroke-width="10" stroke-linecap="round"/>
+      <text x="108" y="46" fill="#1f2937" font-size="24" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">selected trajectory</text>
+      <line x1="274" y1="38" x2="338" y2="38" stroke="#94a3b8" stroke-width="8" stroke-linecap="round"/>
+      <text x="356" y="46" fill="#1f2937" font-size="24" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">lattice samples</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- replace the GitHub Pages CGMRES card image with a clearer showcase teaser
- replace the State Lattice card image with a denser lattice-style teaser
- keep raw algorithm output assets in the repo unchanged

## Verification
- checked docs/app.js with node --check
- verified the new SVG teaser assets are present and parse as SVG
