### PR TITLE
Use actual state lattice and CGMRES images in showcase

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -173,7 +173,7 @@ const galleryItems = [
   {
     title: "State Lattice Planner",
     category: "Path Planning",
-    image: "assets/state-lattice-teaser.svg",
+    image: "img/path_planning/state_lattice_lane.svg",
     command: "cargo run --example state_lattice",
     description: "Lattice motion primitives turned into a high-density planner poster."
   },
@@ -237,7 +237,7 @@ const galleryItems = [
   {
     title: "C-GMRES NMPC",
     category: "Path Tracking",
-    image: "assets/cgmres-nmpc-teaser.svg",
+    image: "img/path_tracking/cgmres_nmpc.svg",
     command: "cargo run --bin cgmres_nmpc",
     description: "Nonlinear predictive control with a denser optimization feel."
   },

--- a/docs/assets/behavior-tree-teaser.svg
+++ b/docs/assets/behavior-tree-teaser.svg
@@ -3,8 +3,8 @@
   <desc id="desc">A stylized behavior tree diagram for the GitHub Pages showcase.</desc>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0d1824"/>
-      <stop offset="100%" stop-color="#08111a"/>
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#f4f0e8"/>
     </linearGradient>
     <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#35d0ba"/>
@@ -28,8 +28,8 @@
     <circle cx="1030" cy="220" r="160" fill="#35d0ba"/>
     <circle cx="980" cy="760" r="180" fill="#ffd166"/>
   </g>
-  <text x="80" y="118" fill="#f4ede3" font-size="68" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">Behavior Tree</text>
-  <text x="80" y="164" fill="#9ab0bf" font-size="26" font-family="IBM Plex Mono, monospace">cargo run --bin behavior_tree</text>
+  <text x="80" y="118" fill="#1f2937" font-size="68" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">Behavior Tree</text>
+  <text x="80" y="164" fill="#64748b" font-size="26" font-family="IBM Plex Mono, monospace">cargo run --bin behavior_tree</text>
   <g stroke="#35506c" stroke-width="8" stroke-linecap="round">
     <path d="M600 230v90"/>
     <path d="M260 430h680"/>
@@ -43,26 +43,26 @@
     <text x="600" y="238" text-anchor="middle" fill="#08111a" font-size="34" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">mission_root</text>
   </g>
   <g>
-    <rect x="150" y="320" width="220" height="84" rx="22" fill="#10202f" stroke="#35506c" stroke-width="4"/>
-    <rect x="390" y="320" width="220" height="84" rx="22" fill="#10202f" stroke="#35506c" stroke-width="4"/>
-    <rect x="630" y="320" width="220" height="84" rx="22" fill="#10202f" stroke="#35506c" stroke-width="4"/>
-    <rect x="870" y="320" width="220" height="84" rx="22" fill="#10202f" stroke="#35506c" stroke-width="4"/>
+    <rect x="150" y="320" width="220" height="84" rx="22" fill="#fff8ef" stroke="#35506c" stroke-width="4"/>
+    <rect x="390" y="320" width="220" height="84" rx="22" fill="#fff8ef" stroke="#35506c" stroke-width="4"/>
+    <rect x="630" y="320" width="220" height="84" rx="22" fill="#fff8ef" stroke="#35506c" stroke-width="4"/>
+    <rect x="870" y="320" width="220" height="84" rx="22" fill="#fff8ef" stroke="#35506c" stroke-width="4"/>
     <text x="260" y="374" text-anchor="middle" fill="#7ef0cb" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">sense</text>
     <text x="500" y="374" text-anchor="middle" fill="#7ef0cb" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">plan</text>
     <text x="740" y="374" text-anchor="middle" fill="#7ef0cb" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">act</text>
     <text x="980" y="374" text-anchor="middle" fill="#7ef0cb" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">recover</text>
   </g>
   <g>
-    <rect x="120" y="500" width="280" height="94" rx="24" fill="#0d1824" stroke="#ff7a18" stroke-width="4"/>
-    <rect x="320" y="650" width="280" height="94" rx="24" fill="#0d1824" stroke="#35d0ba" stroke-width="4"/>
-    <rect x="600" y="500" width="280" height="94" rx="24" fill="#0d1824" stroke="#35d0ba" stroke-width="4"/>
-    <rect x="800" y="650" width="280" height="94" rx="24" fill="#0d1824" stroke="#ff7a18" stroke-width="4"/>
-    <text x="260" y="557" text-anchor="middle" fill="#f4ede3" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">check battery</text>
-    <text x="460" y="707" text-anchor="middle" fill="#f4ede3" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">scan obstacles</text>
-    <text x="740" y="557" text-anchor="middle" fill="#f4ede3" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">run planner</text>
-    <text x="940" y="707" text-anchor="middle" fill="#f4ede3" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">fallback route</text>
+    <rect x="120" y="500" width="280" height="94" rx="24" fill="#ffffff" stroke="#ff7a18" stroke-width="4"/>
+    <rect x="320" y="650" width="280" height="94" rx="24" fill="#ffffff" stroke="#35d0ba" stroke-width="4"/>
+    <rect x="600" y="500" width="280" height="94" rx="24" fill="#ffffff" stroke="#35d0ba" stroke-width="4"/>
+    <rect x="800" y="650" width="280" height="94" rx="24" fill="#ffffff" stroke="#ff7a18" stroke-width="4"/>
+    <text x="260" y="557" text-anchor="middle" fill="#1f2937" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">check battery</text>
+    <text x="460" y="707" text-anchor="middle" fill="#1f2937" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">scan obstacles</text>
+    <text x="740" y="557" text-anchor="middle" fill="#1f2937" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">run planner</text>
+    <text x="940" y="707" text-anchor="middle" fill="#1f2937" font-size="28" font-family="Space Grotesk, Arial, sans-serif" font-weight="600">fallback route</text>
   </g>
-  <g fill="#9ab0bf" font-size="24" font-family="IBM Plex Mono, monospace">
+  <g fill="#64748b" font-size="24" font-family="IBM Plex Mono, monospace">
     <text x="80" y="820">Mission planning module added in the integration phase.</text>
     <text x="80" y="854">Diagram-only teaser until simulation screenshots land.</text>
   </g>

--- a/docs/assets/grid-a-star-3d-teaser.svg
+++ b/docs/assets/grid-a-star-3d-teaser.svg
@@ -3,8 +3,8 @@
   <desc id="desc">A stylized isometric aerial grid path for the GitHub Pages showcase.</desc>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a141f"/>
-      <stop offset="100%" stop-color="#071018"/>
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#f4f0e8"/>
     </linearGradient>
     <linearGradient id="path" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" stop-color="#ff7a18"/>
@@ -20,8 +20,8 @@
     <circle cx="210" cy="170" r="140" fill="#35d0ba"/>
     <circle cx="1010" cy="740" r="190" fill="#ff7a18"/>
   </g>
-  <text x="80" y="118" fill="#f4ede3" font-size="68" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">3D Grid A*</text>
-  <text x="80" y="164" fill="#9ab0bf" font-size="26" font-family="IBM Plex Mono, monospace">cargo run --bin grid_a_star_3d</text>
+  <text x="80" y="118" fill="#1f2937" font-size="68" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">3D Grid A*</text>
+  <text x="80" y="164" fill="#64748b" font-size="26" font-family="IBM Plex Mono, monospace">cargo run --bin grid_a_star_3d</text>
   <g transform="translate(160 250)">
     <g stroke="#274258" stroke-width="2" opacity="0.8">
       <path d="M0 100 260 0 640 180 380 280Z" fill="none"/>
@@ -35,7 +35,7 @@
       <path d="M520 130 900 310"/>
       <path d="M620 170 1000 350"/>
     </g>
-    <g fill="#112131">
+    <g fill="#dbe4ef">
       <path d="M260 80 320 50 320 140 260 170Z"/>
       <path d="M420 90 500 130 500 250 420 210Z"/>
       <path d="M520 130 620 170 620 310 520 270Z"/>
@@ -52,12 +52,12 @@
     <g fill="url(#goal)">
       <circle cx="860" cy="200" r="22"/>
     </g>
-    <g fill="#f4ede3" font-family="IBM Plex Mono, monospace" font-size="22">
+    <g fill="#1f2937" font-family="IBM Plex Mono, monospace" font-size="22">
       <text x="0" y="360">start</text>
       <text x="878" y="204">goal</text>
     </g>
   </g>
-  <g fill="#9ab0bf" font-size="24" font-family="IBM Plex Mono, monospace">
+  <g fill="#64748b" font-size="24" font-family="IBM Plex Mono, monospace">
     <text x="80" y="820">Aerial navigation teaser for the new 3D planner module.</text>
     <text x="80" y="854">Designed for the showcase until rendered screenshots are added.</text>
   </g>


### PR DESCRIPTION
## Summary
- switch the showcase state lattice card to the actual lane-sampling SVG
- switch the showcase C-GMRES card back to the actual generated SVG
- change the remaining visible teaser cards to white backgrounds

## Verification
- checked docs/app.js with node --check
- verified updated image references in docs/app.js
- verified teaser SVGs now use white backgrounds
