### PR TITLE
Improve histogram filter showcase readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cargo run --bin unscented_kalman_filter
 
 Grid-based probabilistic localization using RFID landmarks. The algorithm maintains a probability distribution over a 2D grid and updates it based on motion and observations.
 
-Blue: True path, Yellow: Dead Reckoning, Green: Histogram Filter estimate, Black: RFID landmarks
+Blue: True path, Orange: Dead Reckoning, Green: Histogram Filter estimate, Black: RFID landmarks
 
 - [src](./src/localization/histogram_filter.rs)
 

--- a/img/localization/histogram_filter.svg
+++ b/img/localization/histogram_filter.svg
@@ -1,494 +1,961 @@
-<?xml version="1.0" encoding="utf-8"  standalone="no"?>
-<svg 
- width="640" height="480"
- viewBox="0 0 640 480"
- xmlns="http://www.w3.org/2000/svg"
- xmlns:xlink="http://www.w3.org/1999/xlink"
->
-
-<title>Gnuplot</title>
-<desc>Produced by GNUPLOT 6.0 patchlevel 4 </desc>
-
-<g id="gnuplot_canvas">
-
-<rect x="0" y="0" width="640" height="480" fill="none"/>
-<defs>
-
-	<circle id='gpDot' r='0.5' stroke-width='0.5' stroke='currentColor'/>
-	<path id='gpPt0' stroke-width='0.222' stroke='currentColor' d='M-1,0 h2 M0,-1 v2'/>
-	<path id='gpPt1' stroke-width='0.222' stroke='currentColor' d='M-1,-1 L1,1 M1,-1 L-1,1'/>
-	<path id='gpPt2' stroke-width='0.222' stroke='currentColor' d='M-1,0 L1,0 M0,-1 L0,1 M-1,-1 L1,1 M-1,1 L1,-1'/>
-	<rect id='gpPt3' stroke-width='0.222' stroke='currentColor' x='-1' y='-1' width='2' height='2'/>
-	<rect id='gpPt4' stroke-width='0.222' stroke='currentColor' fill='currentColor' x='-1' y='-1' width='2' height='2'/>
-	<circle id='gpPt5' stroke-width='0.222' stroke='currentColor' cx='0' cy='0' r='1'/>
-	<use xlink:href='#gpPt5' id='gpPt6' fill='currentColor' stroke='none'/>
-	<path id='gpPt7' stroke-width='0.222' stroke='currentColor' d='M0,-1.33 L-1.33,0.67 L1.33,0.67 z'/>
-	<use xlink:href='#gpPt7' id='gpPt8' fill='currentColor' stroke='none'/>
-	<use xlink:href='#gpPt7' id='gpPt9' stroke='currentColor' transform='rotate(180)'/>
-	<use xlink:href='#gpPt9' id='gpPt10' fill='currentColor' stroke='none'/>
-	<use xlink:href='#gpPt3' id='gpPt11' stroke='currentColor' transform='rotate(45)'/>
-	<use xlink:href='#gpPt11' id='gpPt12' fill='currentColor' stroke='none'/>
-	<path id='gpPt13' stroke-width='0.222' stroke='currentColor' d='M0,1.330 L1.265,0.411 L0.782,-1.067 L-0.782,-1.076 L-1.265,0.411 z'/>
-	<use xlink:href='#gpPt13' id='gpPt14' fill='currentColor' stroke='none'/>
-	<filter id='textbox' filterUnits='objectBoundingBox' x='0' y='0' height='1' width='1'>
-	  <feFlood flood-color='white' flood-opacity='1' result='bgnd'/>
-	  <feComposite in='SourceGraphic' in2='bgnd' operator='atop'/>
-	</filter>
-	<filter id='greybox' filterUnits='objectBoundingBox' x='0' y='0' height='1' width='1'>
-	  <feFlood flood-color='lightgrey' flood-opacity='1' result='grey'/>
-	  <feComposite in='SourceGraphic' in2='grey' operator='atop'/>
-	</filter>
-</defs>
-<g fill="none" color="white" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M64.14,400.73 L68.64,400.73 M524.74,400.73 L520.24,400.73  '/>	<g transform="translate(55.75,404.63)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="end">
-		<text><tspan font-family="Arial" >-5</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M64.14,346.55 L68.64,346.55 M524.74,346.55 L520.24,346.55  '/>	<g transform="translate(55.75,350.45)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="end">
-		<text><tspan font-family="Arial" > 0</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M64.14,292.38 L68.64,292.38 M524.74,292.38 L520.24,292.38  '/>	<g transform="translate(55.75,296.28)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="end">
-		<text><tspan font-family="Arial" > 5</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M64.14,238.20 L68.64,238.20 M524.74,238.20 L520.24,238.20  '/>	<g transform="translate(55.75,242.10)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="end">
-		<text><tspan font-family="Arial" > 10</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M64.14,184.03 L68.64,184.03 M524.74,184.03 L520.24,184.03  '/>	<g transform="translate(55.75,187.93)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="end">
-		<text><tspan font-family="Arial" > 15</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M64.14,129.85 L68.64,129.85 M524.74,129.85 L520.24,129.85  '/>	<g transform="translate(55.75,133.75)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="end">
-		<text><tspan font-family="Arial" > 20</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M64.14,75.68 L68.64,75.68 M524.74,75.68 L520.24,75.68  '/>	<g transform="translate(55.75,79.58)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="end">
-		<text><tspan font-family="Arial" > 25</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M91.23,422.40 L91.23,417.90 M91.23,54.01 L91.23,58.51  '/>	<g transform="translate(91.23,444.30)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text><tspan font-family="Arial" >-15</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M158.97,422.40 L158.97,417.90 M158.97,54.01 L158.97,58.51  '/>	<g transform="translate(158.97,444.30)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text><tspan font-family="Arial" >-10</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M226.70,422.40 L226.70,417.90 M226.70,54.01 L226.70,58.51  '/>	<g transform="translate(226.70,444.30)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text><tspan font-family="Arial" >-5</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M294.44,422.40 L294.44,417.90 M294.44,54.01 L294.44,58.51  '/>	<g transform="translate(294.44,444.30)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text><tspan font-family="Arial" > 0</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M362.18,422.40 L362.18,417.90 M362.18,54.01 L362.18,58.51  '/>	<g transform="translate(362.18,444.30)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text><tspan font-family="Arial" > 5</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M429.91,422.40 L429.91,417.90 M429.91,54.01 L429.91,58.51  '/>	<g transform="translate(429.91,444.30)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text><tspan font-family="Arial" > 10</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M497.65,422.40 L497.65,417.90 M497.65,54.01 L497.65,58.51  '/>	<g transform="translate(497.65,444.30)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text><tspan font-family="Arial" > 15</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M64.14,54.01 L64.14,422.40 L524.74,422.40 L524.74,54.01 L64.14,54.01 Z  '/></g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-</g>
-	<g id="gnuplot_plot_1"  fill="none"><title>gnuplot_plot_1</title>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-<image x='87.79' y='72.93' width='413.30' height='330.55' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAIAAAC1nk4lAAAABmJLR0QA/wD/AP+gvaeTAAAIVUlEQVRoge2aS28kVxXHf/dRVf1wu2c8njiPIUFDooR3AhtASEghYoP4CHy0iG+AsmCJxAIhJILCCgmBIlCYkJmJ3+6ux30dFlXVbttjx5npdjZzVC5VuUv3/vrfp88959yG5/bcnttzexpT3d8lJs8++jqGvYL4Waa5zrBPjX4GenF9xXDXmemaQlxztCeMr75ojieOe8Vk1yf+wqEuM6uunEkukV897XwrMaXhCrHl8ouLz/DlZb5szKvNKtCXxJBWZlkaU56ksTr70g2YVb3SqkfvgUQ6GnWO/gr0mzGrUbpzkjPzCqrlFhBEQKHkAvpX4tZWowxKoxRqiVsWrHIWXc6id09/FdDaoDV6AS0ISEIEkf4iofpb6D8H9VVIbg3KYixWo1XH3SqaBEmk9mjREyl1D8iy5DfMbS0mI8/IDFZhWrEFEVIi9keK3VkpkoIEy5LfMLe12JwiZ2jIDVah6YBiIiRCxEdCe2hiTy8JoXebZdovy/00K2JGXjAumFhGhlxhFQgp4SM+0kRcpAk0AR/wmhCJihh7yem5nxgKV04M2JzBgOmAOzlTw1CTgRJiwkWaSBkoPWWg8lSGJuACXqFa7g57iZv1+4nNGQ3ZHvFKznbGRFOAFkLqiGeeY8+x48Ry4phrKkXdx8cAnOPmev79LO/KFmwOeXnM/QEvZ9w2DJXSIjFSB2aBQ8eBYz9jr+HAcGg4aeMMNMDTcT/j52ALbo94bYO3RuprOVuGoUKLSonGM/McOtlreFTzyPLIMNBkCqPQS+tnWAp8shxPVo7bQQ/YHnN/ot4cq3sFE6usRglEYpDGMa/Zb7ibyW3LpHX6pchIH7MFUouelsjOib0qR7cDdsbq/kR9faKmA50y5bQKgoqSexk7GddpWsntTE2tbBgKtRQWF6zLC75C1JVirwC64MUxr030rU0zG5n/5uZTrU7AxHTLpZ0m7tRqM087mQwNA0WGaBAhtke79KRT9LRwklb4dUQSO+DFkXphoqtp9tE4/0OefWTMZ6BjfMmFbzX+nSp8NwuvmjRVyfTEIeETLuEiPhFadE1KKIUsEhIupK+r8emCF0Z6NLZ/nwx+uzF6vxjObAYQA775oG5+nNe/tO7n2n9bMSG9nPBR6kgVKSN16FafYDpu6fNvucyzVwCdqztDFcf5hxuj30xuzQab2AFKER2+Ip/92c7+qctDSML3k2wEXgzMghwFjjwnGfNAHXAGH4nLYq/Ps23GtNCzYfbH0cbx+A7DO2QbKENs8CfYA4zZg/dT2ohpM6S3XJo62XHsOfZy9j1HnpklC1hNUF15f+ok6zBrGWX6MM//UowZbDF8ifw2ypIa3AE6B0jxIITf+fh6k3YGcrdRtxq2a9nKmFrGbfA2GI3Rndjn15bVvgGrya3at/Zf2ZB8k3yb/C56gNToIUBsCBVN/dfa/a0I3yviVsYoY5oxtWwYRobCkGlMW0b0Ynd157kaZyX0VqGV8lo32mIK7Ag7RY+QBhHinPyI7IjshMz+I9OPrPpGpgorI6vGRlriXPe5uFrQ9mzr6JBoIQlGBFKXIwNKozJ0hs7RGdpiDEY/NurIKK/RmlxTaArdZbNmUfgsqNdnOuFj2ojh1eAIJfGkP+bEmuSRuCxUgqRaQ/dJSFukXbeX+exmI6WXHed/4OafuEOaz0FjN0AIM8IRviQ0xEBK20nGgpXW+vUPWCir1q4ygPUcN+n12v20mn2Q73dxw4wBUo07ojmkKXENPrwZ0t0gRSS1y6HghSBEIS26DjdQKFrHfp2y0v9kNn/P7P9eEn6OHaA00eFL6hOqE+rm3dq/06SXvGRe6kAZZR6pEy513DeB20E38rhM9cx/s6h+rVUVw5+KOTYDjUR8Q1NTVT+b17+qwtt13G4SjrnjKHAcmEWqljsR5UzGt07oms9K2Z3Fe9a9myhc+E5Rfmjsv5UqRSYh3Hf+7dr/qPQ/nIf7ZRpUMq9lz8mu4yBwEigjzSJnki7lWK/ktubhnE+O05YOr0R5rwlv5OYXVj9WqhYpYtr26V4T71XxbpkGZapL2a152PDIses5DMwDdcSdzVFPfWUdqtuahzP5OGdLxVe93KnjNNdvGFVrvGCiFEGGTvI6Ucmskt2STyt5UPO/hl3HkWceqdveyFJWLX2qdB54Nalpze6cjzPZFKJLOwUbWRpbNWnXtCQSiU4qx0kt+zUPK3lQ86DmswW0pwn4Xmk5p/QKWU+hG/ZL/mMYRKkb9gu22rJKKyNIW5a3FW4jew2PGh7WPKp53LDnOPaUgSbiY+8eac2+0UIfl3yqsJHSyecZW5YNo4ZKLCCEKHXsuh/7jn3HXsN+w4Hj2DHz1AEXCPH0i3haMq4BuIOeV3wOKlI27GZsGsZGBgrTt5qaSBWYB44XjRvPzFF6qrZd1svcNoVPZeaSi2eF9tQ1RyCRynJgGRkGmryFpmtDNpE6UIWuS1YF6l5j38ocO2iWZV5XEeBwhpmQAo3lxFDoLtVs972SEPve6aIZ6QIunuIuiLuWu1yp9wqgA8HRCBLxhkpjNVZjQPUpfPv1atu+3Tmewe2I01L3Y+WgZ6AjyeOFFAm6K5kW2WY7cdtgT32bPS0CxVmBz6ze53BXHPIiSRETYkhtvbS0+dKVHYtGTLuD0W9rPMEf1u0YC2iBpJFEWuxxqVPidtblxtfp1lFb7izjcoF4HWYTKJKg0tJuorqQyC8yoSU5T1e+K4jXQa8sqH6HfOlHCeegu/jVM50iytmXboAYUObsHvPFn39chFigX/jPGVufhyw0XpyvqvCW95gvu3ji7WrNnLu/LMW5Imu7SdzWTuv+L1VDX/bGbsb+D3ww+9gTiAUYAAAAAElFTkSuQmCC'/>
-</g>
-	</g>
-	<g id="gnuplot_plot_2" ><title>RFID</title>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<g transform="translate(457.01,75.91)" stroke="none" fill="black" font-family="Arial" font-size="12.00"  text-anchor="end">
-		<text><tspan font-family="Arial" >RFID</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<use xlink:href='#gpPt6' transform='translate(429.91,346.55) scale(9.00)' color='rgb(  0,   0,   0)'/>
-	<use xlink:href='#gpPt6' transform='translate(429.91,238.20) scale(9.00)' color='rgb(  0,   0,   0)'/>
-	<use xlink:href='#gpPt6' transform='translate(294.44,184.03) scale(9.00)' color='rgb(  0,   0,   0)'/>
-	<use xlink:href='#gpPt6' transform='translate(226.70,129.85) scale(9.00)' color='rgb(  0,   0,   0)'/>
-	<use xlink:href='#gpPt6' transform='translate(486.68,72.01) scale(9.00)' color='rgb(  0,   0,   0)'/>
-</g>
-	</g>
-	<g id="gnuplot_plot_3" ><title>True</title>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<g transform="translate(457.01,93.91)" stroke="none" fill="black" font-family="Arial" font-size="12.00"  text-anchor="end">
-		<text><tspan font-family="Arial" >True</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0, 255)'  d='M465.40,90.01 L507.96,90.01 M294.44,346.55 L295.79,346.55 L297.15,346.54 L298.50,346.52 L299.86,346.49 L301.21,346.45
-		L302.56,346.39 L303.92,346.33 L305.27,346.25 L306.62,346.17 L307.97,346.07 L309.32,345.96 L310.66,345.84 L312.01,345.71
-		L313.35,345.57 L314.69,345.42 L316.03,345.26 L317.37,345.08 L318.70,344.90 L320.04,344.71 L321.37,344.50 L322.69,344.29
-		L324.02,344.06 L325.34,343.83 L326.66,343.58 L327.98,343.32 L329.29,343.05 L330.60,342.77 L331.90,342.49 L333.21,342.19
-		L334.50,341.88 L335.80,341.56 L337.09,341.23 L338.37,340.88 L339.66,340.53 L340.93,340.17 L342.21,339.80 L343.47,339.42
-		L344.74,339.03 L345.99,338.62 L347.25,338.21 L348.50,337.79 L349.74,337.36 L350.97,336.92 L352.21,336.47 L353.43,336.00
-		L354.65,335.53 L355.87,335.05 L357.07,334.56 L358.28,334.06 L359.47,333.55 L360.66,333.03 L361.84,332.50 L363.02,331.96
-		L364.19,331.42 L365.35,330.86 L366.50,330.29 L367.65,329.72 L368.79,329.13 L369.92,328.54 L371.05,327.94 L372.17,327.32
-		L373.28,326.70 L374.38,326.07 L375.48,325.44 L376.56,324.79 L377.64,324.13 L378.71,323.47 L379.77,322.80 L380.83,322.11
-		L381.87,321.42 L382.91,320.73 L383.93,320.02 L384.95,319.31 L385.96,318.58 L386.96,317.85 L387.95,317.11 L388.94,316.37
-		L389.91,315.61 L390.87,314.85 L391.83,314.08 L392.77,313.30 L393.70,312.52 L394.63,311.73 L395.54,310.93 L396.45,310.12
-		L397.34,309.31 L398.22,308.49 L399.10,307.66 L399.96,306.82 L400.81,305.98 L401.66,305.13 L402.49,304.28 L403.31,303.41
-		L404.12,302.55 L404.92,301.67 L405.70,300.79 L406.48,299.90 L407.25,299.01 L408.00,298.11 L408.74,297.20 L409.48,296.29
-		L410.20,295.37 L410.91,294.45 L411.60,293.52 L412.29,292.59 L412.96,291.65 L413.63,290.70 L414.28,289.75 L414.91,288.80
-		L415.54,287.84 L416.16,286.87 L416.76,285.90 L417.35,284.92 L417.93,283.94 L418.49,282.96 L419.05,281.97 L419.59,280.98
-		L420.12,279.98 L420.63,278.98 L421.13,277.97 L421.63,276.96 L422.10,275.95 L422.57,274.93 L423.02,273.91 L423.46,272.88
-		L423.89,271.86 L424.30,270.83 L424.71,269.79 L425.09,268.75 L425.47,267.71 L425.83,266.67 L426.18,265.62 L426.52,264.57
-		L426.84,263.52 L427.15,262.46 L427.45,261.41 L427.73,260.35 L428.00,259.29 L428.26,258.22 L428.50,257.16 L428.73,256.09
-		L428.95,255.02 L429.15,253.95 L429.34,252.87 L429.52,251.80 L429.68,250.72 L429.83,249.65 L429.97,248.57 L430.09,247.49
-		L430.20,246.41 L430.30,245.33 L430.38,244.25 L430.45,243.17 L430.50,242.08 L430.54,241.00 L430.57,239.92 L430.59,238.83
-		L430.59,237.75 L430.57,236.67 L430.55,235.58 L430.51,234.50 L430.46,233.42 L430.39,232.34 L430.31,231.25 L430.22,230.17
-		L430.11,229.09 L429.99,228.01 L429.85,226.94 L429.71,225.86 L429.54,224.78 L429.37,223.71 L429.18,222.64 L428.98,221.56
-		L428.77,220.49 L428.54,219.43 L428.30,218.36 L428.04,217.30 L427.77,216.23 L427.49,215.17 L427.20,214.12 L426.89,213.06
-		L426.57,212.01 L426.23,210.96 L425.89,209.91 L425.53,208.87 L425.15,207.83 L424.77,206.79 L424.37,205.75 L423.96,204.72
-		L423.53,203.69 L423.09,202.67 L422.64,201.64 L422.18,200.63 L421.70,199.61 L421.21,198.60 L420.71,197.59 L420.20,196.59
-		L419.67,195.59 L419.13,194.60 L418.58,193.61 L418.02,192.62 L417.44,191.64 L416.85,190.67 L416.25,189.70 L415.64,188.73
-		L415.02,187.77 L414.38,186.81 L413.73,185.86 L413.07,184.91 L412.40,183.97 L411.71,183.04 L411.02,182.11 L410.31,181.18
-		L409.59,180.27 L408.86,179.35 L408.12,178.45 L407.37,177.55 L406.60,176.65 L405.83,175.76 L405.04,174.88 L404.25,174.00
-		L403.44,173.13 L402.62,172.27 L401.79,171.42 L400.95,170.57 L400.10,169.72 L399.24,168.89 L398.36,168.06 L397.48,167.23
-		L396.59,166.42 L395.69,165.61 L394.77,164.81 L393.85,164.02 L392.92,163.23 L391.98,162.45 L391.02,161.68 L390.06,160.92
-		L389.09,160.16 L388.11,159.42 L387.12,158.68 L386.12,157.94 L385.11,157.22 L384.10,156.50 L383.07,155.80 L382.04,155.10
-		L380.99,154.41 L379.94,153.72 L378.88,153.05 L377.81,152.38 L376.73,151.73 L375.65,151.08 L374.56,150.44 L373.45,149.81
-		L372.35,149.19 L371.23,148.57 L370.10,147.97 L368.97,147.37 L367.83,146.79 L366.69,146.21 L365.53,145.64 L364.37,145.08
-		L363.20,144.53 L362.03,143.99 L360.85,143.46 L359.66,142.94 L358.47,142.43 L357.27,141.93 L356.06,141.44 L354.85,140.95
-		L353.63,140.48 L352.40,140.02 L351.17,139.57 L349.94,139.12 L348.69,138.69 L347.45,138.27 L346.19,137.85 L344.94,137.45
-		L343.68,137.05 L342.41,136.67 L341.14,136.30 L339.86,135.94 L338.58,135.58 L337.29,135.24 L336.00,134.91 L334.71,134.59
-		L333.41,134.27 L332.11,133.97 L330.81,133.68 L329.50,133.40 L328.19,133.13 L326.87,132.87 L325.55,132.63 L324.23,132.39
-		L322.91,132.16 L321.58,131.94 L320.25,131.74 L318.92,131.54 L317.58,131.36 L316.24,131.18 L314.91,131.02 L313.56,130.86
-		L312.22,130.72 L310.88,130.59 L309.53,130.47 L308.18,130.36 L306.83,130.26 L305.48,130.17 L304.13,130.10 L302.78,130.03
-		L301.43,129.97 L300.07,129.93 L298.72,129.89 L297.37,129.87 L296.01,129.86 L294.66,129.86 L293.30,129.87 L291.95,129.89
-		L290.59,129.92 L289.24,129.96 L287.89,130.01 L286.53,130.07 L285.18,130.15 L283.83,130.23 L282.48,130.33 L281.13,130.43
-		L279.79,130.55 L278.44,130.68 L277.10,130.82 L275.76,130.97 L274.42,131.13 L273.08,131.30 L271.74,131.48 L270.41,131.67
-		L269.08,131.88 L267.75,132.09 L266.43,132.31 L265.10,132.55 L263.78,132.79 L262.47,133.05 L261.15,133.32 L259.84,133.59
-		L258.54,133.88 L257.24,134.18 L255.94,134.49 L254.64,134.80 L253.35,135.13 L252.06,135.47 L250.78,135.82 L249.50,136.18
-		L248.23,136.55 L246.96,136.93 L245.70,137.32 L244.44,137.72 L243.19,138.13 L241.94,138.55 L240.69,138.98 L239.46,139.42
-		L238.22,139.87 L237.00,140.33 L235.78,140.80 L234.56,141.28 L233.35,141.77 L232.15,142.27 L230.95,142.78 L229.76,143.30
-		L228.58,143.82 L227.40,144.36 L226.23,144.91 L225.07,145.46 L223.92,146.03 L222.77,146.60 L221.62,147.19 L220.49,147.78
-		L219.36,148.38 L218.24,148.99 L217.13,149.61 L216.03,150.24 L214.93,150.87 L213.84,151.52 L212.77,152.17 L211.69,152.84
-		L210.63,153.51 L209.58,154.19 L208.53,154.88 L207.49,155.57 L206.46,156.28 L205.44,156.99 L204.43,157.71 L203.43,158.44
-		L202.44,159.18 L201.45,159.92 L200.48,160.68 L199.52,161.44 L198.56,162.21 L197.62,162.98 L196.68,163.77 L195.75,164.56
-		L194.84,165.36 L193.93,166.16 L193.04,166.97 L192.15,167.79 L191.28,168.62 L190.41,169.46 L189.56,170.30 L188.71,171.14
-		L187.88,172.00 L187.06,172.86 L186.25,173.73 L185.44,174.60 L184.66,175.48 L183.88,176.37 L183.11,177.26 L182.35,178.16
-		L181.61,179.06 L180.87,179.97 L180.15,180.89 L179.44,181.81 L178.74,182.74 L178.05,183.68 L177.38,184.61 L176.71,185.56
-		L176.06,186.51 L175.42,187.46 L174.79,188.42 L174.18,189.39 L173.57,190.36 L172.98,191.33 L172.40,192.31 L171.83,193.30
-		L171.28,194.28 L170.73,195.28 L170.20,196.27 L169.68,197.27 L169.18,198.28 L168.69,199.29 L168.21,200.30 L167.74,201.32
-		L167.28,202.34 L166.84,203.36 L166.41,204.39 L166.00,205.42 L165.59,206.46 L165.20,207.49 L164.82,208.53 L164.46,209.58
-		L164.11,210.62 L163.77,211.67 L163.45,212.73 L163.13,213.78 L162.83,214.84 L162.55,215.90 L162.28,216.96 L162.02,218.02
-		L161.77,219.09 L161.54,220.15 L161.32,221.22 L161.11,222.29 L160.92,223.37 L160.74,224.44 L160.58,225.52 L160.43,226.59
-		L160.29,227.67 L160.16,228.75 L160.05,229.83 L159.95,230.91 L159.87,231.99 L159.80,233.07 L159.74,234.16 L159.70,235.24
-		L159.67,236.32 L159.65,237.41 L159.65,238.49 L159.66,239.57 L159.68,240.66 L159.72,241.74 L159.77,242.82 L159.83,243.90
-		L159.91,244.99 L160.00,246.07 L160.11,247.15 L160.23,248.23 L160.36,249.30 L160.50,250.38 L160.66,251.46 L160.84,252.53
-		L161.02,253.61 L161.22,254.68 L161.43,255.75 L161.66,256.82 L161.90,257.88 L162.15,258.95 L162.42,260.01 L162.70,261.07
-		L162.99,262.13 L163.29,263.18 L163.61,264.24 L163.95,265.29 L164.29,266.33 L164.65,267.38 L165.02,268.42  '/></g>
-	</g>
-	<g id="gnuplot_plot_4" ><title>Dead Reckoning</title>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<g transform="translate(457.01,111.91)" stroke="none" fill="black" font-family="Arial" font-size="12.00"  text-anchor="end">
-		<text><tspan font-family="Arial" >Dead Reckoning</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(255, 165,   0)'  d='M465.40,108.01 L507.96,108.01 M294.44,346.55 L295.69,346.55 L296.81,346.54 L297.49,346.53 L298.45,346.52 L299.68,346.48
-		L302.06,346.40 L302.53,346.38 L303.63,346.32 L304.49,346.27 L306.25,346.15 L307.87,346.03 L309.95,345.85 L311.07,345.75
-		L313.42,345.52 L315.11,345.35 L316.24,345.22 L318.21,345.01 L320.20,344.78 L320.39,344.76 L321.65,344.58 L323.42,344.33
-		L325.19,344.05 L325.72,343.96 L326.24,343.86 L328.14,343.52 L329.74,343.21 L331.97,342.76 L334.06,342.32 L334.98,342.12
-		L335.78,341.93 L336.59,341.74 L337.27,341.58 L339.03,341.13 L340.12,340.85 L341.46,340.49 L342.67,340.14 L343.29,339.96
-		L344.37,339.65 L345.58,339.29 L347.55,338.69 L347.84,338.60 L349.11,338.20 L350.38,337.80 L352.08,337.24 L352.94,336.96
-		L354.66,336.37 L355.49,336.09 L357.60,335.36 L358.20,335.15 L360.31,334.39 L363.06,333.38 L364.61,332.79 L366.52,332.02
-		L368.07,331.39 L369.68,330.72 L370.67,330.31 L371.47,329.98 L372.21,329.67 L373.83,328.95 L375.93,328.03 L377.16,327.48
-		L378.07,327.06 L379.76,326.29 L381.68,325.39 L382.54,324.98 L382.94,324.78 L384.01,324.24 L386.37,323.02 L387.23,322.58
-		L389.22,321.52 L390.85,320.65 L392.07,319.98 L393.17,319.37 L394.72,318.46 L396.03,317.68 L396.29,317.52 L398.05,316.45
-		L399.31,315.66 L399.92,315.27 L401.10,314.50 L402.53,313.55 L403.45,312.92 L405.32,311.66 L405.61,311.46 L407.38,310.18
-		L407.99,309.74 L408.97,309.01 L410.04,308.19 L411.10,307.35 L412.67,306.08 L413.35,305.52 L414.61,304.46 L415.91,303.34
-		L416.81,302.56 L416.35,302.96 L417.22,302.19 L418.40,301.11 L419.41,300.16 L421.36,298.30 L422.46,297.23 L423.15,296.56
-		L423.42,296.28 L423.75,295.94 L424.47,295.19 L425.02,294.61 L426.62,292.90 L427.71,291.73 L428.72,290.61 L429.05,290.25
-		L430.79,288.24 L432.22,286.58 L432.86,285.82 L433.99,284.44 L434.14,284.25 L434.88,283.33 L435.82,282.14 L435.56,282.48
-		L436.23,281.58 L436.62,281.03 L437.33,280.03 L438.06,278.97 L438.75,277.94 L440.01,276.05 L440.76,274.90 L441.41,273.86
-		L441.81,273.22 L442.57,271.99 L443.57,270.35 L444.42,268.95 L445.08,267.86 L445.64,266.91 L446.50,265.44 L447.09,264.40
-		L447.64,263.42 L448.16,262.47 L448.84,261.18 L449.33,260.22 L450.07,258.77 L450.12,258.66 L450.57,257.74 L450.95,256.90
-		L451.73,255.13 L452.12,254.22 L452.54,253.19 L452.81,252.52 L453.19,251.51 L453.38,250.99 L453.28,251.29 L453.59,250.37
-		L454.19,248.57 L454.40,247.93 L454.62,247.22 L454.97,246.02 L455.64,243.68 L456.16,241.73 L456.45,240.60 L456.60,240.03
-		L456.89,238.86 L457.34,236.94 L457.56,235.94 L457.71,235.22 L457.84,234.58 L457.99,233.72 L458.14,232.87 L458.31,231.83
-		L458.36,231.49 L458.49,230.47 L458.60,229.43 L458.68,228.61 L458.81,227.13 L458.93,225.54 L458.93,225.46 L458.96,224.61
-		L459.02,222.66 L459.05,221.47 L459.05,220.79 L459.04,219.71 L459.04,219.58 L458.97,218.16 L458.91,217.22 L458.88,216.83
-		L458.80,216.06 L458.69,215.00 L458.58,214.12 L458.45,213.08 L458.14,211.05 L457.91,209.49 L457.68,208.02 L457.55,207.25
-		L457.39,206.45 L457.17,205.41 L457.05,204.92 L456.56,202.92 L456.52,202.77 L456.00,200.81 L455.98,200.72 L455.76,199.97
-		L455.39,198.77 L454.85,197.09 L454.50,196.04 L454.18,195.14 L453.80,194.08 L453.50,193.25 L453.35,192.84 L452.60,190.95
-		L452.11,189.73 L451.94,189.31 L451.60,188.51 L451.53,188.36 L451.23,187.71 L450.82,186.80 L450.43,185.96 L450.19,185.48
-		L449.46,184.01 L448.89,182.88 L448.40,181.95 L447.73,180.71 L447.19,179.71 L447.00,179.37 L446.25,178.08 L445.39,176.60
-		L444.81,175.62 L444.14,174.50 L443.34,173.19 L442.41,171.73 L441.40,170.20 L440.69,169.14 L440.22,168.46 L439.50,167.40
-		L438.73,166.29 L438.22,165.58 L437.96,165.22 L437.77,164.97 L437.15,164.15 L435.89,162.54 L435.07,161.53 L434.73,161.12
-		L433.82,160.00 L433.59,159.73 L432.97,158.99 L432.36,158.29 L431.47,157.29 L430.17,155.88 L429.43,155.09 L428.08,153.67
-		L426.99,152.56 L426.53,152.08 L425.52,151.07 L424.23,149.81 L423.13,148.75 L421.59,147.29 L420.25,146.03 L419.46,145.30
-		L418.94,144.83 L417.41,143.47 L416.98,143.10 L416.19,142.43 L415.19,141.58 L413.70,140.38 L412.47,139.41 L411.60,138.74
-		L411.63,138.76 L411.00,138.29 L408.88,136.76 L407.12,135.51 L406.42,135.01 L405.78,134.56 L403.98,133.33 L402.13,132.08
-		L400.05,130.71 L398.87,129.93 L397.75,129.22 L396.99,128.73 L395.99,128.12 L395.09,127.56 L394.84,127.42 L393.64,126.75
-		L393.09,126.44 L390.48,125.02 L389.60,124.55 L388.79,124.12 L387.74,123.58 L386.68,123.04 L386.32,122.87 L384.33,121.91
-		L383.29,121.41 L382.00,120.80 L379.84,119.81 L378.04,119.00 L376.18,118.18 L375.48,117.87 L375.01,117.68 L372.88,116.82
-		L371.87,116.41 L371.07,116.11 L369.33,115.46 L368.35,115.10 L367.07,114.66 L365.62,114.17 L363.30,113.43 L361.29,112.80
-		L360.06,112.43 L359.17,112.17 L357.14,111.61 L355.68,111.21 L353.89,110.73 L352.97,110.49 L352.08,110.26 L351.33,110.07
-		L350.25,109.82 L348.69,109.46 L347.18,109.14 L344.61,108.62 L344.27,108.55 L342.53,108.20 L340.92,107.89 L340.54,107.82
-		L338.31,107.42 L337.47,107.28 L336.30,107.09 L334.68,106.83 L333.96,106.73 L333.84,106.72 L333.32,106.65 L332.77,106.58
-		L331.36,106.42 L328.83,106.16 L328.51,106.13 L326.45,105.93 L324.79,105.79 L323.53,105.69 L322.25,105.59 L320.76,105.48
-		L319.62,105.40 L318.13,105.31 L315.65,105.18 L315.44,105.17 L313.96,105.12 L311.57,105.06 L309.50,105.03 L308.87,105.03
-		L308.05,105.03 L307.25,105.05 L306.87,105.05 L305.46,105.09 L304.11,105.14 L302.58,105.21 L300.96,105.29 L298.57,105.46
-		L296.47,105.61 L294.08,105.81 L292.65,105.95 L292.11,106.01 L290.53,106.18 L287.99,106.48 L285.58,106.79 L283.46,107.07
-		L281.16,107.39 L279.46,107.65 L278.14,107.86 L276.07,108.21 L275.63,108.30 L274.28,108.56 L271.83,109.05 L270.20,109.39
-		L268.67,109.73 L267.28,110.04 L264.81,110.63 L263.64,110.91 L261.08,111.58 L260.00,111.87 L258.79,112.20 L258.45,112.30
-		L256.21,112.94 L254.98,113.32 L252.49,114.08 L251.69,114.33 L251.13,114.52 L249.97,114.89 L249.80,114.95 L247.99,115.57
-		L246.43,116.12 L245.55,116.45 L243.89,117.08 L243.58,117.20 L242.81,117.51 L241.85,117.91 L241.19,118.19 L239.35,119.00
-		L238.29,119.47 L237.39,119.89 L235.40,120.83 L234.52,121.26 L233.22,121.90 L231.90,122.57 L231.45,122.79 L229.49,123.80
-		L228.45,124.35 L228.17,124.49 L226.33,125.48 L225.09,126.16 L223.85,126.84 L223.34,127.12 L221.80,128.02 L222.27,127.74
-		L222.48,127.61 L221.12,128.44 L219.22,129.62 L218.88,129.83 L217.48,130.73 L216.51,131.38 L215.11,132.32 L214.24,132.92
-		L213.38,133.53 L211.86,134.62 L210.46,135.66 L208.98,136.78 L208.92,136.83 L207.32,138.09 L208.00,137.54 L207.07,138.31
-		L206.58,138.72 L205.96,139.25 L205.44,139.70 L205.13,139.98 L203.35,141.58 L202.74,142.15 L202.62,142.27 L201.57,143.30
-		L201.37,143.50 L200.30,144.61 L199.15,145.83 L197.90,147.19 L196.55,148.65 L195.62,149.69 L195.17,150.20 L194.86,150.56
-		L193.87,151.76 L193.40,152.33 L193.01,152.83 L192.70,153.23 L191.66,154.60 L190.24,156.50 L190.04,156.78 L189.74,157.22
-		L189.26,157.92 L188.55,158.99 L188.28,159.41 L187.50,160.67 L186.75,161.89 L186.44,162.42 L185.40,164.25 L184.78,165.38
-		L184.06,166.69 L183.57,167.58 L182.82,169.01 L182.53,169.59 L182.28,170.11 L182.12,170.47 L181.63,171.54 L181.42,172.02
-		L180.89,173.25 L180.44,174.32 L179.95,175.49 L179.37,176.90 L178.90,178.10 L178.68,178.70 L178.24,179.93 L177.95,180.79
-		L177.58,181.96 L177.17,183.32 L176.75,184.75 L176.42,186.00 L176.18,186.90 L175.88,188.07 L175.81,188.37 L175.31,190.63
-		L175.28,190.78 L175.08,191.86 L174.84,193.19 L174.70,194.04 L174.45,195.56 L174.35,196.29 L174.22,197.28 L174.05,198.72
-		L173.93,199.76 L173.80,200.97 L173.67,202.43 L173.57,203.75 L173.50,204.73 L173.46,205.48 L173.42,206.85 L173.40,207.95
-		L173.38,210.46 L173.37,211.27 L173.37,211.87 L173.39,212.77 L173.43,214.10 L173.48,215.12 L173.51,215.73  '/></g>
-	</g>
-<g fill="none" color="white" stroke="rgb(255, 165,   0)" stroke-width="2.00" stroke-linecap="butt" stroke-linejoin="miter">
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="butt" stroke-linejoin="miter">
-</g>
-<g fill="none" color="black" stroke="black" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M64.14,54.01 L64.14,422.40 L524.74,422.40 L524.74,54.01 L64.14,54.01 Z  '/>	<g transform="translate(19.18,238.21) rotate(270.00)" stroke="none" fill="black" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text><tspan font-family="Arial" >y [m]</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<g transform="translate(533.14,238.21) rotate(270.00)" stroke="none" fill="black" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<g transform="translate(294.44,471.30)" stroke="none" fill="black" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text><tspan font-family="Arial" >x [m]</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<g transform="translate(294.44,57.91)" stroke="none" fill="black" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<g stroke='none' shape-rendering='crispEdges'>
-		<polygon fill = 'rgb(  0,   0,   0)' points = '545.25,422.40 568.28,422.40 568.28,419.52 545.25,419.52 '/>
-		<polygon fill = 'rgb( 23,   0,  13)' points = '545.25,419.53 568.28,419.53 568.28,416.64 545.25,416.64 '/>
-		<polygon fill = 'rgb( 32,   0,  25)' points = '545.25,416.65 568.28,416.65 568.28,413.76 545.25,413.76 '/>
-		<polygon fill = 'rgb( 39,   0,  37)' points = '545.25,413.77 568.28,413.77 568.28,410.88 545.25,410.88 '/>
-		<polygon fill = 'rgb( 45,   0,  50)' points = '545.25,410.89 568.28,410.89 568.28,408.00 545.25,408.00 '/>
-		<polygon fill = 'rgb( 50,   0,  62)' points = '545.25,408.01 568.28,408.01 568.28,405.13 545.25,405.13 '/>
-		<polygon fill = 'rgb( 55,   0,  74)' points = '545.25,405.14 568.28,405.14 568.28,402.25 545.25,402.25 '/>
-		<polygon fill = 'rgb( 60,   0,  86)' points = '545.25,402.26 568.28,402.26 568.28,399.37 545.25,399.37 '/>
-		<polygon fill = 'rgb( 64,   0,  98)' points = '545.25,399.38 568.28,399.38 568.28,396.49 545.25,396.49 '/>
-		<polygon fill = 'rgb( 68,   0, 109)' points = '545.25,396.50 568.28,396.50 568.28,393.61 545.25,393.61 '/>
-		<polygon fill = 'rgb( 71,   0, 120)' points = '545.25,393.62 568.28,393.62 568.28,390.74 545.25,390.74 '/>
-		<polygon fill = 'rgb( 75,   0, 131)' points = '545.25,390.75 568.28,390.75 568.28,387.86 545.25,387.86 '/>
-		<polygon fill = 'rgb( 78,   0, 142)' points = '545.25,387.87 568.28,387.87 568.28,384.98 545.25,384.98 '/>
-		<polygon fill = 'rgb( 81,   0, 152)' points = '545.25,384.99 568.28,384.99 568.28,382.10 545.25,382.10 '/>
-		<polygon fill = 'rgb( 84,   0, 162)' points = '545.25,382.11 568.28,382.11 568.28,379.22 545.25,379.22 '/>
-		<polygon fill = 'rgb( 87,   0, 171)' points = '545.25,379.23 568.28,379.23 568.28,376.35 545.25,376.35 '/>
-		<polygon fill = 'rgb( 90,   0, 180)' points = '545.25,376.36 568.28,376.36 568.28,373.47 545.25,373.47 '/>
-		<polygon fill = 'rgb( 93,   1, 189)' points = '545.25,373.48 568.28,373.48 568.28,370.59 545.25,370.59 '/>
-		<polygon fill = 'rgb( 96,   1, 197)' points = '545.25,370.60 568.28,370.60 568.28,367.71 545.25,367.71 '/>
-		<polygon fill = 'rgb( 98,   1, 205)' points = '545.25,367.72 568.28,367.72 568.28,364.83 545.25,364.83 '/>
-		<polygon fill = 'rgb(101,   1, 212)' points = '545.25,364.84 568.28,364.84 568.28,361.96 545.25,361.96 '/>
-		<polygon fill = 'rgb(103,   1, 219)' points = '545.25,361.97 568.28,361.97 568.28,359.08 545.25,359.08 '/>
-		<polygon fill = 'rgb(106,   1, 225)' points = '545.25,359.09 568.28,359.09 568.28,356.20 545.25,356.20 '/>
-		<polygon fill = 'rgb(108,   1, 231)' points = '545.25,356.21 568.28,356.21 568.28,353.32 545.25,353.32 '/>
-		<polygon fill = 'rgb(110,   2, 236)' points = '545.25,353.33 568.28,353.33 568.28,350.44 545.25,350.44 '/>
-		<polygon fill = 'rgb(113,   2, 240)' points = '545.25,350.45 568.28,350.45 568.28,347.57 545.25,347.57 '/>
-		<polygon fill = 'rgb(115,   2, 244)' points = '545.25,347.58 568.28,347.58 568.28,344.69 545.25,344.69 '/>
-		<polygon fill = 'rgb(117,   2, 247)' points = '545.25,344.70 568.28,344.70 568.28,341.81 545.25,341.81 '/>
-		<polygon fill = 'rgb(119,   3, 250)' points = '545.25,341.82 568.28,341.82 568.28,338.93 545.25,338.93 '/>
-		<polygon fill = 'rgb(121,   3, 252)' points = '545.25,338.94 568.28,338.94 568.28,336.05 545.25,336.05 '/>
-		<polygon fill = 'rgb(123,   3, 254)' points = '545.25,336.06 568.28,336.06 568.28,333.18 545.25,333.18 '/>
-		<polygon fill = 'rgb(125,   4, 255)' points = '545.25,333.19 568.28,333.19 568.28,330.30 545.25,330.30 '/>
-		<polygon fill = 'rgb(128,   4, 255)' points = '545.25,330.31 568.28,330.31 568.28,327.42 545.25,327.42 '/>
-		<polygon fill = 'rgb(129,   4, 255)' points = '545.25,327.43 568.28,327.43 568.28,324.54 545.25,324.54 '/>
-		<polygon fill = 'rgb(131,   5, 254)' points = '545.25,324.55 568.28,324.55 568.28,321.66 545.25,321.66 '/>
-		<polygon fill = 'rgb(133,   5, 252)' points = '545.25,321.67 568.28,321.67 568.28,318.79 545.25,318.79 '/>
-		<polygon fill = 'rgb(135,   6, 250)' points = '545.25,318.80 568.28,318.80 568.28,315.91 545.25,315.91 '/>
-		<polygon fill = 'rgb(137,   6, 247)' points = '545.25,315.92 568.28,315.92 568.28,313.03 545.25,313.03 '/>
-		<polygon fill = 'rgb(139,   7, 244)' points = '545.25,313.04 568.28,313.04 568.28,310.15 545.25,310.15 '/>
-		<polygon fill = 'rgb(141,   7, 240)' points = '545.25,310.16 568.28,310.16 568.28,307.27 545.25,307.27 '/>
-		<polygon fill = 'rgb(143,   8, 236)' points = '545.25,307.28 568.28,307.28 568.28,304.40 545.25,304.40 '/>
-		<polygon fill = 'rgb(144,   8, 231)' points = '545.25,304.41 568.28,304.41 568.28,301.52 545.25,301.52 '/>
-		<polygon fill = 'rgb(146,   9, 225)' points = '545.25,301.53 568.28,301.53 568.28,298.64 545.25,298.64 '/>
-		<polygon fill = 'rgb(148,  10, 219)' points = '545.25,298.65 568.28,298.65 568.28,295.76 545.25,295.76 '/>
-		<polygon fill = 'rgb(150,  10, 212)' points = '545.25,295.77 568.28,295.77 568.28,292.88 545.25,292.88 '/>
-		<polygon fill = 'rgb(151,  11, 205)' points = '545.25,292.89 568.28,292.89 568.28,290.00 545.25,290.00 '/>
-		<polygon fill = 'rgb(153,  12, 197)' points = '545.25,290.01 568.28,290.01 568.28,287.13 545.25,287.13 '/>
-		<polygon fill = 'rgb(155,  13, 189)' points = '545.25,287.14 568.28,287.14 568.28,284.25 545.25,284.25 '/>
-		<polygon fill = 'rgb(156,  13, 180)' points = '545.25,284.26 568.28,284.26 568.28,281.37 545.25,281.37 '/>
-		<polygon fill = 'rgb(158,  14, 171)' points = '545.25,281.38 568.28,281.38 568.28,278.49 545.25,278.49 '/>
-		<polygon fill = 'rgb(159,  15, 162)' points = '545.25,278.50 568.28,278.50 568.28,275.61 545.25,275.61 '/>
-		<polygon fill = 'rgb(161,  16, 152)' points = '545.25,275.62 568.28,275.62 568.28,272.74 545.25,272.74 '/>
-		<polygon fill = 'rgb(163,  17, 142)' points = '545.25,272.75 568.28,272.75 568.28,269.86 545.25,269.86 '/>
-		<polygon fill = 'rgb(164,  18, 131)' points = '545.25,269.87 568.28,269.87 568.28,266.98 545.25,266.98 '/>
-		<polygon fill = 'rgb(166,  19, 120)' points = '545.25,266.99 568.28,266.99 568.28,264.10 545.25,264.10 '/>
-		<polygon fill = 'rgb(167,  20, 109)' points = '545.25,264.11 568.28,264.11 568.28,261.22 545.25,261.22 '/>
-		<polygon fill = 'rgb(169,  21,  98)' points = '545.25,261.23 568.28,261.23 568.28,258.35 545.25,258.35 '/>
-		<polygon fill = 'rgb(170,  23,  86)' points = '545.25,258.36 568.28,258.36 568.28,255.47 545.25,255.47 '/>
-		<polygon fill = 'rgb(172,  24,  74)' points = '545.25,255.48 568.28,255.48 568.28,252.59 545.25,252.59 '/>
-		<polygon fill = 'rgb(173,  25,  62)' points = '545.25,252.60 568.28,252.60 568.28,249.71 545.25,249.71 '/>
-		<polygon fill = 'rgb(175,  26,  50)' points = '545.25,249.72 568.28,249.72 568.28,246.83 545.25,246.83 '/>
-		<polygon fill = 'rgb(176,  28,  37)' points = '545.25,246.84 568.28,246.84 568.28,243.96 545.25,243.96 '/>
-		<polygon fill = 'rgb(177,  29,  25)' points = '545.25,243.97 568.28,243.97 568.28,241.08 545.25,241.08 '/>
-		<polygon fill = 'rgb(179,  30,  13)' points = '545.25,241.09 568.28,241.09 568.28,238.20 545.25,238.20 '/>
-		<polygon fill = 'rgb(180,  32,   0)' points = '545.25,238.21 568.28,238.21 568.28,235.32 545.25,235.32 '/>
-		<polygon fill = 'rgb(182,  33,   0)' points = '545.25,235.33 568.28,235.33 568.28,232.44 545.25,232.44 '/>
-		<polygon fill = 'rgb(183,  35,   0)' points = '545.25,232.45 568.28,232.45 568.28,229.57 545.25,229.57 '/>
-		<polygon fill = 'rgb(184,  37,   0)' points = '545.25,229.58 568.28,229.58 568.28,226.69 545.25,226.69 '/>
-		<polygon fill = 'rgb(186,  38,   0)' points = '545.25,226.70 568.28,226.70 568.28,223.81 545.25,223.81 '/>
-		<polygon fill = 'rgb(187,  40,   0)' points = '545.25,223.82 568.28,223.82 568.28,220.93 545.25,220.93 '/>
-		<polygon fill = 'rgb(189,  42,   0)' points = '545.25,220.94 568.28,220.94 568.28,218.05 545.25,218.05 '/>
-		<polygon fill = 'rgb(190,  44,   0)' points = '545.25,218.06 568.28,218.06 568.28,215.18 545.25,215.18 '/>
-		<polygon fill = 'rgb(191,  45,   0)' points = '545.25,215.19 568.28,215.19 568.28,212.30 545.25,212.30 '/>
-		<polygon fill = 'rgb(193,  47,   0)' points = '545.25,212.31 568.28,212.31 568.28,209.42 545.25,209.42 '/>
-		<polygon fill = 'rgb(194,  49,   0)' points = '545.25,209.43 568.28,209.43 568.28,206.54 545.25,206.54 '/>
-		<polygon fill = 'rgb(195,  51,   0)' points = '545.25,206.55 568.28,206.55 568.28,203.66 545.25,203.66 '/>
-		<polygon fill = 'rgb(196,  53,   0)' points = '545.25,203.67 568.28,203.67 568.28,200.79 545.25,200.79 '/>
-		<polygon fill = 'rgb(198,  56,   0)' points = '545.25,200.80 568.28,200.80 568.28,197.91 545.25,197.91 '/>
-		<polygon fill = 'rgb(199,  58,   0)' points = '545.25,197.92 568.28,197.92 568.28,195.03 545.25,195.03 '/>
-		<polygon fill = 'rgb(200,  60,   0)' points = '545.25,195.04 568.28,195.04 568.28,192.15 545.25,192.15 '/>
-		<polygon fill = 'rgb(202,  62,   0)' points = '545.25,192.16 568.28,192.16 568.28,189.27 545.25,189.27 '/>
-		<polygon fill = 'rgb(203,  65,   0)' points = '545.25,189.28 568.28,189.28 568.28,186.40 545.25,186.40 '/>
-		<polygon fill = 'rgb(204,  67,   0)' points = '545.25,186.41 568.28,186.41 568.28,183.52 545.25,183.52 '/>
-		<polygon fill = 'rgb(205,  70,   0)' points = '545.25,183.53 568.28,183.53 568.28,180.64 545.25,180.64 '/>
-		<polygon fill = 'rgb(207,  72,   0)' points = '545.25,180.65 568.28,180.65 568.28,177.76 545.25,177.76 '/>
-		<polygon fill = 'rgb(208,  75,   0)' points = '545.25,177.77 568.28,177.77 568.28,174.88 545.25,174.88 '/>
-		<polygon fill = 'rgb(209,  77,   0)' points = '545.25,174.89 568.28,174.89 568.28,172.00 545.25,172.00 '/>
-		<polygon fill = 'rgb(210,  80,   0)' points = '545.25,172.01 568.28,172.01 568.28,169.13 545.25,169.13 '/>
-		<polygon fill = 'rgb(211,  83,   0)' points = '545.25,169.14 568.28,169.14 568.28,166.25 545.25,166.25 '/>
-		<polygon fill = 'rgb(213,  86,   0)' points = '545.25,166.26 568.28,166.26 568.28,163.37 545.25,163.37 '/>
-		<polygon fill = 'rgb(214,  89,   0)' points = '545.25,163.38 568.28,163.38 568.28,160.49 545.25,160.49 '/>
-		<polygon fill = 'rgb(215,  92,   0)' points = '545.25,160.50 568.28,160.50 568.28,157.61 545.25,157.61 '/>
-		<polygon fill = 'rgb(216,  95,   0)' points = '545.25,157.62 568.28,157.62 568.28,154.74 545.25,154.74 '/>
-		<polygon fill = 'rgb(217,  98,   0)' points = '545.25,154.75 568.28,154.75 568.28,151.86 545.25,151.86 '/>
-		<polygon fill = 'rgb(219, 101,   0)' points = '545.25,151.87 568.28,151.87 568.28,148.98 545.25,148.98 '/>
-		<polygon fill = 'rgb(220, 104,   0)' points = '545.25,148.99 568.28,148.99 568.28,146.10 545.25,146.10 '/>
-		<polygon fill = 'rgb(221, 108,   0)' points = '545.25,146.11 568.28,146.11 568.28,143.22 545.25,143.22 '/>
-		<polygon fill = 'rgb(222, 111,   0)' points = '545.25,143.23 568.28,143.23 568.28,140.35 545.25,140.35 '/>
-		<polygon fill = 'rgb(223, 114,   0)' points = '545.25,140.36 568.28,140.36 568.28,137.47 545.25,137.47 '/>
-		<polygon fill = 'rgb(224, 118,   0)' points = '545.25,137.48 568.28,137.48 568.28,134.59 545.25,134.59 '/>
-		<polygon fill = 'rgb(225, 122,   0)' points = '545.25,134.60 568.28,134.60 568.28,131.71 545.25,131.71 '/>
-		<polygon fill = 'rgb(227, 125,   0)' points = '545.25,131.72 568.28,131.72 568.28,128.83 545.25,128.83 '/>
-		<polygon fill = 'rgb(228, 129,   0)' points = '545.25,128.84 568.28,128.84 568.28,125.96 545.25,125.96 '/>
-		<polygon fill = 'rgb(229, 133,   0)' points = '545.25,125.97 568.28,125.97 568.28,123.08 545.25,123.08 '/>
-		<polygon fill = 'rgb(230, 137,   0)' points = '545.25,123.09 568.28,123.09 568.28,120.20 545.25,120.20 '/>
-		<polygon fill = 'rgb(231, 141,   0)' points = '545.25,120.21 568.28,120.21 568.28,117.32 545.25,117.32 '/>
-		<polygon fill = 'rgb(232, 145,   0)' points = '545.25,117.33 568.28,117.33 568.28,114.44 545.25,114.44 '/>
-		<polygon fill = 'rgb(233, 149,   0)' points = '545.25,114.45 568.28,114.45 568.28,111.57 545.25,111.57 '/>
-		<polygon fill = 'rgb(234, 153,   0)' points = '545.25,111.58 568.28,111.58 568.28,108.69 545.25,108.69 '/>
-		<polygon fill = 'rgb(235, 157,   0)' points = '545.25,108.70 568.28,108.70 568.28,105.81 545.25,105.81 '/>
-		<polygon fill = 'rgb(236, 162,   0)' points = '545.25,105.82 568.28,105.82 568.28,102.93 545.25,102.93 '/>
-		<polygon fill = 'rgb(237, 166,   0)' points = '545.25,102.94 568.28,102.94 568.28,100.05 545.25,100.05 '/>
-		<polygon fill = 'rgb(239, 171,   0)' points = '545.25,100.06 568.28,100.06 568.28,97.18 545.25,97.18 '/>
-		<polygon fill = 'rgb(240, 175,   0)' points = '545.25,97.19 568.28,97.19 568.28,94.30 545.25,94.30 '/>
-		<polygon fill = 'rgb(241, 180,   0)' points = '545.25,94.31 568.28,94.31 568.28,91.42 545.25,91.42 '/>
-		<polygon fill = 'rgb(242, 185,   0)' points = '545.25,91.43 568.28,91.43 568.28,88.54 545.25,88.54 '/>
-		<polygon fill = 'rgb(243, 190,   0)' points = '545.25,88.55 568.28,88.55 568.28,85.66 545.25,85.66 '/>
-		<polygon fill = 'rgb(244, 195,   0)' points = '545.25,85.67 568.28,85.67 568.28,82.79 545.25,82.79 '/>
-		<polygon fill = 'rgb(245, 200,   0)' points = '545.25,82.80 568.28,82.80 568.28,79.91 545.25,79.91 '/>
-		<polygon fill = 'rgb(246, 205,   0)' points = '545.25,79.92 568.28,79.92 568.28,77.03 545.25,77.03 '/>
-		<polygon fill = 'rgb(247, 210,   0)' points = '545.25,77.04 568.28,77.04 568.28,74.15 545.25,74.15 '/>
-		<polygon fill = 'rgb(248, 215,   0)' points = '545.25,74.16 568.28,74.16 568.28,71.27 545.25,71.27 '/>
-		<polygon fill = 'rgb(249, 221,   0)' points = '545.25,71.28 568.28,71.28 568.28,68.40 545.25,68.40 '/>
-		<polygon fill = 'rgb(250, 226,   0)' points = '545.25,68.41 568.28,68.41 568.28,65.52 545.25,65.52 '/>
-		<polygon fill = 'rgb(251, 232,   0)' points = '545.25,65.53 568.28,65.53 568.28,62.64 545.25,62.64 '/>
-		<polygon fill = 'rgb(252, 237,   0)' points = '545.25,62.65 568.28,62.65 568.28,59.76 545.25,59.76 '/>
-		<polygon fill = 'rgb(253, 243,   0)' points = '545.25,59.77 568.28,59.77 568.28,56.88 545.25,56.88 '/>
-		<polygon fill = 'rgb(254, 249,   0)' points = '545.25,56.89 568.28,56.89 568.28,54.01 545.25,54.01 '/>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M545.25,422.40 L568.28,422.40 L568.28,54.01 L545.25,54.01 L545.25,422.40 Z  '/></g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M568.28,422.40 L563.78,422.40  '/>	<g transform="translate(576.67,426.30)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="start">
-		<text><tspan font-family="Arial" > 0</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M545.25,422.40 L549.75,422.40 M568.28,361.01 L563.78,361.01  '/>	<g transform="translate(576.67,364.91)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="start">
-		<text><tspan font-family="Arial" > 0.001</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M545.25,361.01 L549.75,361.01 M568.28,299.61 L563.78,299.61  '/>	<g transform="translate(576.67,303.51)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="start">
-		<text><tspan font-family="Arial" > 0.002</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M545.25,299.61 L549.75,299.61 M568.28,238.21 L563.78,238.21  '/>	<g transform="translate(576.67,242.11)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="start">
-		<text><tspan font-family="Arial" > 0.003</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M545.25,238.21 L549.75,238.21 M568.28,176.81 L563.78,176.81  '/>	<g transform="translate(576.67,180.71)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="start">
-		<text><tspan font-family="Arial" > 0.004</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M545.25,176.81 L549.75,176.81 M568.28,115.41 L563.78,115.41  '/>	<g transform="translate(576.67,119.31)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="start">
-		<text><tspan font-family="Arial" > 0.005</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M545.25,115.41 L549.75,115.41 M568.28,54.01 L563.78,54.01  '/>	<g transform="translate(576.67,57.91)" stroke="none" fill="rgb(0,0,0)" font-family="Arial" font-size="12.00"  text-anchor="start">
-		<text><tspan font-family="Arial" > 0.006</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<path stroke='rgb(  0,   0,   0)'  d='M545.25,54.01 L549.75,54.01  '/>	<g transform="translate(635.10,238.21) rotate(270.00)" stroke="none" fill="black" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-	<g transform="translate(294.44,30.91)" stroke="none" fill="black" font-family="Arial" font-size="12.00"  text-anchor="middle">
-		<text><tspan font-family="Arial" >Histogram Filter Localization</tspan></text>
-	</g>
-</g>
-<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
-</g>
-</g>
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='920' height='700' viewBox='0 0 920 700'>
+<rect width='100%' height='100%' fill='white'/>
+<text x='460.0' y='38' text-anchor='middle' font-size='24' font-family='sans-serif' font-weight='700' fill='#111827'>Histogram Filter Localization</text>
+<rect x='72.0' y='72.0' width='556.0' height='556.0' fill='#fffdf7' stroke='#d6d3d1' stroke-width='2'/>
+<line x1='72.00' y1='72.00' x2='72.00' y2='628.00' stroke='#ece7dc' stroke-width='1'/>
+<text x='72.00' y='652.00' text-anchor='middle' font-size='14' font-family='sans-serif' fill='#374151'>-15</text>
+<line x1='164.67' y1='72.00' x2='164.67' y2='628.00' stroke='#ece7dc' stroke-width='1'/>
+<text x='164.67' y='652.00' text-anchor='middle' font-size='14' font-family='sans-serif' fill='#374151'>-10</text>
+<line x1='257.33' y1='72.00' x2='257.33' y2='628.00' stroke='#ece7dc' stroke-width='1'/>
+<text x='257.33' y='652.00' text-anchor='middle' font-size='14' font-family='sans-serif' fill='#374151'>-5</text>
+<line x1='350.00' y1='72.00' x2='350.00' y2='628.00' stroke='#ece7dc' stroke-width='1'/>
+<text x='350.00' y='652.00' text-anchor='middle' font-size='14' font-family='sans-serif' fill='#374151'>0</text>
+<line x1='442.67' y1='72.00' x2='442.67' y2='628.00' stroke='#ece7dc' stroke-width='1'/>
+<text x='442.67' y='652.00' text-anchor='middle' font-size='14' font-family='sans-serif' fill='#374151'>5</text>
+<line x1='535.33' y1='72.00' x2='535.33' y2='628.00' stroke='#ece7dc' stroke-width='1'/>
+<text x='535.33' y='652.00' text-anchor='middle' font-size='14' font-family='sans-serif' fill='#374151'>10</text>
+<line x1='628.00' y1='72.00' x2='628.00' y2='628.00' stroke='#ece7dc' stroke-width='1'/>
+<text x='628.00' y='652.00' text-anchor='middle' font-size='14' font-family='sans-serif' fill='#374151'>15</text>
+<line x1='72.00' y1='628.00' x2='628.00' y2='628.00' stroke='#ece7dc' stroke-width='1'/>
+<text x='62.00' y='633.00' text-anchor='end' font-size='14' font-family='sans-serif' fill='#374151'>-5</text>
+<line x1='72.00' y1='535.33' x2='628.00' y2='535.33' stroke='#ece7dc' stroke-width='1'/>
+<text x='62.00' y='540.33' text-anchor='end' font-size='14' font-family='sans-serif' fill='#374151'>0</text>
+<line x1='72.00' y1='442.67' x2='628.00' y2='442.67' stroke='#ece7dc' stroke-width='1'/>
+<text x='62.00' y='447.67' text-anchor='end' font-size='14' font-family='sans-serif' fill='#374151'>5</text>
+<line x1='72.00' y1='350.00' x2='628.00' y2='350.00' stroke='#ece7dc' stroke-width='1'/>
+<text x='62.00' y='355.00' text-anchor='end' font-size='14' font-family='sans-serif' fill='#374151'>10</text>
+<line x1='72.00' y1='257.33' x2='628.00' y2='257.33' stroke='#ece7dc' stroke-width='1'/>
+<text x='62.00' y='262.33' text-anchor='end' font-size='14' font-family='sans-serif' fill='#374151'>15</text>
+<line x1='72.00' y1='164.67' x2='628.00' y2='164.67' stroke='#ece7dc' stroke-width='1'/>
+<text x='62.00' y='169.67' text-anchor='end' font-size='14' font-family='sans-serif' fill='#374151'>20</text>
+<line x1='72.00' y1='72.00' x2='628.00' y2='72.00' stroke='#ece7dc' stroke-width='1'/>
+<text x='62.00' y='77.00' text-anchor='end' font-size='14' font-family='sans-serif' fill='#374151'>25</text>
+<rect x='146.13' y='553.87' width='9.27' height='9.27' fill='#fff6d8' fill-opacity='0.235' stroke='none'/>
+<rect x='155.40' y='553.87' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.240' stroke='none'/>
+<rect x='164.67' y='553.87' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.244' stroke='none'/>
+<rect x='173.93' y='553.87' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.247' stroke='none'/>
+<rect x='183.20' y='553.87' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.249' stroke='none'/>
+<rect x='192.47' y='553.87' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.249' stroke='none'/>
+<rect x='201.73' y='553.87' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.248' stroke='none'/>
+<rect x='211.00' y='553.87' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.245' stroke='none'/>
+<rect x='220.27' y='553.87' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.242' stroke='none'/>
+<rect x='229.53' y='553.87' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.237' stroke='none'/>
+<rect x='238.80' y='553.87' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.232' stroke='none'/>
+<rect x='118.33' y='544.60' width='9.27' height='9.27' fill='#fff6d8' fill-opacity='0.234' stroke='none'/>
+<rect x='127.60' y='544.60' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.244' stroke='none'/>
+<rect x='136.87' y='544.60' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.252' stroke='none'/>
+<rect x='146.13' y='544.60' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.260' stroke='none'/>
+<rect x='155.40' y='544.60' width='9.27' height='9.27' fill='#fff5d0' fill-opacity='0.266' stroke='none'/>
+<rect x='164.67' y='544.60' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.271' stroke='none'/>
+<rect x='173.93' y='544.60' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.275' stroke='none'/>
+<rect x='183.20' y='544.60' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.277' stroke='none'/>
+<rect x='192.47' y='544.60' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.277' stroke='none'/>
+<rect x='201.73' y='544.60' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.275' stroke='none'/>
+<rect x='211.00' y='544.60' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.272' stroke='none'/>
+<rect x='220.27' y='544.60' width='9.27' height='9.27' fill='#fff5d0' fill-opacity='0.268' stroke='none'/>
+<rect x='229.53' y='544.60' width='9.27' height='9.27' fill='#fff5d1' fill-opacity='0.261' stroke='none'/>
+<rect x='238.80' y='544.60' width='9.27' height='9.27' fill='#fff5d3' fill-opacity='0.254' stroke='none'/>
+<rect x='248.07' y='544.60' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.246' stroke='none'/>
+<rect x='257.33' y='544.60' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.238' stroke='none'/>
+<rect x='99.80' y='535.33' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.231' stroke='none'/>
+<rect x='109.07' y='535.33' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.245' stroke='none'/>
+<rect x='118.33' y='535.33' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.258' stroke='none'/>
+<rect x='127.60' y='535.33' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.270' stroke='none'/>
+<rect x='136.87' y='535.33' width='9.27' height='9.27' fill='#fff5cd' fill-opacity='0.280' stroke='none'/>
+<rect x='146.13' y='535.33' width='9.27' height='9.27' fill='#fff5ca' fill-opacity='0.290' stroke='none'/>
+<rect x='155.40' y='535.33' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.298' stroke='none'/>
+<rect x='164.67' y='535.33' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.304' stroke='none'/>
+<rect x='173.93' y='535.33' width='9.27' height='9.27' fill='#fff4c6' fill-opacity='0.308' stroke='none'/>
+<rect x='183.20' y='535.33' width='9.27' height='9.27' fill='#fff4c5' fill-opacity='0.310' stroke='none'/>
+<rect x='192.47' y='535.33' width='9.27' height='9.27' fill='#fff4c5' fill-opacity='0.310' stroke='none'/>
+<rect x='201.73' y='535.33' width='9.27' height='9.27' fill='#fff4c6' fill-opacity='0.308' stroke='none'/>
+<rect x='211.00' y='535.33' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.304' stroke='none'/>
+<rect x='220.27' y='535.33' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.298' stroke='none'/>
+<rect x='229.53' y='535.33' width='9.27' height='9.27' fill='#fff5ca' fill-opacity='0.290' stroke='none'/>
+<rect x='238.80' y='535.33' width='9.27' height='9.27' fill='#fff5cd' fill-opacity='0.281' stroke='none'/>
+<rect x='248.07' y='535.33' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.271' stroke='none'/>
+<rect x='257.33' y='535.33' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.260' stroke='none'/>
+<rect x='266.60' y='535.33' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.248' stroke='none'/>
+<rect x='275.87' y='535.33' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.237' stroke='none'/>
+<rect x='90.53' y='526.07' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.232' stroke='none'/>
+<rect x='99.80' y='526.07' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.252' stroke='none'/>
+<rect x='109.07' y='526.07' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.269' stroke='none'/>
+<rect x='118.33' y='526.07' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.285' stroke='none'/>
+<rect x='127.60' y='526.07' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.300' stroke='none'/>
+<rect x='136.87' y='526.07' width='9.27' height='9.27' fill='#fff4c5' fill-opacity='0.313' stroke='none'/>
+<rect x='146.13' y='526.07' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.325' stroke='none'/>
+<rect x='155.40' y='526.07' width='9.27' height='9.27' fill='#fff4bf' fill-opacity='0.334' stroke='none'/>
+<rect x='164.67' y='526.07' width='9.27' height='9.27' fill='#fff4be' fill-opacity='0.342' stroke='none'/>
+<rect x='173.93' y='526.07' width='9.27' height='9.27' fill='#fff4bc' fill-opacity='0.347' stroke='none'/>
+<rect x='183.20' y='526.07' width='9.27' height='9.27' fill='#fff4bc' fill-opacity='0.349' stroke='none'/>
+<rect x='192.47' y='526.07' width='9.27' height='9.27' fill='#fff4bc' fill-opacity='0.349' stroke='none'/>
+<rect x='201.73' y='526.07' width='9.27' height='9.27' fill='#fff4bd' fill-opacity='0.346' stroke='none'/>
+<rect x='211.00' y='526.07' width='9.27' height='9.27' fill='#fff4be' fill-opacity='0.340' stroke='none'/>
+<rect x='220.27' y='526.07' width='9.27' height='9.27' fill='#fff4c0' fill-opacity='0.333' stroke='none'/>
+<rect x='229.53' y='526.07' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.323' stroke='none'/>
+<rect x='238.80' y='526.07' width='9.27' height='9.27' fill='#fff4c5' fill-opacity='0.311' stroke='none'/>
+<rect x='248.07' y='526.07' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.299' stroke='none'/>
+<rect x='257.33' y='526.07' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.285' stroke='none'/>
+<rect x='266.60' y='526.07' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.271' stroke='none'/>
+<rect x='275.87' y='526.07' width='9.27' height='9.27' fill='#fff5d3' fill-opacity='0.257' stroke='none'/>
+<rect x='285.13' y='526.07' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.243' stroke='none'/>
+<rect x='294.40' y='526.07' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.230' stroke='none'/>
+<rect x='90.53' y='516.80' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.252' stroke='none'/>
+<rect x='99.80' y='516.80' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.276' stroke='none'/>
+<rect x='109.07' y='516.80' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.297' stroke='none'/>
+<rect x='118.33' y='516.80' width='9.27' height='9.27' fill='#fff4c4' fill-opacity='0.317' stroke='none'/>
+<rect x='127.60' y='516.80' width='9.27' height='9.27' fill='#fff4bf' fill-opacity='0.335' stroke='none'/>
+<rect x='136.87' y='516.80' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.351' stroke='none'/>
+<rect x='146.13' y='516.80' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.365' stroke='none'/>
+<rect x='155.40' y='516.80' width='9.27' height='9.27' fill='#fef3b5' fill-opacity='0.376' stroke='none'/>
+<rect x='164.67' y='516.80' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.385' stroke='none'/>
+<rect x='173.93' y='516.80' width='9.27' height='9.27' fill='#fef3b1' fill-opacity='0.391' stroke='none'/>
+<rect x='183.20' y='516.80' width='9.27' height='9.27' fill='#fef3b1' fill-opacity='0.393' stroke='none'/>
+<rect x='192.47' y='516.80' width='9.27' height='9.27' fill='#fef3b1' fill-opacity='0.393' stroke='none'/>
+<rect x='201.73' y='516.80' width='9.27' height='9.27' fill='#fef3b2' fill-opacity='0.389' stroke='none'/>
+<rect x='211.00' y='516.80' width='9.27' height='9.27' fill='#fef3b4' fill-opacity='0.382' stroke='none'/>
+<rect x='220.27' y='516.80' width='9.27' height='9.27' fill='#fef3b6' fill-opacity='0.372' stroke='none'/>
+<rect x='229.53' y='516.80' width='9.27' height='9.27' fill='#fef3b9' fill-opacity='0.360' stroke='none'/>
+<rect x='238.80' y='516.80' width='9.27' height='9.27' fill='#fff4bd' fill-opacity='0.346' stroke='none'/>
+<rect x='248.07' y='516.80' width='9.27' height='9.27' fill='#fff4c0' fill-opacity='0.330' stroke='none'/>
+<rect x='257.33' y='516.80' width='9.27' height='9.27' fill='#fff4c5' fill-opacity='0.313' stroke='none'/>
+<rect x='266.60' y='516.80' width='9.27' height='9.27' fill='#fff4c9' fill-opacity='0.296' stroke='none'/>
+<rect x='275.87' y='516.80' width='9.27' height='9.27' fill='#fff5cd' fill-opacity='0.279' stroke='none'/>
+<rect x='285.13' y='516.80' width='9.27' height='9.27' fill='#fff5d1' fill-opacity='0.263' stroke='none'/>
+<rect x='294.40' y='516.80' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.247' stroke='none'/>
+<rect x='303.67' y='516.80' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.232' stroke='none'/>
+<rect x='81.27' y='507.53' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.241' stroke='none'/>
+<rect x='90.53' y='507.53' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.274' stroke='none'/>
+<rect x='99.80' y='507.53' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.304' stroke='none'/>
+<rect x='109.07' y='507.53' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.329' stroke='none'/>
+<rect x='118.33' y='507.53' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.353' stroke='none'/>
+<rect x='127.60' y='507.53' width='9.27' height='9.27' fill='#fef3b6' fill-opacity='0.374' stroke='none'/>
+<rect x='136.87' y='507.53' width='9.27' height='9.27' fill='#fef3b1' fill-opacity='0.393' stroke='none'/>
+<rect x='146.13' y='507.53' width='9.27' height='9.27' fill='#fef2ad' fill-opacity='0.410' stroke='none'/>
+<rect x='155.40' y='507.53' width='9.27' height='9.27' fill='#fef2a9' fill-opacity='0.423' stroke='none'/>
+<rect x='164.67' y='507.53' width='9.27' height='9.27' fill='#fef2a7' fill-opacity='0.433' stroke='none'/>
+<rect x='173.93' y='507.53' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.440' stroke='none'/>
+<rect x='183.20' y='507.53' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.443' stroke='none'/>
+<rect x='192.47' y='507.53' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.442' stroke='none'/>
+<rect x='201.73' y='507.53' width='9.27' height='9.27' fill='#fef2a6' fill-opacity='0.437' stroke='none'/>
+<rect x='211.00' y='507.53' width='9.27' height='9.27' fill='#fef2a8' fill-opacity='0.428' stroke='none'/>
+<rect x='220.27' y='507.53' width='9.27' height='9.27' fill='#fef2ab' fill-opacity='0.416' stroke='none'/>
+<rect x='229.53' y='507.53' width='9.27' height='9.27' fill='#fef3af' fill-opacity='0.401' stroke='none'/>
+<rect x='238.80' y='507.53' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.383' stroke='none'/>
+<rect x='248.07' y='507.53' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.364' stroke='none'/>
+<rect x='257.33' y='507.53' width='9.27' height='9.27' fill='#fff4bd' fill-opacity='0.344' stroke='none'/>
+<rect x='266.60' y='507.53' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.324' stroke='none'/>
+<rect x='275.87' y='507.53' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.303' stroke='none'/>
+<rect x='285.13' y='507.53' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.283' stroke='none'/>
+<rect x='294.40' y='507.53' width='9.27' height='9.27' fill='#fff5d1' fill-opacity='0.265' stroke='none'/>
+<rect x='303.67' y='507.53' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.247' stroke='none'/>
+<rect x='312.93' y='507.53' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.231' stroke='none'/>
+<rect x='81.27' y='498.27' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.260' stroke='none'/>
+<rect x='90.53' y='498.27' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.299' stroke='none'/>
+<rect x='99.80' y='498.27' width='9.27' height='9.27' fill='#fff4bf' fill-opacity='0.334' stroke='none'/>
+<rect x='109.07' y='498.27' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.365' stroke='none'/>
+<rect x='118.33' y='498.27' width='9.27' height='9.27' fill='#fef3b1' fill-opacity='0.392' stroke='none'/>
+<rect x='127.60' y='498.27' width='9.27' height='9.27' fill='#fef2ab' fill-opacity='0.417' stroke='none'/>
+<rect x='136.87' y='498.27' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.440' stroke='none'/>
+<rect x='146.13' y='498.27' width='9.27' height='9.27' fill='#fef2a1' fill-opacity='0.459' stroke='none'/>
+<rect x='155.40' y='498.27' width='9.27' height='9.27' fill='#fef19d' fill-opacity='0.475' stroke='none'/>
+<rect x='164.67' y='498.27' width='9.27' height='9.27' fill='#fef19a' fill-opacity='0.486' stroke='none'/>
+<rect x='173.93' y='498.27' width='9.27' height='9.27' fill='#fef198' fill-opacity='0.494' stroke='none'/>
+<rect x='183.20' y='498.27' width='9.27' height='9.27' fill='#fef197' fill-opacity='0.497' stroke='none'/>
+<rect x='192.47' y='498.27' width='9.27' height='9.27' fill='#fef198' fill-opacity='0.495' stroke='none'/>
+<rect x='201.73' y='498.27' width='9.27' height='9.27' fill='#fef199' fill-opacity='0.488' stroke='none'/>
+<rect x='211.00' y='498.27' width='9.27' height='9.27' fill='#fef19c' fill-opacity='0.477' stroke='none'/>
+<rect x='220.27' y='498.27' width='9.27' height='9.27' fill='#fef2a0' fill-opacity='0.463' stroke='none'/>
+<rect x='229.53' y='498.27' width='9.27' height='9.27' fill='#fef2a4' fill-opacity='0.445' stroke='none'/>
+<rect x='238.80' y='498.27' width='9.27' height='9.27' fill='#fef2a9' fill-opacity='0.424' stroke='none'/>
+<rect x='248.07' y='498.27' width='9.27' height='9.27' fill='#fef3af' fill-opacity='0.401' stroke='none'/>
+<rect x='257.33' y='498.27' width='9.27' height='9.27' fill='#fef3b5' fill-opacity='0.378' stroke='none'/>
+<rect x='266.60' y='498.27' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.353' stroke='none'/>
+<rect x='275.87' y='498.27' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.329' stroke='none'/>
+<rect x='285.13' y='498.27' width='9.27' height='9.27' fill='#fff4c6' fill-opacity='0.306' stroke='none'/>
+<rect x='294.40' y='498.27' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.284' stroke='none'/>
+<rect x='303.67' y='498.27' width='9.27' height='9.27' fill='#fff5d1' fill-opacity='0.263' stroke='none'/>
+<rect x='312.93' y='498.27' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.244' stroke='none'/>
+<rect x='72.00' y='489.00' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.231' stroke='none'/>
+<rect x='81.27' y='489.00' width='9.27' height='9.27' fill='#fff5cd' fill-opacity='0.280' stroke='none'/>
+<rect x='90.53' y='489.00' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.326' stroke='none'/>
+<rect x='99.80' y='489.00' width='9.27' height='9.27' fill='#fef3b7' fill-opacity='0.367' stroke='none'/>
+<rect x='109.07' y='489.00' width='9.27' height='9.27' fill='#fef3ae' fill-opacity='0.403' stroke='none'/>
+<rect x='118.33' y='489.00' width='9.27' height='9.27' fill='#fef2a6' fill-opacity='0.435' stroke='none'/>
+<rect x='127.60' y='489.00' width='9.27' height='9.27' fill='#fef29f' fill-opacity='0.464' stroke='none'/>
+<rect x='136.87' y='489.00' width='9.27' height='9.27' fill='#fef199' fill-opacity='0.490' stroke='none'/>
+<rect x='146.13' y='489.00' width='9.27' height='9.27' fill='#fef193' fill-opacity='0.512' stroke='none'/>
+<rect x='155.40' y='489.00' width='9.27' height='9.27' fill='#fef08f' fill-opacity='0.530' stroke='none'/>
+<rect x='164.67' y='489.00' width='9.27' height='9.27' fill='#fef08c' fill-opacity='0.543' stroke='none'/>
+<rect x='173.93' y='489.00' width='9.27' height='9.27' fill='#feef8a' fill-opacity='0.551' stroke='none'/>
+<rect x='183.20' y='489.00' width='9.27' height='9.27' fill='#fdee89' fill-opacity='0.554' stroke='none'/>
+<rect x='192.47' y='489.00' width='9.27' height='9.27' fill='#fef08a' fill-opacity='0.551' stroke='none'/>
+<rect x='201.73' y='489.00' width='9.27' height='9.27' fill='#fef08c' fill-opacity='0.543' stroke='none'/>
+<rect x='211.00' y='489.00' width='9.27' height='9.27' fill='#fef08f' fill-opacity='0.530' stroke='none'/>
+<rect x='220.27' y='489.00' width='9.27' height='9.27' fill='#fef193' fill-opacity='0.512' stroke='none'/>
+<rect x='229.53' y='489.00' width='9.27' height='9.27' fill='#fef199' fill-opacity='0.491' stroke='none'/>
+<rect x='238.80' y='489.00' width='9.27' height='9.27' fill='#fef19f' fill-opacity='0.467' stroke='none'/>
+<rect x='248.07' y='489.00' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.440' stroke='none'/>
+<rect x='257.33' y='489.00' width='9.27' height='9.27' fill='#fef2ac' fill-opacity='0.412' stroke='none'/>
+<rect x='266.60' y='489.00' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.384' stroke='none'/>
+<rect x='275.87' y='489.00' width='9.27' height='9.27' fill='#fef3ba' fill-opacity='0.356' stroke='none'/>
+<rect x='285.13' y='489.00' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.329' stroke='none'/>
+<rect x='294.40' y='489.00' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.303' stroke='none'/>
+<rect x='303.67' y='489.00' width='9.27' height='9.27' fill='#fff5cd' fill-opacity='0.279' stroke='none'/>
+<rect x='312.93' y='489.00' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.258' stroke='none'/>
+<rect x='322.20' y='489.00' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.239' stroke='none'/>
+<rect x='72.00' y='479.73' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.244' stroke='none'/>
+<rect x='81.27' y='479.73' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.301' stroke='none'/>
+<rect x='90.53' y='479.73' width='9.27' height='9.27' fill='#fef3ba' fill-opacity='0.354' stroke='none'/>
+<rect x='99.80' y='479.73' width='9.27' height='9.27' fill='#fef3af' fill-opacity='0.402' stroke='none'/>
+<rect x='109.07' y='479.73' width='9.27' height='9.27' fill='#fef2a4' fill-opacity='0.443' stroke='none'/>
+<rect x='118.33' y='479.73' width='9.27' height='9.27' fill='#fef19b' fill-opacity='0.480' stroke='none'/>
+<rect x='127.60' y='479.73' width='9.27' height='9.27' fill='#fef193' fill-opacity='0.513' stroke='none'/>
+<rect x='136.87' y='479.73' width='9.27' height='9.27' fill='#fef08c' fill-opacity='0.543' stroke='none'/>
+<rect x='146.13' y='479.73' width='9.27' height='9.27' fill='#fbe785' fill-opacity='0.568' stroke='none'/>
+<rect x='155.40' y='479.73' width='9.27' height='9.27' fill='#f8dc80' fill-opacity='0.587' stroke='none'/>
+<rect x='164.67' y='479.73' width='9.27' height='9.27' fill='#f5d47c' fill-opacity='0.602' stroke='none'/>
+<rect x='173.93' y='479.73' width='9.27' height='9.27' fill='#f4d079' fill-opacity='0.611' stroke='none'/>
+<rect x='183.20' y='479.73' width='9.27' height='9.27' fill='#f3cf79' fill-opacity='0.613' stroke='none'/>
+<rect x='192.47' y='479.73' width='9.27' height='9.27' fill='#f4d17a' fill-opacity='0.609' stroke='none'/>
+<rect x='201.73' y='479.73' width='9.27' height='9.27' fill='#f6d67c' fill-opacity='0.599' stroke='none'/>
+<rect x='211.00' y='479.73' width='9.27' height='9.27' fill='#f8de81' fill-opacity='0.584' stroke='none'/>
+<rect x='220.27' y='479.73' width='9.27' height='9.27' fill='#fce986' fill-opacity='0.563' stroke='none'/>
+<rect x='229.53' y='479.73' width='9.27' height='9.27' fill='#fef08d' fill-opacity='0.538' stroke='none'/>
+<rect x='238.80' y='479.73' width='9.27' height='9.27' fill='#fef194' fill-opacity='0.510' stroke='none'/>
+<rect x='248.07' y='479.73' width='9.27' height='9.27' fill='#fef19b' fill-opacity='0.480' stroke='none'/>
+<rect x='257.33' y='479.73' width='9.27' height='9.27' fill='#fef2a3' fill-opacity='0.448' stroke='none'/>
+<rect x='266.60' y='479.73' width='9.27' height='9.27' fill='#fef2ab' fill-opacity='0.415' stroke='none'/>
+<rect x='275.87' y='479.73' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.383' stroke='none'/>
+<rect x='285.13' y='479.73' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.352' stroke='none'/>
+<rect x='294.40' y='479.73' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.323' stroke='none'/>
+<rect x='303.67' y='479.73' width='9.27' height='9.27' fill='#fff4c9' fill-opacity='0.296' stroke='none'/>
+<rect x='312.93' y='479.73' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.271' stroke='none'/>
+<rect x='322.20' y='479.73' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.250' stroke='none'/>
+<rect x='331.47' y='479.73' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.231' stroke='none'/>
+<rect x='72.00' y='470.47' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.258' stroke='none'/>
+<rect x='81.27' y='470.47' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.322' stroke='none'/>
+<rect x='90.53' y='470.47' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.383' stroke='none'/>
+<rect x='99.80' y='470.47' width='9.27' height='9.27' fill='#fef2a6' fill-opacity='0.438' stroke='none'/>
+<rect x='109.07' y='470.47' width='9.27' height='9.27' fill='#fef19a' fill-opacity='0.485' stroke='none'/>
+<rect x='118.33' y='470.47' width='9.27' height='9.27' fill='#fef090' fill-opacity='0.526' stroke='none'/>
+<rect x='127.60' y='470.47' width='9.27' height='9.27' fill='#fce986' fill-opacity='0.564' stroke='none'/>
+<rect x='136.87' y='470.47' width='9.27' height='9.27' fill='#f6d77d' fill-opacity='0.596' stroke='none'/>
+<rect x='146.13' y='470.47' width='9.27' height='9.27' fill='#f1c976' fill-opacity='0.624' stroke='none'/>
+<rect x='155.40' y='470.47' width='9.27' height='9.27' fill='#edbd70' fill-opacity='0.646' stroke='none'/>
+<rect x='164.67' y='470.47' width='9.27' height='9.27' fill='#ebb56b' fill-opacity='0.662' stroke='none'/>
+<rect x='173.93' y='470.47' width='9.27' height='9.27' fill='#e9b069' fill-opacity='0.671' stroke='none'/>
+<rect x='183.20' y='470.47' width='9.27' height='9.27' fill='#e9af68' fill-opacity='0.672' stroke='none'/>
+<rect x='192.47' y='470.47' width='9.27' height='9.27' fill='#eab26a' fill-opacity='0.667' stroke='none'/>
+<rect x='201.73' y='470.47' width='9.27' height='9.27' fill='#ecb86d' fill-opacity='0.655' stroke='none'/>
+<rect x='211.00' y='470.47' width='9.27' height='9.27' fill='#efc272' fill-opacity='0.637' stroke='none'/>
+<rect x='220.27' y='470.47' width='9.27' height='9.27' fill='#f3ce79' fill-opacity='0.614' stroke='none'/>
+<rect x='229.53' y='470.47' width='9.27' height='9.27' fill='#f8dd80' fill-opacity='0.585' stroke='none'/>
+<rect x='238.80' y='470.47' width='9.27' height='9.27' fill='#fdee89' fill-opacity='0.553' stroke='none'/>
+<rect x='248.07' y='470.47' width='9.27' height='9.27' fill='#fef192' fill-opacity='0.518' stroke='none'/>
+<rect x='257.33' y='470.47' width='9.27' height='9.27' fill='#fef19b' fill-opacity='0.482' stroke='none'/>
+<rect x='266.60' y='470.47' width='9.27' height='9.27' fill='#fef2a4' fill-opacity='0.446' stroke='none'/>
+<rect x='275.87' y='470.47' width='9.27' height='9.27' fill='#fef2ad' fill-opacity='0.409' stroke='none'/>
+<rect x='285.13' y='470.47' width='9.27' height='9.27' fill='#fef3b5' fill-opacity='0.375' stroke='none'/>
+<rect x='294.40' y='470.47' width='9.27' height='9.27' fill='#fff4bd' fill-opacity='0.342' stroke='none'/>
+<rect x='303.67' y='470.47' width='9.27' height='9.27' fill='#fff4c5' fill-opacity='0.312' stroke='none'/>
+<rect x='312.93' y='470.47' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.285' stroke='none'/>
+<rect x='322.20' y='470.47' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.260' stroke='none'/>
+<rect x='331.47' y='470.47' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.239' stroke='none'/>
+<rect x='72.00' y='461.20' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.272' stroke='none'/>
+<rect x='81.27' y='461.20' width='9.27' height='9.27' fill='#fff4bd' fill-opacity='0.344' stroke='none'/>
+<rect x='90.53' y='461.20' width='9.27' height='9.27' fill='#fef2ac' fill-opacity='0.413' stroke='none'/>
+<rect x='99.80' y='461.20' width='9.27' height='9.27' fill='#fef19d' fill-opacity='0.474' stroke='none'/>
+<rect x='109.07' y='461.20' width='9.27' height='9.27' fill='#fef090' fill-opacity='0.526' stroke='none'/>
+<rect x='118.33' y='461.20' width='9.27' height='9.27' fill='#fae484' fill-opacity='0.573' stroke='none'/>
+<rect x='127.60' y='461.20' width='9.27' height='9.27' fill='#f3ce78' fill-opacity='0.614' stroke='none'/>
+<rect x='136.87' y='461.20' width='9.27' height='9.27' fill='#edbb6f' fill-opacity='0.650' stroke='none'/>
+<rect x='146.13' y='461.20' width='9.27' height='9.27' fill='#e8ab66' fill-opacity='0.680' stroke='none'/>
+<rect x='155.40' y='461.20' width='9.27' height='9.27' fill='#e39e60' fill-opacity='0.704' stroke='none'/>
+<rect x='164.67' y='461.20' width='9.27' height='9.27' fill='#e1965b' fill-opacity='0.720' stroke='none'/>
+<rect x='173.93' y='461.20' width='9.27' height='9.27' fill='#df9159' fill-opacity='0.729' stroke='none'/>
+<rect x='183.20' y='461.20' width='9.27' height='9.27' fill='#df9058' fill-opacity='0.731' stroke='none'/>
+<rect x='192.47' y='461.20' width='9.27' height='9.27' fill='#e0945a' fill-opacity='0.724' stroke='none'/>
+<rect x='201.73' y='461.20' width='9.27' height='9.27' fill='#e29b5e' fill-opacity='0.710' stroke='none'/>
+<rect x='211.00' y='461.20' width='9.27' height='9.27' fill='#e6a664' fill-opacity='0.689' stroke='none'/>
+<rect x='220.27' y='461.20' width='9.27' height='9.27' fill='#ebb56b' fill-opacity='0.662' stroke='none'/>
+<rect x='229.53' y='461.20' width='9.27' height='9.27' fill='#f0c674' fill-opacity='0.630' stroke='none'/>
+<rect x='238.80' y='461.20' width='9.27' height='9.27' fill='#f6d97e' fill-opacity='0.594' stroke='none'/>
+<rect x='248.07' y='461.20' width='9.27' height='9.27' fill='#fded89' fill-opacity='0.555' stroke='none'/>
+<rect x='257.33' y='461.20' width='9.27' height='9.27' fill='#fef193' fill-opacity='0.515' stroke='none'/>
+<rect x='266.60' y='461.20' width='9.27' height='9.27' fill='#fef19d' fill-opacity='0.474' stroke='none'/>
+<rect x='275.87' y='461.20' width='9.27' height='9.27' fill='#fef2a7' fill-opacity='0.434' stroke='none'/>
+<rect x='285.13' y='461.20' width='9.27' height='9.27' fill='#fef3b0' fill-opacity='0.396' stroke='none'/>
+<rect x='294.40' y='461.20' width='9.27' height='9.27' fill='#fef3b9' fill-opacity='0.360' stroke='none'/>
+<rect x='303.67' y='461.20' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.327' stroke='none'/>
+<rect x='312.93' y='461.20' width='9.27' height='9.27' fill='#fff4c9' fill-opacity='0.297' stroke='none'/>
+<rect x='322.20' y='461.20' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.270' stroke='none'/>
+<rect x='331.47' y='461.20' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.247' stroke='none'/>
+<rect x='72.00' y='451.93' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.285' stroke='none'/>
+<rect x='81.27' y='451.93' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.366' stroke='none'/>
+<rect x='90.53' y='451.93' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.442' stroke='none'/>
+<rect x='99.80' y='451.93' width='9.27' height='9.27' fill='#fef194' fill-opacity='0.509' stroke='none'/>
+<rect x='109.07' y='451.93' width='9.27' height='9.27' fill='#fbe785' fill-opacity='0.567' stroke='none'/>
+<rect x='118.33' y='451.93' width='9.27' height='9.27' fill='#f2cc77' fill-opacity='0.617' stroke='none'/>
+<rect x='127.60' y='451.93' width='9.27' height='9.27' fill='#ebb46b' fill-opacity='0.662' stroke='none'/>
+<rect x='136.87' y='451.93' width='9.27' height='9.27' fill='#e4a060' fill-opacity='0.701' stroke='none'/>
+<rect x='146.13' y='451.93' width='9.27' height='9.27' fill='#de8f57' fill-opacity='0.734' stroke='none'/>
+<rect x='155.40' y='451.93' width='9.27' height='9.27' fill='#da8151' fill-opacity='0.759' stroke='none'/>
+<rect x='164.67' y='451.93' width='9.27' height='9.27' fill='#d7784c' fill-opacity='0.776' stroke='none'/>
+<rect x='173.93' y='451.93' width='9.27' height='9.27' fill='#d57349' fill-opacity='0.785' stroke='none'/>
+<rect x='183.20' y='451.93' width='9.27' height='9.27' fill='#d57349' fill-opacity='0.785' stroke='none'/>
+<rect x='192.47' y='451.93' width='9.27' height='9.27' fill='#d7784b' fill-opacity='0.777' stroke='none'/>
+<rect x='201.73' y='451.93' width='9.27' height='9.27' fill='#da8050' fill-opacity='0.761' stroke='none'/>
+<rect x='211.00' y='451.93' width='9.27' height='9.27' fill='#de8d56' fill-opacity='0.737' stroke='none'/>
+<rect x='220.27' y='451.93' width='9.27' height='9.27' fill='#e39d5f' fill-opacity='0.707' stroke='none'/>
+<rect x='229.53' y='451.93' width='9.27' height='9.27' fill='#e9b069' fill-opacity='0.671' stroke='none'/>
+<rect x='238.80' y='451.93' width='9.27' height='9.27' fill='#f0c574' fill-opacity='0.632' stroke='none'/>
+<rect x='248.07' y='451.93' width='9.27' height='9.27' fill='#f7db7f' fill-opacity='0.589' stroke='none'/>
+<rect x='257.33' y='451.93' width='9.27' height='9.27' fill='#fef08b' fill-opacity='0.545' stroke='none'/>
+<rect x='266.60' y='451.93' width='9.27' height='9.27' fill='#fef196' fill-opacity='0.500' stroke='none'/>
+<rect x='275.87' y='451.93' width='9.27' height='9.27' fill='#fef2a1' fill-opacity='0.457' stroke='none'/>
+<rect x='285.13' y='451.93' width='9.27' height='9.27' fill='#fef2ab' fill-opacity='0.415' stroke='none'/>
+<rect x='294.40' y='451.93' width='9.27' height='9.27' fill='#fef3b5' fill-opacity='0.376' stroke='none'/>
+<rect x='303.67' y='451.93' width='9.27' height='9.27' fill='#fff4be' fill-opacity='0.340' stroke='none'/>
+<rect x='312.93' y='451.93' width='9.27' height='9.27' fill='#fff4c6' fill-opacity='0.308' stroke='none'/>
+<rect x='322.20' y='451.93' width='9.27' height='9.27' fill='#fff5cd' fill-opacity='0.279' stroke='none'/>
+<rect x='331.47' y='451.93' width='9.27' height='9.27' fill='#fff5d3' fill-opacity='0.254' stroke='none'/>
+<rect x='340.73' y='451.93' width='9.27' height='9.27' fill='#fff6d8' fill-opacity='0.233' stroke='none'/>
+<rect x='72.00' y='442.67' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.298' stroke='none'/>
+<rect x='81.27' y='442.67' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.386' stroke='none'/>
+<rect x='90.53' y='442.67' width='9.27' height='9.27' fill='#fef19e' fill-opacity='0.469' stroke='none'/>
+<rect x='99.80' y='442.67' width='9.27' height='9.27' fill='#fef08c' fill-opacity='0.542' stroke='none'/>
+<rect x='109.07' y='442.67' width='9.27' height='9.27' fill='#f5d37b' fill-opacity='0.604' stroke='none'/>
+<rect x='118.33' y='442.67' width='9.27' height='9.27' fill='#ebb66c' fill-opacity='0.659' stroke='none'/>
+<rect x='127.60' y='442.67' width='9.27' height='9.27' fill='#e39d5f' fill-opacity='0.707' stroke='none'/>
+<rect x='136.87' y='442.67' width='9.27' height='9.27' fill='#dc8753' fill-opacity='0.749' stroke='none'/>
+<rect x='146.13' y='442.67' width='9.27' height='9.27' fill='#d6754a' fill-opacity='0.783' stroke='none'/>
+<rect x='155.40' y='442.67' width='9.27' height='9.27' fill='#d16743' fill-opacity='0.809' stroke='none'/>
+<rect x='164.67' y='442.67' width='9.27' height='9.27' fill='#ce5d3e' fill-opacity='0.827' stroke='none'/>
+<rect x='173.93' y='442.67' width='9.27' height='9.27' fill='#cd593c' fill-opacity='0.835' stroke='none'/>
+<rect x='183.20' y='442.67' width='9.27' height='9.27' fill='#cd593c' fill-opacity='0.835' stroke='none'/>
+<rect x='192.47' y='442.67' width='9.27' height='9.27' fill='#cf5e3e' fill-opacity='0.825' stroke='none'/>
+<rect x='201.73' y='442.67' width='9.27' height='9.27' fill='#d26843' fill-opacity='0.806' stroke='none'/>
+<rect x='211.00' y='442.67' width='9.27' height='9.27' fill='#d6764b' fill-opacity='0.780' stroke='none'/>
+<rect x='220.27' y='442.67' width='9.27' height='9.27' fill='#dc8854' fill-opacity='0.747' stroke='none'/>
+<rect x='229.53' y='442.67' width='9.27' height='9.27' fill='#e39c5f' fill-opacity='0.708' stroke='none'/>
+<rect x='238.80' y='442.67' width='9.27' height='9.27' fill='#eab36b' fill-opacity='0.664' stroke='none'/>
+<rect x='248.07' y='442.67' width='9.27' height='9.27' fill='#f2cc77' fill-opacity='0.618' stroke='none'/>
+<rect x='257.33' y='442.67' width='9.27' height='9.27' fill='#fae584' fill-opacity='0.570' stroke='none'/>
+<rect x='266.60' y='442.67' width='9.27' height='9.27' fill='#fef091' fill-opacity='0.523' stroke='none'/>
+<rect x='275.87' y='442.67' width='9.27' height='9.27' fill='#fef19c' fill-opacity='0.476' stroke='none'/>
+<rect x='285.13' y='442.67' width='9.27' height='9.27' fill='#fef2a7' fill-opacity='0.431' stroke='none'/>
+<rect x='294.40' y='442.67' width='9.27' height='9.27' fill='#fef3b2' fill-opacity='0.389' stroke='none'/>
+<rect x='303.67' y='442.67' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.351' stroke='none'/>
+<rect x='312.93' y='442.67' width='9.27' height='9.27' fill='#fff4c4' fill-opacity='0.317' stroke='none'/>
+<rect x='322.20' y='442.67' width='9.27' height='9.27' fill='#fff5cb' fill-opacity='0.286' stroke='none'/>
+<rect x='331.47' y='442.67' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.260' stroke='none'/>
+<rect x='340.73' y='442.67' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.237' stroke='none'/>
+<rect x='72.00' y='433.40' width='9.27' height='9.27' fill='#fff4c6' fill-opacity='0.309' stroke='none'/>
+<rect x='81.27' y='433.40' width='9.27' height='9.27' fill='#fef3ae' fill-opacity='0.404' stroke='none'/>
+<rect x='90.53' y='433.40' width='9.27' height='9.27' fill='#fef198' fill-opacity='0.493' stroke='none'/>
+<rect x='99.80' y='433.40' width='9.27' height='9.27' fill='#fae584' fill-opacity='0.571' stroke='none'/>
+<rect x='109.07' y='433.40' width='9.27' height='9.27' fill='#efc172' fill-opacity='0.638' stroke='none'/>
+<rect x='118.33' y='433.40' width='9.27' height='9.27' fill='#e5a262' fill-opacity='0.696' stroke='none'/>
+<rect x='127.60' y='433.40' width='9.27' height='9.27' fill='#dc8854' fill-opacity='0.747' stroke='none'/>
+<rect x='136.87' y='433.40' width='9.27' height='9.27' fill='#d57148' fill-opacity='0.791' stroke='none'/>
+<rect x='146.13' y='433.40' width='9.27' height='9.27' fill='#ce5e3e' fill-opacity='0.826' stroke='none'/>
+<rect x='155.40' y='433.40' width='9.27' height='9.27' fill='#ca4f37' fill-opacity='0.853' stroke='none'/>
+<rect x='164.67' y='433.40' width='9.27' height='9.27' fill='#c74632' fill-opacity='0.871' stroke='none'/>
+<rect x='173.93' y='433.40' width='9.27' height='9.27' fill='#c54230' fill-opacity='0.879' stroke='none'/>
+<rect x='183.20' y='433.40' width='9.27' height='9.27' fill='#c64330' fill-opacity='0.877' stroke='none'/>
+<rect x='192.47' y='433.40' width='9.27' height='9.27' fill='#c84933' fill-opacity='0.865' stroke='none'/>
+<rect x='201.73' y='433.40' width='9.27' height='9.27' fill='#cb5439' fill-opacity='0.845' stroke='none'/>
+<rect x='211.00' y='433.40' width='9.27' height='9.27' fill='#d06341' fill-opacity='0.816' stroke='none'/>
+<rect x='220.27' y='433.40' width='9.27' height='9.27' fill='#d6764b' fill-opacity='0.779' stroke='none'/>
+<rect x='229.53' y='433.40' width='9.27' height='9.27' fill='#de8d56' fill-opacity='0.737' stroke='none'/>
+<rect x='238.80' y='433.40' width='9.27' height='9.27' fill='#e6a563' fill-opacity='0.691' stroke='none'/>
+<rect x='248.07' y='433.40' width='9.27' height='9.27' fill='#eebf71' fill-opacity='0.642' stroke='none'/>
+<rect x='257.33' y='433.40' width='9.27' height='9.27' fill='#f7da7f' fill-opacity='0.591' stroke='none'/>
+<rect x='266.60' y='433.40' width='9.27' height='9.27' fill='#fef08c' fill-opacity='0.540' stroke='none'/>
+<rect x='275.87' y='433.40' width='9.27' height='9.27' fill='#fef199' fill-opacity='0.491' stroke='none'/>
+<rect x='285.13' y='433.40' width='9.27' height='9.27' fill='#fef2a4' fill-opacity='0.444' stroke='none'/>
+<rect x='294.40' y='433.40' width='9.27' height='9.27' fill='#fef3af' fill-opacity='0.400' stroke='none'/>
+<rect x='303.67' y='433.40' width='9.27' height='9.27' fill='#fef3b9' fill-opacity='0.359' stroke='none'/>
+<rect x='312.93' y='433.40' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.323' stroke='none'/>
+<rect x='322.20' y='433.40' width='9.27' height='9.27' fill='#fff5ca' fill-opacity='0.291' stroke='none'/>
+<rect x='331.47' y='433.40' width='9.27' height='9.27' fill='#fff5d1' fill-opacity='0.264' stroke='none'/>
+<rect x='340.73' y='433.40' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.240' stroke='none'/>
+<rect x='72.00' y='424.13' width='9.27' height='9.27' fill='#fff4c3' fill-opacity='0.319' stroke='none'/>
+<rect x='81.27' y='424.13' width='9.27' height='9.27' fill='#fef2aa' fill-opacity='0.419' stroke='none'/>
+<rect x='90.53' y='424.13' width='9.27' height='9.27' fill='#fef193' fill-opacity='0.514' stroke='none'/>
+<rect x='99.80' y='424.13' width='9.27' height='9.27' fill='#f6d77d' fill-opacity='0.597' stroke='none'/>
+<rect x='109.07' y='424.13' width='9.27' height='9.27' fill='#eab26a' fill-opacity='0.666' stroke='none'/>
+<rect x='118.33' y='424.13' width='9.27' height='9.27' fill='#df9259' fill-opacity='0.727' stroke='none'/>
+<rect x='127.60' y='424.13' width='9.27' height='9.27' fill='#d6764b' fill-opacity='0.780' stroke='none'/>
+<rect x='136.87' y='424.13' width='9.27' height='9.27' fill='#cf5e3e' fill-opacity='0.825' stroke='none'/>
+<rect x='146.13' y='424.13' width='9.27' height='9.27' fill='#c84b34' fill-opacity='0.861' stroke='none'/>
+<rect x='155.40' y='424.13' width='9.27' height='9.27' fill='#c43d2d' fill-opacity='0.888' stroke='none'/>
+<rect x='164.67' y='424.13' width='9.27' height='9.27' fill='#c13328' fill-opacity='0.906' stroke='none'/>
+<rect x='173.93' y='424.13' width='9.27' height='9.27' fill='#bf3026' fill-opacity='0.913' stroke='none'/>
+<rect x='183.20' y='424.13' width='9.27' height='9.27' fill='#c03127' fill-opacity='0.910' stroke='none'/>
+<rect x='192.47' y='424.13' width='9.27' height='9.27' fill='#c2382b' fill-opacity='0.896' stroke='none'/>
+<rect x='201.73' y='424.13' width='9.27' height='9.27' fill='#c64431' fill-opacity='0.874' stroke='none'/>
+<rect x='211.00' y='424.13' width='9.27' height='9.27' fill='#cc553a' fill-opacity='0.842' stroke='none'/>
+<rect x='220.27' y='424.13' width='9.27' height='9.27' fill='#d26944' fill-opacity='0.804' stroke='none'/>
+<rect x='229.53' y='424.13' width='9.27' height='9.27' fill='#da8150' fill-opacity='0.759' stroke='none'/>
+<rect x='238.80' y='424.13' width='9.27' height='9.27' fill='#e29b5e' fill-opacity='0.710' stroke='none'/>
+<rect x='248.07' y='424.13' width='9.27' height='9.27' fill='#ebb76c' fill-opacity='0.658' stroke='none'/>
+<rect x='257.33' y='424.13' width='9.27' height='9.27' fill='#f4d37b' fill-opacity='0.605' stroke='none'/>
+<rect x='266.60' y='424.13' width='9.27' height='9.27' fill='#feef89' fill-opacity='0.552' stroke='none'/>
+<rect x='275.87' y='424.13' width='9.27' height='9.27' fill='#fef196' fill-opacity='0.501' stroke='none'/>
+<rect x='285.13' y='424.13' width='9.27' height='9.27' fill='#fef2a2' fill-opacity='0.452' stroke='none'/>
+<rect x='294.40' y='424.13' width='9.27' height='9.27' fill='#fef3ae' fill-opacity='0.406' stroke='none'/>
+<rect x='303.67' y='424.13' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.365' stroke='none'/>
+<rect x='312.93' y='424.13' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.328' stroke='none'/>
+<rect x='322.20' y='424.13' width='9.27' height='9.27' fill='#fff4c9' fill-opacity='0.295' stroke='none'/>
+<rect x='331.47' y='424.13' width='9.27' height='9.27' fill='#fff5d0' fill-opacity='0.266' stroke='none'/>
+<rect x='340.73' y='424.13' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.242' stroke='none'/>
+<rect x='72.00' y='414.87' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.327' stroke='none'/>
+<rect x='81.27' y='414.87' width='9.27' height='9.27' fill='#fef2a7' fill-opacity='0.431' stroke='none'/>
+<rect x='90.53' y='414.87' width='9.27' height='9.27' fill='#fef08f' fill-opacity='0.530' stroke='none'/>
+<rect x='99.80' y='414.87' width='9.27' height='9.27' fill='#f3cd78' fill-opacity='0.616' stroke='none'/>
+<rect x='109.07' y='414.87' width='9.27' height='9.27' fill='#e6a764' fill-opacity='0.688' stroke='none'/>
+<rect x='118.33' y='414.87' width='9.27' height='9.27' fill='#db8553' fill-opacity='0.751' stroke='none'/>
+<rect x='127.60' y='414.87' width='9.27' height='9.27' fill='#d26944' fill-opacity='0.805' stroke='none'/>
+<rect x='136.87' y='414.87' width='9.27' height='9.27' fill='#ca5137' fill-opacity='0.851' stroke='none'/>
+<rect x='146.13' y='414.87' width='9.27' height='9.27' fill='#c43d2d' fill-opacity='0.887' stroke='none'/>
+<rect x='155.40' y='414.87' width='9.27' height='9.27' fill='#bf2f26' fill-opacity='0.914' stroke='none'/>
+<rect x='164.67' y='414.87' width='9.27' height='9.27' fill='#bc2621' fill-opacity='0.931' stroke='none'/>
+<rect x='173.93' y='414.87' width='9.27' height='9.27' fill='#bb2320' fill-opacity='0.937' stroke='none'/>
+<rect x='183.20' y='414.87' width='9.27' height='9.27' fill='#bc2521' fill-opacity='0.932' stroke='none'/>
+<rect x='192.47' y='414.87' width='9.27' height='9.27' fill='#bf2d25' fill-opacity='0.917' stroke='none'/>
+<rect x='201.73' y='414.87' width='9.27' height='9.27' fill='#c33a2c' fill-opacity='0.893' stroke='none'/>
+<rect x='211.00' y='414.87' width='9.27' height='9.27' fill='#c94c35' fill-opacity='0.860' stroke='none'/>
+<rect x='220.27' y='414.87' width='9.27' height='9.27' fill='#d06140' fill-opacity='0.819' stroke='none'/>
+<rect x='229.53' y='414.87' width='9.27' height='9.27' fill='#d87a4d' fill-opacity='0.772' stroke='none'/>
+<rect x='238.80' y='414.87' width='9.27' height='9.27' fill='#e0955b' fill-opacity='0.721' stroke='none'/>
+<rect x='248.07' y='414.87' width='9.27' height='9.27' fill='#eab26a' fill-opacity='0.668' stroke='none'/>
+<rect x='257.33' y='414.87' width='9.27' height='9.27' fill='#f3cf79' fill-opacity='0.613' stroke='none'/>
+<rect x='266.60' y='414.87' width='9.27' height='9.27' fill='#fdeb88' fill-opacity='0.559' stroke='none'/>
+<rect x='275.87' y='414.87' width='9.27' height='9.27' fill='#fef195' fill-opacity='0.506' stroke='none'/>
+<rect x='285.13' y='414.87' width='9.27' height='9.27' fill='#fef2a1' fill-opacity='0.456' stroke='none'/>
+<rect x='294.40' y='414.87' width='9.27' height='9.27' fill='#fef2ad' fill-opacity='0.409' stroke='none'/>
+<rect x='303.67' y='414.87' width='9.27' height='9.27' fill='#fef3b7' fill-opacity='0.367' stroke='none'/>
+<rect x='312.93' y='414.87' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.329' stroke='none'/>
+<rect x='322.20' y='414.87' width='9.27' height='9.27' fill='#fff4c9' fill-opacity='0.296' stroke='none'/>
+<rect x='331.47' y='414.87' width='9.27' height='9.27' fill='#fff5d0' fill-opacity='0.267' stroke='none'/>
+<rect x='340.73' y='414.87' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.243' stroke='none'/>
+<rect x='72.00' y='405.60' width='9.27' height='9.27' fill='#fff4c0' fill-opacity='0.332' stroke='none'/>
+<rect x='81.27' y='405.60' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.440' stroke='none'/>
+<rect x='90.53' y='405.60' width='9.27' height='9.27' fill='#fef08c' fill-opacity='0.541' stroke='none'/>
+<rect x='99.80' y='405.60' width='9.27' height='9.27' fill='#f0c674' fill-opacity='0.629' stroke='none'/>
+<rect x='109.07' y='405.60' width='9.27' height='9.27' fill='#e49f60' fill-opacity='0.703' stroke='none'/>
+<rect x='118.33' y='405.60' width='9.27' height='9.27' fill='#d97d4e' fill-opacity='0.767' stroke='none'/>
+<rect x='127.60' y='405.60' width='9.27' height='9.27' fill='#cf603f' fill-opacity='0.821' stroke='none'/>
+<rect x='136.87' y='405.60' width='9.27' height='9.27' fill='#c74833' fill-opacity='0.867' stroke='none'/>
+<rect x='146.13' y='405.60' width='9.27' height='9.27' fill='#c13529' fill-opacity='0.903' stroke='none'/>
+<rect x='155.40' y='405.60' width='9.27' height='9.27' fill='#bd2722' fill-opacity='0.929' stroke='none'/>
+<rect x='164.67' y='405.60' width='9.27' height='9.27' fill='#ba1f1e' fill-opacity='0.944' stroke='none'/>
+<rect x='173.93' y='405.60' width='9.27' height='9.27' fill='#b91c1c' fill-opacity='0.949' stroke='none'/>
+<rect x='183.20' y='405.60' width='9.27' height='9.27' fill='#ba201e' fill-opacity='0.943' stroke='none'/>
+<rect x='192.47' y='405.60' width='9.27' height='9.27' fill='#bd2822' fill-opacity='0.927' stroke='none'/>
+<rect x='201.73' y='405.60' width='9.27' height='9.27' fill='#c1362a' fill-opacity='0.901' stroke='none'/>
+<rect x='211.00' y='405.60' width='9.27' height='9.27' fill='#c74833' fill-opacity='0.866' stroke='none'/>
+<rect x='220.27' y='405.60' width='9.27' height='9.27' fill='#cf5f3f' fill-opacity='0.824' stroke='none'/>
+<rect x='229.53' y='405.60' width='9.27' height='9.27' fill='#d7784c' fill-opacity='0.776' stroke='none'/>
+<rect x='238.80' y='405.60' width='9.27' height='9.27' fill='#e0945a' fill-opacity='0.724' stroke='none'/>
+<rect x='248.07' y='405.60' width='9.27' height='9.27' fill='#e9b169' fill-opacity='0.669' stroke='none'/>
+<rect x='257.33' y='405.60' width='9.27' height='9.27' fill='#f3ce79' fill-opacity='0.614' stroke='none'/>
+<rect x='266.60' y='405.60' width='9.27' height='9.27' fill='#fdec88' fill-opacity='0.558' stroke='none'/>
+<rect x='275.87' y='405.60' width='9.27' height='9.27' fill='#fef195' fill-opacity='0.505' stroke='none'/>
+<rect x='285.13' y='405.60' width='9.27' height='9.27' fill='#fef2a2' fill-opacity='0.455' stroke='none'/>
+<rect x='294.40' y='405.60' width='9.27' height='9.27' fill='#fef2ad' fill-opacity='0.408' stroke='none'/>
+<rect x='303.67' y='405.60' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.366' stroke='none'/>
+<rect x='312.93' y='405.60' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.328' stroke='none'/>
+<rect x='322.20' y='405.60' width='9.27' height='9.27' fill='#fff4c9' fill-opacity='0.295' stroke='none'/>
+<rect x='331.47' y='405.60' width='9.27' height='9.27' fill='#fff5d0' fill-opacity='0.266' stroke='none'/>
+<rect x='340.73' y='405.60' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.242' stroke='none'/>
+<rect x='72.00' y='396.33' width='9.27' height='9.27' fill='#fff4bf' fill-opacity='0.335' stroke='none'/>
+<rect x='81.27' y='396.33' width='9.27' height='9.27' fill='#fef2a4' fill-opacity='0.444' stroke='none'/>
+<rect x='90.53' y='396.33' width='9.27' height='9.27' fill='#fef08b' fill-opacity='0.546' stroke='none'/>
+<rect x='99.80' y='396.33' width='9.27' height='9.27' fill='#efc372' fill-opacity='0.635' stroke='none'/>
+<rect x='109.07' y='396.33' width='9.27' height='9.27' fill='#e29b5e' fill-opacity='0.710' stroke='none'/>
+<rect x='118.33' y='396.33' width='9.27' height='9.27' fill='#d77a4d' fill-opacity='0.773' stroke='none'/>
+<rect x='127.60' y='396.33' width='9.27' height='9.27' fill='#ce5d3e' fill-opacity='0.827' stroke='none'/>
+<rect x='136.87' y='396.33' width='9.27' height='9.27' fill='#c64531' fill-opacity='0.872' stroke='none'/>
+<rect x='146.13' y='396.33' width='9.27' height='9.27' fill='#c03328' fill-opacity='0.907' stroke='none'/>
+<rect x='155.40' y='396.33' width='9.27' height='9.27' fill='#bc2521' fill-opacity='0.932' stroke='none'/>
+<rect x='164.67' y='396.33' width='9.27' height='9.27' fill='#ba1e1d' fill-opacity='0.947' stroke='none'/>
+<rect x='173.93' y='396.33' width='9.27' height='9.27' fill='#b91c1c' fill-opacity='0.950' stroke='none'/>
+<rect x='183.20' y='396.33' width='9.27' height='9.27' fill='#ba201e' fill-opacity='0.943' stroke='none'/>
+<rect x='192.47' y='396.33' width='9.27' height='9.27' fill='#bd2923' fill-opacity='0.925' stroke='none'/>
+<rect x='201.73' y='396.33' width='9.27' height='9.27' fill='#c2382a' fill-opacity='0.898' stroke='none'/>
+<rect x='211.00' y='396.33' width='9.27' height='9.27' fill='#c84b34' fill-opacity='0.862' stroke='none'/>
+<rect x='220.27' y='396.33' width='9.27' height='9.27' fill='#d06240' fill-opacity='0.819' stroke='none'/>
+<rect x='229.53' y='396.33' width='9.27' height='9.27' fill='#d87b4d' fill-opacity='0.770' stroke='none'/>
+<rect x='238.80' y='396.33' width='9.27' height='9.27' fill='#e1975c' fill-opacity='0.718' stroke='none'/>
+<rect x='248.07' y='396.33' width='9.27' height='9.27' fill='#ebb46b' fill-opacity='0.663' stroke='none'/>
+<rect x='257.33' y='396.33' width='9.27' height='9.27' fill='#f4d27a' fill-opacity='0.607' stroke='none'/>
+<rect x='266.60' y='396.33' width='9.27' height='9.27' fill='#feef89' fill-opacity='0.552' stroke='none'/>
+<rect x='275.87' y='396.33' width='9.27' height='9.27' fill='#fef197' fill-opacity='0.499' stroke='none'/>
+<rect x='285.13' y='396.33' width='9.27' height='9.27' fill='#fef2a3' fill-opacity='0.449' stroke='none'/>
+<rect x='294.40' y='396.33' width='9.27' height='9.27' fill='#fef3ae' fill-opacity='0.403' stroke='none'/>
+<rect x='303.67' y='396.33' width='9.27' height='9.27' fill='#fef3b9' fill-opacity='0.361' stroke='none'/>
+<rect x='312.93' y='396.33' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.324' stroke='none'/>
+<rect x='322.20' y='396.33' width='9.27' height='9.27' fill='#fff5ca' fill-opacity='0.291' stroke='none'/>
+<rect x='331.47' y='396.33' width='9.27' height='9.27' fill='#fff5d1' fill-opacity='0.263' stroke='none'/>
+<rect x='340.73' y='396.33' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.239' stroke='none'/>
+<rect x='72.00' y='387.07' width='9.27' height='9.27' fill='#fff4bf' fill-opacity='0.335' stroke='none'/>
+<rect x='81.27' y='387.07' width='9.27' height='9.27' fill='#fef2a4' fill-opacity='0.444' stroke='none'/>
+<rect x='90.53' y='387.07' width='9.27' height='9.27' fill='#fef08b' fill-opacity='0.546' stroke='none'/>
+<rect x='99.80' y='387.07' width='9.27' height='9.27' fill='#efc373' fill-opacity='0.635' stroke='none'/>
+<rect x='109.07' y='387.07' width='9.27' height='9.27' fill='#e39c5e' fill-opacity='0.708' stroke='none'/>
+<rect x='118.33' y='387.07' width='9.27' height='9.27' fill='#d87b4d' fill-opacity='0.771' stroke='none'/>
+<rect x='127.60' y='387.07' width='9.27' height='9.27' fill='#cf5f3f' fill-opacity='0.824' stroke='none'/>
+<rect x='136.87' y='387.07' width='9.27' height='9.27' fill='#c74833' fill-opacity='0.867' stroke='none'/>
+<rect x='146.13' y='387.07' width='9.27' height='9.27' fill='#c2362a' fill-opacity='0.901' stroke='none'/>
+<rect x='155.40' y='387.07' width='9.27' height='9.27' fill='#bd2a23' fill-opacity='0.924' stroke='none'/>
+<rect x='164.67' y='387.07' width='9.27' height='9.27' fill='#bb2320' fill-opacity='0.937' stroke='none'/>
+<rect x='173.93' y='387.07' width='9.27' height='9.27' fill='#bb221f' fill-opacity='0.939' stroke='none'/>
+<rect x='183.20' y='387.07' width='9.27' height='9.27' fill='#bc2621' fill-opacity='0.930' stroke='none'/>
+<rect x='192.47' y='387.07' width='9.27' height='9.27' fill='#c03027' fill-opacity='0.911' stroke='none'/>
+<rect x='201.73' y='387.07' width='9.27' height='9.27' fill='#c43f2e' fill-opacity='0.883' stroke='none'/>
+<rect x='211.00' y='387.07' width='9.27' height='9.27' fill='#cb5338' fill-opacity='0.847' stroke='none'/>
+<rect x='220.27' y='387.07' width='9.27' height='9.27' fill='#d26944' fill-opacity='0.804' stroke='none'/>
+<rect x='229.53' y='387.07' width='9.27' height='9.27' fill='#db8352' fill-opacity='0.755' stroke='none'/>
+<rect x='238.80' y='387.07' width='9.27' height='9.27' fill='#e49f60' fill-opacity='0.703' stroke='none'/>
+<rect x='248.07' y='387.07' width='9.27' height='9.27' fill='#edbc6f' fill-opacity='0.649' stroke='none'/>
+<rect x='257.33' y='387.07' width='9.27' height='9.27' fill='#f6d97e' fill-opacity='0.594' stroke='none'/>
+<rect x='266.60' y='387.07' width='9.27' height='9.27' fill='#fef08c' fill-opacity='0.540' stroke='none'/>
+<rect x='275.87' y='387.07' width='9.27' height='9.27' fill='#fef199' fill-opacity='0.488' stroke='none'/>
+<rect x='285.13' y='387.07' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.439' stroke='none'/>
+<rect x='294.40' y='387.07' width='9.27' height='9.27' fill='#fef3b1' fill-opacity='0.394' stroke='none'/>
+<rect x='303.67' y='387.07' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.353' stroke='none'/>
+<rect x='312.93' y='387.07' width='9.27' height='9.27' fill='#fff4c4' fill-opacity='0.317' stroke='none'/>
+<rect x='322.20' y='387.07' width='9.27' height='9.27' fill='#fff5cb' fill-opacity='0.286' stroke='none'/>
+<rect x='331.47' y='387.07' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.259' stroke='none'/>
+<rect x='340.73' y='387.07' width='9.27' height='9.27' fill='#fff6d8' fill-opacity='0.236' stroke='none'/>
+<rect x='72.00' y='377.80' width='9.27' height='9.27' fill='#fff4c0' fill-opacity='0.332' stroke='none'/>
+<rect x='81.27' y='377.80' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.440' stroke='none'/>
+<rect x='90.53' y='377.80' width='9.27' height='9.27' fill='#fef08c' fill-opacity='0.540' stroke='none'/>
+<rect x='99.80' y='377.80' width='9.27' height='9.27' fill='#f1c775' fill-opacity='0.627' stroke='none'/>
+<rect x='109.07' y='377.80' width='9.27' height='9.27' fill='#e4a161' fill-opacity='0.699' stroke='none'/>
+<rect x='118.33' y='377.80' width='9.27' height='9.27' fill='#da8150' fill-opacity='0.759' stroke='none'/>
+<rect x='127.60' y='377.80' width='9.27' height='9.27' fill='#d16643' fill-opacity='0.810' stroke='none'/>
+<rect x='136.87' y='377.80' width='9.27' height='9.27' fill='#ca5037' fill-opacity='0.851' stroke='none'/>
+<rect x='146.13' y='377.80' width='9.27' height='9.27' fill='#c53f2e' fill-opacity='0.883' stroke='none'/>
+<rect x='155.40' y='377.80' width='9.27' height='9.27' fill='#c13428' fill-opacity='0.905' stroke='none'/>
+<rect x='164.67' y='377.80' width='9.27' height='9.27' fill='#bf2e25' fill-opacity='0.916' stroke='none'/>
+<rect x='173.93' y='377.80' width='9.27' height='9.27' fill='#bf2e25' fill-opacity='0.916' stroke='none'/>
+<rect x='183.20' y='377.80' width='9.27' height='9.27' fill='#c03328' fill-opacity='0.907' stroke='none'/>
+<rect x='192.47' y='377.80' width='9.27' height='9.27' fill='#c43d2d' fill-opacity='0.887' stroke='none'/>
+<rect x='201.73' y='377.80' width='9.27' height='9.27' fill='#c94c35' fill-opacity='0.859' stroke='none'/>
+<rect x='211.00' y='377.80' width='9.27' height='9.27' fill='#cf603f' fill-opacity='0.822' stroke='none'/>
+<rect x='220.27' y='377.80' width='9.27' height='9.27' fill='#d6764b' fill-opacity='0.780' stroke='none'/>
+<rect x='229.53' y='377.80' width='9.27' height='9.27' fill='#df9058' fill-opacity='0.732' stroke='none'/>
+<rect x='238.80' y='377.80' width='9.27' height='9.27' fill='#e7ab66' fill-opacity='0.681' stroke='none'/>
+<rect x='248.07' y='377.80' width='9.27' height='9.27' fill='#f1c775' fill-opacity='0.628' stroke='none'/>
+<rect x='257.33' y='377.80' width='9.27' height='9.27' fill='#fae383' fill-opacity='0.575' stroke='none'/>
+<rect x='266.60' y='377.80' width='9.27' height='9.27' fill='#fef091' fill-opacity='0.522' stroke='none'/>
+<rect x='275.87' y='377.80' width='9.27' height='9.27' fill='#fef19d' fill-opacity='0.472' stroke='none'/>
+<rect x='285.13' y='377.80' width='9.27' height='9.27' fill='#fef2a9' fill-opacity='0.425' stroke='none'/>
+<rect x='294.40' y='377.80' width='9.27' height='9.27' fill='#fef3b4' fill-opacity='0.382' stroke='none'/>
+<rect x='303.67' y='377.80' width='9.27' height='9.27' fill='#fff4bd' fill-opacity='0.343' stroke='none'/>
+<rect x='312.93' y='377.80' width='9.27' height='9.27' fill='#fff4c6' fill-opacity='0.308' stroke='none'/>
+<rect x='322.20' y='377.80' width='9.27' height='9.27' fill='#fff5cd' fill-opacity='0.278' stroke='none'/>
+<rect x='331.47' y='377.80' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.253' stroke='none'/>
+<rect x='340.73' y='377.80' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.231' stroke='none'/>
+<rect x='72.00' y='368.53' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.327' stroke='none'/>
+<rect x='81.27' y='368.53' width='9.27' height='9.27' fill='#fef2a7' fill-opacity='0.431' stroke='none'/>
+<rect x='90.53' y='368.53' width='9.27' height='9.27' fill='#fef08f' fill-opacity='0.528' stroke='none'/>
+<rect x='99.80' y='368.53' width='9.27' height='9.27' fill='#f3cf79' fill-opacity='0.612' stroke='none'/>
+<rect x='109.07' y='368.53' width='9.27' height='9.27' fill='#e7aa66' fill-opacity='0.681' stroke='none'/>
+<rect x='118.33' y='368.53' width='9.27' height='9.27' fill='#dd8c56' fill-opacity='0.739' stroke='none'/>
+<rect x='127.60' y='368.53' width='9.27' height='9.27' fill='#d57249' fill-opacity='0.787' stroke='none'/>
+<rect x='136.87' y='368.53' width='9.27' height='9.27' fill='#ce5e3e' fill-opacity='0.826' stroke='none'/>
+<rect x='146.13' y='368.53' width='9.27' height='9.27' fill='#c94e36' fill-opacity='0.855' stroke='none'/>
+<rect x='155.40' y='368.53' width='9.27' height='9.27' fill='#c64431' fill-opacity='0.875' stroke='none'/>
+<rect x='164.67' y='368.53' width='9.27' height='9.27' fill='#c43f2e' fill-opacity='0.884' stroke='none'/>
+<rect x='173.93' y='368.53' width='9.27' height='9.27' fill='#c43f2e' fill-opacity='0.883' stroke='none'/>
+<rect x='183.20' y='368.53' width='9.27' height='9.27' fill='#c64531' fill-opacity='0.873' stroke='none'/>
+<rect x='192.47' y='368.53' width='9.27' height='9.27' fill='#ca4f37' fill-opacity='0.853' stroke='none'/>
+<rect x='201.73' y='368.53' width='9.27' height='9.27' fill='#cf5f3f' fill-opacity='0.824' stroke='none'/>
+<rect x='211.00' y='368.53' width='9.27' height='9.27' fill='#d57148' fill-opacity='0.789' stroke='none'/>
+<rect x='220.27' y='368.53' width='9.27' height='9.27' fill='#dc8854' fill-opacity='0.747' stroke='none'/>
+<rect x='229.53' y='368.53' width='9.27' height='9.27' fill='#e4a061' fill-opacity='0.701' stroke='none'/>
+<rect x='238.80' y='368.53' width='9.27' height='9.27' fill='#ecba6e' fill-opacity='0.652' stroke='none'/>
+<rect x='248.07' y='368.53' width='9.27' height='9.27' fill='#f5d57c' fill-opacity='0.601' stroke='none'/>
+<rect x='257.33' y='368.53' width='9.27' height='9.27' fill='#fef08a' fill-opacity='0.550' stroke='none'/>
+<rect x='266.60' y='368.53' width='9.27' height='9.27' fill='#fef196' fill-opacity='0.500' stroke='none'/>
+<rect x='275.87' y='368.53' width='9.27' height='9.27' fill='#fef2a2' fill-opacity='0.452' stroke='none'/>
+<rect x='285.13' y='368.53' width='9.27' height='9.27' fill='#fef2ad' fill-opacity='0.408' stroke='none'/>
+<rect x='294.40' y='368.53' width='9.27' height='9.27' fill='#fef3b7' fill-opacity='0.367' stroke='none'/>
+<rect x='303.67' y='368.53' width='9.27' height='9.27' fill='#fff4c0' fill-opacity='0.330' stroke='none'/>
+<rect x='312.93' y='368.53' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.298' stroke='none'/>
+<rect x='322.20' y='368.53' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.270' stroke='none'/>
+<rect x='331.47' y='368.53' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.245' stroke='none'/>
+<rect x='72.00' y='359.27' width='9.27' height='9.27' fill='#fff4c3' fill-opacity='0.319' stroke='none'/>
+<rect x='81.27' y='359.27' width='9.27' height='9.27' fill='#fef2aa' fill-opacity='0.419' stroke='none'/>
+<rect x='90.53' y='359.27' width='9.27' height='9.27' fill='#fef193' fill-opacity='0.512' stroke='none'/>
+<rect x='99.80' y='359.27' width='9.27' height='9.27' fill='#f7da7f' fill-opacity='0.592' stroke='none'/>
+<rect x='109.07' y='359.27' width='9.27' height='9.27' fill='#ecb76d' fill-opacity='0.657' stroke='none'/>
+<rect x='118.33' y='359.27' width='9.27' height='9.27' fill='#e29a5e' fill-opacity='0.711' stroke='none'/>
+<rect x='127.60' y='359.27' width='9.27' height='9.27' fill='#da8351' fill-opacity='0.756' stroke='none'/>
+<rect x='136.87' y='359.27' width='9.27' height='9.27' fill='#d47047' fill-opacity='0.792' stroke='none'/>
+<rect x='146.13' y='359.27' width='9.27' height='9.27' fill='#d06140' fill-opacity='0.819' stroke='none'/>
+<rect x='155.40' y='359.27' width='9.27' height='9.27' fill='#cd583b' fill-opacity='0.836' stroke='none'/>
+<rect x='164.67' y='359.27' width='9.27' height='9.27' fill='#cb5439' fill-opacity='0.844' stroke='none'/>
+<rect x='173.93' y='359.27' width='9.27' height='9.27' fill='#cc553a' fill-opacity='0.842' stroke='none'/>
+<rect x='183.20' y='359.27' width='9.27' height='9.27' fill='#ce5b3d' fill-opacity='0.830' stroke='none'/>
+<rect x='192.47' y='359.27' width='9.27' height='9.27' fill='#d16642' fill-opacity='0.810' stroke='none'/>
+<rect x='201.73' y='359.27' width='9.27' height='9.27' fill='#d6754a' fill-opacity='0.782' stroke='none'/>
+<rect x='211.00' y='359.27' width='9.27' height='9.27' fill='#dc8754' fill-opacity='0.748' stroke='none'/>
+<rect x='220.27' y='359.27' width='9.27' height='9.27' fill='#e39c5f' fill-opacity='0.708' stroke='none'/>
+<rect x='229.53' y='359.27' width='9.27' height='9.27' fill='#eab46b' fill-opacity='0.664' stroke='none'/>
+<rect x='238.80' y='359.27' width='9.27' height='9.27' fill='#f2cd78' fill-opacity='0.617' stroke='none'/>
+<rect x='248.07' y='359.27' width='9.27' height='9.27' fill='#fbe685' fill-opacity='0.569' stroke='none'/>
+<rect x='257.33' y='359.27' width='9.27' height='9.27' fill='#fef191' fill-opacity='0.521' stroke='none'/>
+<rect x='266.60' y='359.27' width='9.27' height='9.27' fill='#fef19d' fill-opacity='0.474' stroke='none'/>
+<rect x='275.87' y='359.27' width='9.27' height='9.27' fill='#fef2a8' fill-opacity='0.430' stroke='none'/>
+<rect x='285.13' y='359.27' width='9.27' height='9.27' fill='#fef3b2' fill-opacity='0.388' stroke='none'/>
+<rect x='294.40' y='359.27' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.350' stroke='none'/>
+<rect x='303.67' y='359.27' width='9.27' height='9.27' fill='#fff4c4' fill-opacity='0.316' stroke='none'/>
+<rect x='312.93' y='359.27' width='9.27' height='9.27' fill='#fff5cb' fill-opacity='0.286' stroke='none'/>
+<rect x='322.20' y='359.27' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.260' stroke='none'/>
+<rect x='331.47' y='359.27' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.237' stroke='none'/>
+<rect x='72.00' y='350.00' width='9.27' height='9.27' fill='#fff4c6' fill-opacity='0.310' stroke='none'/>
+<rect x='81.27' y='350.00' width='9.27' height='9.27' fill='#fef3ae' fill-opacity='0.404' stroke='none'/>
+<rect x='90.53' y='350.00' width='9.27' height='9.27' fill='#fef199' fill-opacity='0.491' stroke='none'/>
+<rect x='99.80' y='350.00' width='9.27' height='9.27' fill='#fbe886' fill-opacity='0.566' stroke='none'/>
+<rect x='109.07' y='350.00' width='9.27' height='9.27' fill='#f1c775' fill-opacity='0.627' stroke='none'/>
+<rect x='118.33' y='350.00' width='9.27' height='9.27' fill='#e8ad67' fill-opacity='0.677' stroke='none'/>
+<rect x='127.60' y='350.00' width='9.27' height='9.27' fill='#e1975c' fill-opacity='0.719' stroke='none'/>
+<rect x='136.87' y='350.00' width='9.27' height='9.27' fill='#db8553' fill-opacity='0.751' stroke='none'/>
+<rect x='146.13' y='350.00' width='9.27' height='9.27' fill='#d7794c' fill-opacity='0.775' stroke='none'/>
+<rect x='155.40' y='350.00' width='9.27' height='9.27' fill='#d57148' fill-opacity='0.790' stroke='none'/>
+<rect x='164.67' y='350.00' width='9.27' height='9.27' fill='#d46e46' fill-opacity='0.796' stroke='none'/>
+<rect x='173.93' y='350.00' width='9.27' height='9.27' fill='#d46f47' fill-opacity='0.793' stroke='none'/>
+<rect x='183.20' y='350.00' width='9.27' height='9.27' fill='#d6764b' fill-opacity='0.781' stroke='none'/>
+<rect x='192.47' y='350.00' width='9.27' height='9.27' fill='#da8050' fill-opacity='0.761' stroke='none'/>
+<rect x='201.73' y='350.00' width='9.27' height='9.27' fill='#de8e57' fill-opacity='0.734' stroke='none'/>
+<rect x='211.00' y='350.00' width='9.27' height='9.27' fill='#e4a060' fill-opacity='0.701' stroke='none'/>
+<rect x='220.27' y='350.00' width='9.27' height='9.27' fill='#eab46b' fill-opacity='0.663' stroke='none'/>
+<rect x='229.53' y='350.00' width='9.27' height='9.27' fill='#f2ca76' fill-opacity='0.622' stroke='none'/>
+<rect x='238.80' y='350.00' width='9.27' height='9.27' fill='#f9e182' fill-opacity='0.578' stroke='none'/>
+<rect x='248.07' y='350.00' width='9.27' height='9.27' fill='#fef08e' fill-opacity='0.533' stroke='none'/>
+<rect x='257.33' y='350.00' width='9.27' height='9.27' fill='#fef199' fill-opacity='0.489' stroke='none'/>
+<rect x='266.60' y='350.00' width='9.27' height='9.27' fill='#fef2a4' fill-opacity='0.446' stroke='none'/>
+<rect x='275.87' y='350.00' width='9.27' height='9.27' fill='#fef3ae' fill-opacity='0.405' stroke='none'/>
+<rect x='285.13' y='350.00' width='9.27' height='9.27' fill='#fef3b7' fill-opacity='0.366' stroke='none'/>
+<rect x='294.40' y='350.00' width='9.27' height='9.27' fill='#fff4c0' fill-opacity='0.331' stroke='none'/>
+<rect x='303.67' y='350.00' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.300' stroke='none'/>
+<rect x='312.93' y='350.00' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.273' stroke='none'/>
+<rect x='322.20' y='350.00' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.249' stroke='none'/>
+<rect x='72.00' y='340.73' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.298' stroke='none'/>
+<rect x='81.27' y='340.73' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.386' stroke='none'/>
+<rect x='90.53' y='340.73' width='9.27' height='9.27' fill='#fef19f' fill-opacity='0.467' stroke='none'/>
+<rect x='99.80' y='340.73' width='9.27' height='9.27' fill='#fef08e' fill-opacity='0.536' stroke='none'/>
+<rect x='109.07' y='340.73' width='9.27' height='9.27' fill='#f7da7e' fill-opacity='0.592' stroke='none'/>
+<rect x='118.33' y='340.73' width='9.27' height='9.27' fill='#efc172' fill-opacity='0.638' stroke='none'/>
+<rect x='127.60' y='340.73' width='9.27' height='9.27' fill='#e8ae68' fill-opacity='0.675' stroke='none'/>
+<rect x='136.87' y='340.73' width='9.27' height='9.27' fill='#e39e5f' fill-opacity='0.705' stroke='none'/>
+<rect x='146.13' y='340.73' width='9.27' height='9.27' fill='#e0935a' fill-opacity='0.726' stroke='none'/>
+<rect x='155.40' y='340.73' width='9.27' height='9.27' fill='#de8c56' fill-opacity='0.738' stroke='none'/>
+<rect x='164.67' y='340.73' width='9.27' height='9.27' fill='#dd8a55' fill-opacity='0.742' stroke='none'/>
+<rect x='173.93' y='340.73' width='9.27' height='9.27' fill='#de8c56' fill-opacity='0.738' stroke='none'/>
+<rect x='183.20' y='340.73' width='9.27' height='9.27' fill='#e09359' fill-opacity='0.726' stroke='none'/>
+<rect x='192.47' y='340.73' width='9.27' height='9.27' fill='#e39d5f' fill-opacity='0.707' stroke='none'/>
+<rect x='201.73' y='340.73' width='9.27' height='9.27' fill='#e7aa66' fill-opacity='0.682' stroke='none'/>
+<rect x='211.00' y='340.73' width='9.27' height='9.27' fill='#edbb6e' fill-opacity='0.651' stroke='none'/>
+<rect x='220.27' y='340.73' width='9.27' height='9.27' fill='#f3cd78' fill-opacity='0.615' stroke='none'/>
+<rect x='229.53' y='340.73' width='9.27' height='9.27' fill='#f9e283' fill-opacity='0.577' stroke='none'/>
+<rect x='238.80' y='340.73' width='9.27' height='9.27' fill='#fef08d' fill-opacity='0.536' stroke='none'/>
+<rect x='248.07' y='340.73' width='9.27' height='9.27' fill='#fef198' fill-opacity='0.495' stroke='none'/>
+<rect x='257.33' y='340.73' width='9.27' height='9.27' fill='#fef2a2' fill-opacity='0.455' stroke='none'/>
+<rect x='266.60' y='340.73' width='9.27' height='9.27' fill='#fef2ab' fill-opacity='0.415' stroke='none'/>
+<rect x='275.87' y='340.73' width='9.27' height='9.27' fill='#fef3b5' fill-opacity='0.378' stroke='none'/>
+<rect x='285.13' y='340.73' width='9.27' height='9.27' fill='#fff4bd' fill-opacity='0.344' stroke='none'/>
+<rect x='294.40' y='340.73' width='9.27' height='9.27' fill='#fff4c5' fill-opacity='0.312' stroke='none'/>
+<rect x='303.67' y='340.73' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.284' stroke='none'/>
+<rect x='312.93' y='340.73' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.259' stroke='none'/>
+<rect x='322.20' y='340.73' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.238' stroke='none'/>
+<rect x='72.00' y='331.47' width='9.27' height='9.27' fill='#fff5cb' fill-opacity='0.286' stroke='none'/>
+<rect x='81.27' y='331.47' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.366' stroke='none'/>
+<rect x='90.53' y='331.47' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.440' stroke='none'/>
+<rect x='99.80' y='331.47' width='9.27' height='9.27' fill='#fef196' fill-opacity='0.503' stroke='none'/>
+<rect x='109.07' y='331.47' width='9.27' height='9.27' fill='#fdee89' fill-opacity='0.554' stroke='none'/>
+<rect x='118.33' y='331.47' width='9.27' height='9.27' fill='#f6d87e' fill-opacity='0.595' stroke='none'/>
+<rect x='127.60' y='331.47' width='9.27' height='9.27' fill='#f0c674' fill-opacity='0.628' stroke='none'/>
+<rect x='136.87' y='331.47' width='9.27' height='9.27' fill='#ecb96d' fill-opacity='0.654' stroke='none'/>
+<rect x='146.13' y='331.47' width='9.27' height='9.27' fill='#e9af68' fill-opacity='0.672' stroke='none'/>
+<rect x='155.40' y='331.47' width='9.27' height='9.27' fill='#e7aa66' fill-opacity='0.683' stroke='none'/>
+<rect x='164.67' y='331.47' width='9.27' height='9.27' fill='#e7a865' fill-opacity='0.685' stroke='none'/>
+<rect x='173.93' y='331.47' width='9.27' height='9.27' fill='#e7ab66' fill-opacity='0.681' stroke='none'/>
+<rect x='183.20' y='331.47' width='9.27' height='9.27' fill='#eab169' fill-opacity='0.669' stroke='none'/>
+<rect x='192.47' y='331.47' width='9.27' height='9.27' fill='#edbb6e' fill-opacity='0.651' stroke='none'/>
+<rect x='201.73' y='331.47' width='9.27' height='9.27' fill='#f1c775' fill-opacity='0.627' stroke='none'/>
+<rect x='211.00' y='331.47' width='9.27' height='9.27' fill='#f6d77d' fill-opacity='0.598' stroke='none'/>
+<rect x='220.27' y='331.47' width='9.27' height='9.27' fill='#fbe886' fill-opacity='0.565' stroke='none'/>
+<rect x='229.53' y='331.47' width='9.27' height='9.27' fill='#fef08f' fill-opacity='0.530' stroke='none'/>
+<rect x='238.80' y='331.47' width='9.27' height='9.27' fill='#fef198' fill-opacity='0.494' stroke='none'/>
+<rect x='248.07' y='331.47' width='9.27' height='9.27' fill='#fef2a1' fill-opacity='0.457' stroke='none'/>
+<rect x='257.33' y='331.47' width='9.27' height='9.27' fill='#fef2aa' fill-opacity='0.420' stroke='none'/>
+<rect x='266.60' y='331.47' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.385' stroke='none'/>
+<rect x='275.87' y='331.47' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.351' stroke='none'/>
+<rect x='285.13' y='331.47' width='9.27' height='9.27' fill='#fff4c3' fill-opacity='0.320' stroke='none'/>
+<rect x='294.40' y='331.47' width='9.27' height='9.27' fill='#fff5ca' fill-opacity='0.293' stroke='none'/>
+<rect x='303.67' y='331.47' width='9.27' height='9.27' fill='#fff5d0' fill-opacity='0.268' stroke='none'/>
+<rect x='312.93' y='331.47' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.246' stroke='none'/>
+<rect x='72.00' y='322.20' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.273' stroke='none'/>
+<rect x='81.27' y='322.20' width='9.27' height='9.27' fill='#fff4bd' fill-opacity='0.345' stroke='none'/>
+<rect x='90.53' y='322.20' width='9.27' height='9.27' fill='#fef2ac' fill-opacity='0.411' stroke='none'/>
+<rect x='99.80' y='322.20' width='9.27' height='9.27' fill='#fef19e' fill-opacity='0.468' stroke='none'/>
+<rect x='109.07' y='322.20' width='9.27' height='9.27' fill='#fef193' fill-opacity='0.513' stroke='none'/>
+<rect x='118.33' y='322.20' width='9.27' height='9.27' fill='#fef08a' fill-opacity='0.550' stroke='none'/>
+<rect x='127.60' y='322.20' width='9.27' height='9.27' fill='#f9e082' fill-opacity='0.579' stroke='none'/>
+<rect x='136.87' y='322.20' width='9.27' height='9.27' fill='#f5d57c' fill-opacity='0.602' stroke='none'/>
+<rect x='146.13' y='322.20' width='9.27' height='9.27' fill='#f2cd78' fill-opacity='0.617' stroke='none'/>
+<rect x='155.40' y='322.20' width='9.27' height='9.27' fill='#f1c875' fill-opacity='0.625' stroke='none'/>
+<rect x='164.67' y='322.20' width='9.27' height='9.27' fill='#f1c775' fill-opacity='0.627' stroke='none'/>
+<rect x='173.93' y='322.20' width='9.27' height='9.27' fill='#f2ca76' fill-opacity='0.621' stroke='none'/>
+<rect x='183.20' y='322.20' width='9.27' height='9.27' fill='#f4d079' fill-opacity='0.610' stroke='none'/>
+<rect x='192.47' y='322.20' width='9.27' height='9.27' fill='#f7d97e' fill-opacity='0.593' stroke='none'/>
+<rect x='201.73' y='322.20' width='9.27' height='9.27' fill='#fae584' fill-opacity='0.571' stroke='none'/>
+<rect x='211.00' y='322.20' width='9.27' height='9.27' fill='#fef08b' fill-opacity='0.545' stroke='none'/>
+<rect x='220.27' y='322.20' width='9.27' height='9.27' fill='#fef193' fill-opacity='0.515' stroke='none'/>
+<rect x='229.53' y='322.20' width='9.27' height='9.27' fill='#fef19a' fill-opacity='0.484' stroke='none'/>
+<rect x='238.80' y='322.20' width='9.27' height='9.27' fill='#fef2a3' fill-opacity='0.451' stroke='none'/>
+<rect x='248.07' y='322.20' width='9.27' height='9.27' fill='#fef2ab' fill-opacity='0.418' stroke='none'/>
+<rect x='257.33' y='322.20' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.385' stroke='none'/>
+<rect x='266.60' y='322.20' width='9.27' height='9.27' fill='#fef3ba' fill-opacity='0.354' stroke='none'/>
+<rect x='275.87' y='322.20' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.325' stroke='none'/>
+<rect x='285.13' y='322.20' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.298' stroke='none'/>
+<rect x='294.40' y='322.20' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.273' stroke='none'/>
+<rect x='303.67' y='322.20' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.252' stroke='none'/>
+<rect x='312.93' y='322.20' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.233' stroke='none'/>
+<rect x='72.00' y='312.93' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.259' stroke='none'/>
+<rect x='81.27' y='312.93' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.323' stroke='none'/>
+<rect x='90.53' y='312.93' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.382' stroke='none'/>
+<rect x='99.80' y='312.93' width='9.27' height='9.27' fill='#fef2a7' fill-opacity='0.432' stroke='none'/>
+<rect x='109.07' y='312.93' width='9.27' height='9.27' fill='#fef19d' fill-opacity='0.472' stroke='none'/>
+<rect x='118.33' y='312.93' width='9.27' height='9.27' fill='#fef195' fill-opacity='0.504' stroke='none'/>
+<rect x='127.60' y='312.93' width='9.27' height='9.27' fill='#fef08f' fill-opacity='0.530' stroke='none'/>
+<rect x='136.87' y='312.93' width='9.27' height='9.27' fill='#fef08a' fill-opacity='0.549' stroke='none'/>
+<rect x='146.13' y='312.93' width='9.27' height='9.27' fill='#fcea87' fill-opacity='0.561' stroke='none'/>
+<rect x='155.40' y='312.93' width='9.27' height='9.27' fill='#fbe785' fill-opacity='0.568' stroke='none'/>
+<rect x='164.67' y='312.93' width='9.27' height='9.27' fill='#fbe685' fill-opacity='0.568' stroke='none'/>
+<rect x='173.93' y='312.93' width='9.27' height='9.27' fill='#fce986' fill-opacity='0.563' stroke='none'/>
+<rect x='183.20' y='312.93' width='9.27' height='9.27' fill='#feef89' fill-opacity='0.552' stroke='none'/>
+<rect x='192.47' y='312.93' width='9.27' height='9.27' fill='#fef08d' fill-opacity='0.536' stroke='none'/>
+<rect x='201.73' y='312.93' width='9.27' height='9.27' fill='#fef192' fill-opacity='0.516' stroke='none'/>
+<rect x='211.00' y='312.93' width='9.27' height='9.27' fill='#fef198' fill-opacity='0.493' stroke='none'/>
+<rect x='220.27' y='312.93' width='9.27' height='9.27' fill='#fef19f' fill-opacity='0.466' stroke='none'/>
+<rect x='229.53' y='312.93' width='9.27' height='9.27' fill='#fef2a6' fill-opacity='0.438' stroke='none'/>
+<rect x='238.80' y='312.93' width='9.27' height='9.27' fill='#fef2ad' fill-opacity='0.410' stroke='none'/>
+<rect x='248.07' y='312.93' width='9.27' height='9.27' fill='#fef3b4' fill-opacity='0.381' stroke='none'/>
+<rect x='257.33' y='312.93' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.352' stroke='none'/>
+<rect x='266.60' y='312.93' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.325' stroke='none'/>
+<rect x='275.87' y='312.93' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.300' stroke='none'/>
+<rect x='285.13' y='312.93' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.276' stroke='none'/>
+<rect x='294.40' y='312.93' width='9.27' height='9.27' fill='#fff5d3' fill-opacity='0.255' stroke='none'/>
+<rect x='303.67' y='312.93' width='9.27' height='9.27' fill='#fff5d8' fill-opacity='0.236' stroke='none'/>
+<rect x='72.00' y='303.67' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.246' stroke='none'/>
+<rect x='81.27' y='303.67' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.302' stroke='none'/>
+<rect x='90.53' y='303.67' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.354' stroke='none'/>
+<rect x='99.80' y='303.67' width='9.27' height='9.27' fill='#fef3b0' fill-opacity='0.397' stroke='none'/>
+<rect x='109.07' y='303.67' width='9.27' height='9.27' fill='#fef2a7' fill-opacity='0.432' stroke='none'/>
+<rect x='118.33' y='303.67' width='9.27' height='9.27' fill='#fef2a0' fill-opacity='0.459' stroke='none'/>
+<rect x='127.60' y='303.67' width='9.27' height='9.27' fill='#fef19b' fill-opacity='0.481' stroke='none'/>
+<rect x='136.87' y='303.67' width='9.27' height='9.27' fill='#fef197' fill-opacity='0.497' stroke='none'/>
+<rect x='146.13' y='303.67' width='9.27' height='9.27' fill='#fef195' fill-opacity='0.507' stroke='none'/>
+<rect x='155.40' y='303.67' width='9.27' height='9.27' fill='#fef193' fill-opacity='0.512' stroke='none'/>
+<rect x='164.67' y='303.67' width='9.27' height='9.27' fill='#fef194' fill-opacity='0.512' stroke='none'/>
+<rect x='173.93' y='303.67' width='9.27' height='9.27' fill='#fef195' fill-opacity='0.506' stroke='none'/>
+<rect x='183.20' y='303.67' width='9.27' height='9.27' fill='#fef197' fill-opacity='0.496' stroke='none'/>
+<rect x='192.47' y='303.67' width='9.27' height='9.27' fill='#fef19b' fill-opacity='0.482' stroke='none'/>
+<rect x='201.73' y='303.67' width='9.27' height='9.27' fill='#fef29f' fill-opacity='0.464' stroke='none'/>
+<rect x='211.00' y='303.67' width='9.27' height='9.27' fill='#fef2a5' fill-opacity='0.443' stroke='none'/>
+<rect x='220.27' y='303.67' width='9.27' height='9.27' fill='#fef2aa' fill-opacity='0.420' stroke='none'/>
+<rect x='229.53' y='303.67' width='9.27' height='9.27' fill='#fef3b0' fill-opacity='0.396' stroke='none'/>
+<rect x='238.80' y='303.67' width='9.27' height='9.27' fill='#fef3b6' fill-opacity='0.370' stroke='none'/>
+<rect x='248.07' y='303.67' width='9.27' height='9.27' fill='#fff4bd' fill-opacity='0.345' stroke='none'/>
+<rect x='257.33' y='303.67' width='9.27' height='9.27' fill='#fff4c3' fill-opacity='0.321' stroke='none'/>
+<rect x='266.60' y='303.67' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.298' stroke='none'/>
+<rect x='275.87' y='303.67' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.276' stroke='none'/>
+<rect x='285.13' y='303.67' width='9.27' height='9.27' fill='#fff5d3' fill-opacity='0.256' stroke='none'/>
+<rect x='294.40' y='303.67' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.238' stroke='none'/>
+<rect x='72.00' y='294.40' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.233' stroke='none'/>
+<rect x='81.27' y='294.40' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.281' stroke='none'/>
+<rect x='90.53' y='294.40' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.326' stroke='none'/>
+<rect x='99.80' y='294.40' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.363' stroke='none'/>
+<rect x='109.07' y='294.40' width='9.27' height='9.27' fill='#fef3b1' fill-opacity='0.393' stroke='none'/>
+<rect x='118.33' y='294.40' width='9.27' height='9.27' fill='#fef2ab' fill-opacity='0.416' stroke='none'/>
+<rect x='127.60' y='294.40' width='9.27' height='9.27' fill='#fef2a7' fill-opacity='0.434' stroke='none'/>
+<rect x='136.87' y='294.40' width='9.27' height='9.27' fill='#fef2a3' fill-opacity='0.447' stroke='none'/>
+<rect x='146.13' y='294.40' width='9.27' height='9.27' fill='#fef2a1' fill-opacity='0.455' stroke='none'/>
+<rect x='155.40' y='294.40' width='9.27' height='9.27' fill='#fef2a1' fill-opacity='0.459' stroke='none'/>
+<rect x='164.67' y='294.40' width='9.27' height='9.27' fill='#fef2a1' fill-opacity='0.458' stroke='none'/>
+<rect x='173.93' y='294.40' width='9.27' height='9.27' fill='#fef2a2' fill-opacity='0.453' stroke='none'/>
+<rect x='183.20' y='294.40' width='9.27' height='9.27' fill='#fef2a4' fill-opacity='0.443' stroke='none'/>
+<rect x='192.47' y='294.40' width='9.27' height='9.27' fill='#fef2a8' fill-opacity='0.431' stroke='none'/>
+<rect x='201.73' y='294.40' width='9.27' height='9.27' fill='#fef2ab' fill-opacity='0.415' stroke='none'/>
+<rect x='211.00' y='294.40' width='9.27' height='9.27' fill='#fef3b0' fill-opacity='0.397' stroke='none'/>
+<rect x='220.27' y='294.40' width='9.27' height='9.27' fill='#fef3b5' fill-opacity='0.377' stroke='none'/>
+<rect x='229.53' y='294.40' width='9.27' height='9.27' fill='#fef3ba' fill-opacity='0.356' stroke='none'/>
+<rect x='238.80' y='294.40' width='9.27' height='9.27' fill='#fff4bf' fill-opacity='0.334' stroke='none'/>
+<rect x='248.07' y='294.40' width='9.27' height='9.27' fill='#fff4c5' fill-opacity='0.313' stroke='none'/>
+<rect x='257.33' y='294.40' width='9.27' height='9.27' fill='#fff5ca' fill-opacity='0.292' stroke='none'/>
+<rect x='266.60' y='294.40' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.273' stroke='none'/>
+<rect x='275.87' y='294.40' width='9.27' height='9.27' fill='#fff5d3' fill-opacity='0.254' stroke='none'/>
+<rect x='285.13' y='294.40' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.238' stroke='none'/>
+<rect x='81.27' y='285.13' width='9.27' height='9.27' fill='#fff5d1' fill-opacity='0.262' stroke='none'/>
+<rect x='90.53' y='285.13' width='9.27' height='9.27' fill='#fff4c8' fill-opacity='0.300' stroke='none'/>
+<rect x='99.80' y='285.13' width='9.27' height='9.27' fill='#fff4c0' fill-opacity='0.331' stroke='none'/>
+<rect x='109.07' y='285.13' width='9.27' height='9.27' fill='#fef3ba' fill-opacity='0.356' stroke='none'/>
+<rect x='118.33' y='285.13' width='9.27' height='9.27' fill='#fef3b5' fill-opacity='0.376' stroke='none'/>
+<rect x='127.60' y='285.13' width='9.27' height='9.27' fill='#fef3b1' fill-opacity='0.390' stroke='none'/>
+<rect x='136.87' y='285.13' width='9.27' height='9.27' fill='#fef3af' fill-opacity='0.401' stroke='none'/>
+<rect x='146.13' y='285.13' width='9.27' height='9.27' fill='#fef2ad' fill-opacity='0.407' stroke='none'/>
+<rect x='155.40' y='285.13' width='9.27' height='9.27' fill='#fef2ad' fill-opacity='0.410' stroke='none'/>
+<rect x='164.67' y='285.13' width='9.27' height='9.27' fill='#fef2ad' fill-opacity='0.408' stroke='none'/>
+<rect x='173.93' y='285.13' width='9.27' height='9.27' fill='#fef3ae' fill-opacity='0.403' stroke='none'/>
+<rect x='183.20' y='285.13' width='9.27' height='9.27' fill='#fef3b0' fill-opacity='0.395' stroke='none'/>
+<rect x='192.47' y='285.13' width='9.27' height='9.27' fill='#fef3b3' fill-opacity='0.384' stroke='none'/>
+<rect x='201.73' y='285.13' width='9.27' height='9.27' fill='#fef3b7' fill-opacity='0.370' stroke='none'/>
+<rect x='211.00' y='285.13' width='9.27' height='9.27' fill='#fef3ba' fill-opacity='0.355' stroke='none'/>
+<rect x='220.27' y='285.13' width='9.27' height='9.27' fill='#fff4bf' fill-opacity='0.338' stroke='none'/>
+<rect x='229.53' y='285.13' width='9.27' height='9.27' fill='#fff4c3' fill-opacity='0.320' stroke='none'/>
+<rect x='238.80' y='285.13' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.302' stroke='none'/>
+<rect x='248.07' y='285.13' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.284' stroke='none'/>
+<rect x='257.33' y='285.13' width='9.27' height='9.27' fill='#fff5d0' fill-opacity='0.267' stroke='none'/>
+<rect x='266.60' y='285.13' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.250' stroke='none'/>
+<rect x='275.87' y='285.13' width='9.27' height='9.27' fill='#fff6d8' fill-opacity='0.235' stroke='none'/>
+<rect x='81.27' y='275.87' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.244' stroke='none'/>
+<rect x='90.53' y='275.87' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.275' stroke='none'/>
+<rect x='99.80' y='275.87' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.302' stroke='none'/>
+<rect x='109.07' y='275.87' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.322' stroke='none'/>
+<rect x='118.33' y='275.87' width='9.27' height='9.27' fill='#fff4be' fill-opacity='0.338' stroke='none'/>
+<rect x='127.60' y='275.87' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.351' stroke='none'/>
+<rect x='136.87' y='275.87' width='9.27' height='9.27' fill='#fef3b9' fill-opacity='0.359' stroke='none'/>
+<rect x='146.13' y='275.87' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.364' stroke='none'/>
+<rect x='155.40' y='275.87' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.365' stroke='none'/>
+<rect x='164.67' y='275.87' width='9.27' height='9.27' fill='#fef3b8' fill-opacity='0.364' stroke='none'/>
+<rect x='173.93' y='275.87' width='9.27' height='9.27' fill='#fef3b9' fill-opacity='0.359' stroke='none'/>
+<rect x='183.20' y='275.87' width='9.27' height='9.27' fill='#fef3bb' fill-opacity='0.352' stroke='none'/>
+<rect x='192.47' y='275.87' width='9.27' height='9.27' fill='#fff4bd' fill-opacity='0.342' stroke='none'/>
+<rect x='201.73' y='275.87' width='9.27' height='9.27' fill='#fff4c0' fill-opacity='0.330' stroke='none'/>
+<rect x='211.00' y='275.87' width='9.27' height='9.27' fill='#fff4c4' fill-opacity='0.317' stroke='none'/>
+<rect x='220.27' y='275.87' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.303' stroke='none'/>
+<rect x='229.53' y='275.87' width='9.27' height='9.27' fill='#fff5cb' fill-opacity='0.288' stroke='none'/>
+<rect x='238.80' y='275.87' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.273' stroke='none'/>
+<rect x='248.07' y='275.87' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.258' stroke='none'/>
+<rect x='257.33' y='275.87' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.244' stroke='none'/>
+<rect x='266.60' y='275.87' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.231' stroke='none'/>
+<rect x='90.53' y='266.60' width='9.27' height='9.27' fill='#fff5d3' fill-opacity='0.254' stroke='none'/>
+<rect x='99.80' y='266.60' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.275' stroke='none'/>
+<rect x='109.07' y='266.60' width='9.27' height='9.27' fill='#fff5ca' fill-opacity='0.292' stroke='none'/>
+<rect x='118.33' y='266.60' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.305' stroke='none'/>
+<rect x='127.60' y='266.60' width='9.27' height='9.27' fill='#fff4c4' fill-opacity='0.315' stroke='none'/>
+<rect x='136.87' y='266.60' width='9.27' height='9.27' fill='#fff4c3' fill-opacity='0.321' stroke='none'/>
+<rect x='146.13' y='266.60' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.325' stroke='none'/>
+<rect x='155.40' y='266.60' width='9.27' height='9.27' fill='#fff4c1' fill-opacity='0.326' stroke='none'/>
+<rect x='164.67' y='266.60' width='9.27' height='9.27' fill='#fff4c2' fill-opacity='0.324' stroke='none'/>
+<rect x='173.93' y='266.60' width='9.27' height='9.27' fill='#fff4c3' fill-opacity='0.320' stroke='none'/>
+<rect x='183.20' y='266.60' width='9.27' height='9.27' fill='#fff4c5' fill-opacity='0.313' stroke='none'/>
+<rect x='192.47' y='266.60' width='9.27' height='9.27' fill='#fff4c7' fill-opacity='0.305' stroke='none'/>
+<rect x='201.73' y='266.60' width='9.27' height='9.27' fill='#fff4c9' fill-opacity='0.295' stroke='none'/>
+<rect x='211.00' y='266.60' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.284' stroke='none'/>
+<rect x='220.27' y='266.60' width='9.27' height='9.27' fill='#fff5cf' fill-opacity='0.273' stroke='none'/>
+<rect x='229.53' y='266.60' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.261' stroke='none'/>
+<rect x='238.80' y='266.60' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.248' stroke='none'/>
+<rect x='248.07' y='266.60' width='9.27' height='9.27' fill='#fff5d8' fill-opacity='0.236' stroke='none'/>
+<rect x='90.53' y='257.33' width='9.27' height='9.27' fill='#fff6d8' fill-opacity='0.234' stroke='none'/>
+<rect x='99.80' y='257.33' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.252' stroke='none'/>
+<rect x='109.07' y='257.33' width='9.27' height='9.27' fill='#fff5d0' fill-opacity='0.265' stroke='none'/>
+<rect x='118.33' y='257.33' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.276' stroke='none'/>
+<rect x='127.60' y='257.33' width='9.27' height='9.27' fill='#fff5cc' fill-opacity='0.283' stroke='none'/>
+<rect x='136.87' y='257.33' width='9.27' height='9.27' fill='#fff5cb' fill-opacity='0.288' stroke='none'/>
+<rect x='146.13' y='257.33' width='9.27' height='9.27' fill='#fff5ca' fill-opacity='0.291' stroke='none'/>
+<rect x='155.40' y='257.33' width='9.27' height='9.27' fill='#fff5ca' fill-opacity='0.291' stroke='none'/>
+<rect x='164.67' y='257.33' width='9.27' height='9.27' fill='#fff5ca' fill-opacity='0.290' stroke='none'/>
+<rect x='173.93' y='257.33' width='9.27' height='9.27' fill='#fff5cb' fill-opacity='0.286' stroke='none'/>
+<rect x='183.20' y='257.33' width='9.27' height='9.27' fill='#fff5cd' fill-opacity='0.281' stroke='none'/>
+<rect x='192.47' y='257.33' width='9.27' height='9.27' fill='#fff5ce' fill-opacity='0.274' stroke='none'/>
+<rect x='201.73' y='257.33' width='9.27' height='9.27' fill='#fff5d0' fill-opacity='0.266' stroke='none'/>
+<rect x='211.00' y='257.33' width='9.27' height='9.27' fill='#fff5d3' fill-opacity='0.257' stroke='none'/>
+<rect x='220.27' y='257.33' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.247' stroke='none'/>
+<rect x='229.53' y='257.33' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.237' stroke='none'/>
+<rect x='99.80' y='248.07' width='9.27' height='9.27' fill='#fff6d9' fill-opacity='0.232' stroke='none'/>
+<rect x='109.07' y='248.07' width='9.27' height='9.27' fill='#fff5d6' fill-opacity='0.242' stroke='none'/>
+<rect x='118.33' y='248.07' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.251' stroke='none'/>
+<rect x='127.60' y='248.07' width='9.27' height='9.27' fill='#fff5d3' fill-opacity='0.256' stroke='none'/>
+<rect x='136.87' y='248.07' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.260' stroke='none'/>
+<rect x='146.13' y='248.07' width='9.27' height='9.27' fill='#fff5d1' fill-opacity='0.262' stroke='none'/>
+<rect x='155.40' y='248.07' width='9.27' height='9.27' fill='#fff5d1' fill-opacity='0.262' stroke='none'/>
+<rect x='164.67' y='248.07' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.260' stroke='none'/>
+<rect x='173.93' y='248.07' width='9.27' height='9.27' fill='#fff5d2' fill-opacity='0.257' stroke='none'/>
+<rect x='183.20' y='248.07' width='9.27' height='9.27' fill='#fff5d4' fill-opacity='0.253' stroke='none'/>
+<rect x='192.47' y='248.07' width='9.27' height='9.27' fill='#fff5d5' fill-opacity='0.247' stroke='none'/>
+<rect x='201.73' y='248.07' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.240' stroke='none'/>
+<rect x='211.00' y='248.07' width='9.27' height='9.27' fill='#fff6d8' fill-opacity='0.233' stroke='none'/>
+<rect x='127.60' y='238.80' width='9.27' height='9.27' fill='#fff6d8' fill-opacity='0.234' stroke='none'/>
+<rect x='136.87' y='238.80' width='9.27' height='9.27' fill='#fff5d8' fill-opacity='0.236' stroke='none'/>
+<rect x='146.13' y='238.80' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.238' stroke='none'/>
+<rect x='155.40' y='238.80' width='9.27' height='9.27' fill='#fff5d7' fill-opacity='0.238' stroke='none'/>
+<rect x='164.67' y='238.80' width='9.27' height='9.27' fill='#fff5d8' fill-opacity='0.236' stroke='none'/>
+<rect x='173.93' y='238.80' width='9.27' height='9.27' fill='#fff6d8' fill-opacity='0.233' stroke='none'/>
+<path d='M 350.00,535.33 L 351.85,535.33 L 353.71,535.31 L 355.56,535.28 L 357.41,535.22 L 359.26,535.15 L 361.11,535.06 L 362.96,534.94 L 364.81,534.81 L 366.66,534.67 L 368.51,534.50 L 370.35,534.31 L 372.19,534.11 L 374.03,533.89 L 375.87,533.65 L 377.71,533.39 L 379.54,533.11 L 381.37,532.82 L 383.19,532.50 L 385.02,532.17 L 386.84,531.82 L 388.65,531.45 L 390.47,531.07 L 392.28,530.66 L 394.08,530.24 L 395.88,529.80 L 397.68,529.34 L 399.47,528.87 L 401.25,528.37 L 403.03,527.86 L 404.81,527.33 L 406.58,526.78 L 408.35,526.22 L 410.11,525.63 L 411.86,525.03 L 413.61,524.41 L 415.35,523.78 L 417.08,523.13 L 418.81,522.46 L 420.53,521.77 L 422.24,521.06 L 423.95,520.34 L 425.65,519.60 L 427.34,518.85 L 429.03,518.08 L 430.71,517.29 L 432.37,516.48 L 434.03,515.66 L 435.69,514.82 L 437.33,513.96 L 438.97,513.09 L 440.59,512.20 L 442.21,511.30 L 443.82,510.38 L 445.42,509.44 L 447.01,508.49 L 448.59,507.52 L 450.16,506.53 L 451.72,505.53 L 453.27,504.52 L 454.81,503.49 L 456.34,502.44 L 457.86,501.38 L 459.37,500.30 L 460.86,499.21 L 462.35,498.10 L 463.82,496.98 L 465.29,495.84 L 466.74,494.69 L 468.18,493.53 L 469.61,492.35 L 471.03,491.15 L 472.43,489.95 L 473.83,488.72 L 475.21,487.49 L 476.58,486.24 L 477.93,484.98 L 479.28,483.70 L 480.61,482.41 L 481.93,481.10 L 483.23,479.79 L 484.52,478.46 L 485.80,477.12 L 487.06,475.76 L 488.31,474.39 L 489.55,473.01 L 490.77,471.62 L 491.98,470.22 L 493.18,468.80 L 494.36,467.37 L 495.53,465.93 L 496.68,464.48 L 497.82,463.02 L 498.94,461.54 L 500.05,460.06 L 501.14,458.56 L 502.22,457.05 L 503.28,455.53 L 504.33,454.01 L 505.36,452.47 L 506.38,450.92 L 507.38,449.36 L 508.36,447.79 L 509.33,446.21 L 510.29,444.62 L 511.23,443.02 L 512.15,441.41 L 513.05,439.80 L 513.94,438.17 L 514.82,436.54 L 515.68,434.89 L 516.52,433.24 L 517.34,431.58 L 518.15,429.91 L 518.94,428.24 L 519.71,426.55 L 520.47,424.86 L 521.21,423.16 L 521.93,421.46 L 522.64,419.74 L 523.33,418.02 L 524.00,416.29 L 524.65,414.56 L 525.29,412.82 L 525.91,411.07 L 526.51,409.32 L 527.10,407.56 L 527.66,405.80 L 528.21,404.03 L 528.74,402.25 L 529.26,400.47 L 529.75,398.68 L 530.23,396.89 L 530.69,395.10 L 531.13,393.30 L 531.56,391.49 L 531.96,389.69 L 532.35,387.87 L 532.72,386.06 L 533.07,384.24 L 533.40,382.42 L 533.72,380.59 L 534.02,378.76 L 534.29,376.93 L 534.55,375.09 L 534.80,373.25 L 535.02,371.41 L 535.22,369.57 L 535.41,367.73 L 535.58,365.88 L 535.73,364.04 L 535.86,362.19 L 535.97,360.34 L 536.07,358.49 L 536.14,356.63 L 536.20,354.78 L 536.24,352.93 L 536.26,351.08 L 536.26,349.22 L 536.24,347.37 L 536.21,345.52 L 536.15,343.66 L 536.08,341.81 L 535.99,339.96 L 535.88,338.11 L 535.75,336.26 L 535.60,334.41 L 535.44,332.57 L 535.26,330.72 L 535.05,328.88 L 534.83,327.04 L 534.59,325.20 L 534.34,323.37 L 534.06,321.54 L 533.77,319.71 L 533.46,317.88 L 533.13,316.06 L 532.78,314.23 L 532.41,312.42 L 532.03,310.61 L 531.62,308.80 L 531.20,306.99 L 530.76,305.19 L 530.30,303.39 L 529.83,301.60 L 529.34,299.82 L 528.83,298.04 L 528.30,296.26 L 527.75,294.49 L 527.19,292.72 L 526.61,290.96 L 526.01,289.21 L 525.39,287.46 L 524.76,285.72 L 524.10,283.98 L 523.44,282.26 L 522.75,280.53 L 522.05,278.82 L 521.33,277.11 L 520.59,275.41 L 519.83,273.72 L 519.06,272.03 L 518.27,270.36 L 517.47,268.69 L 516.65,267.03 L 515.81,265.37 L 514.96,263.73 L 514.08,262.09 L 513.20,260.46 L 512.29,258.85 L 511.37,257.24 L 510.44,255.64 L 509.49,254.05 L 508.52,252.47 L 507.54,250.90 L 506.54,249.33 L 505.52,247.78 L 504.49,246.24 L 503.45,244.71 L 502.39,243.19 L 501.31,241.68 L 500.22,240.18 L 499.12,238.70 L 498.00,237.22 L 496.86,235.76 L 495.71,234.30 L 494.55,232.86 L 493.37,231.43 L 492.17,230.01 L 490.97,228.60 L 489.75,227.21 L 488.51,225.83 L 487.26,224.46 L 486.00,223.10 L 484.73,221.76 L 483.44,220.43 L 482.13,219.11 L 480.82,217.80 L 479.49,216.51 L 478.15,215.23 L 476.79,213.96 L 475.43,212.71 L 474.05,211.47 L 472.66,210.25 L 471.25,209.04 L 469.84,207.84 L 468.41,206.66 L 466.97,205.49 L 465.52,204.34 L 464.06,203.20 L 462.58,202.08 L 461.10,200.97 L 459.60,199.88 L 458.10,198.80 L 456.58,197.73 L 455.05,196.68 L 453.51,195.65 L 451.97,194.63 L 450.41,193.63 L 448.84,192.64 L 447.26,191.67 L 445.67,190.72 L 444.07,189.78 L 442.47,188.85 L 440.85,187.94 L 439.23,187.05 L 437.59,186.18 L 435.95,185.32 L 434.30,184.48 L 432.64,183.65 L 430.97,182.84 L 429.30,182.05 L 427.61,181.28 L 425.92,180.52 L 424.22,179.78 L 422.52,179.05 L 420.80,178.35 L 419.08,177.66 L 417.36,176.98 L 415.62,176.33 L 413.88,175.69 L 412.14,175.07 L 410.39,174.46 L 408.63,173.88 L 406.86,173.31 L 405.09,172.76 L 403.32,172.23 L 401.54,171.71 L 399.75,171.21 L 397.96,170.74 L 396.17,170.27 L 394.37,169.83 L 392.56,169.41 L 390.76,169.00 L 388.94,168.61 L 387.13,168.24 L 385.31,167.88 L 383.49,167.55 L 381.66,167.23 L 379.83,166.94 L 378.00,166.66 L 376.16,166.39 L 374.33,166.15 L 372.49,165.93 L 370.64,165.72 L 368.80,165.53 L 366.96,165.36 L 365.11,165.21 L 363.26,165.08 L 361.41,164.96 L 359.56,164.87 L 357.71,164.79 L 355.85,164.73 L 354.00,164.69 L 352.15,164.67 L 350.30,164.67 L 348.44,164.68 L 346.59,164.72 L 344.74,164.77 L 342.88,164.84 L 341.03,164.93 L 339.18,165.04 L 337.33,165.17 L 335.49,165.31 L 333.64,165.48 L 331.80,165.66 L 329.95,165.86 L 328.11,166.08 L 326.28,166.31 L 324.44,166.57 L 322.61,166.84 L 320.78,167.14 L 318.95,167.45 L 317.13,167.78 L 315.30,168.12 L 313.49,168.49 L 311.67,168.87 L 309.87,169.27 L 308.06,169.69 L 306.26,170.13 L 304.46,170.59 L 302.67,171.06 L 300.88,171.55 L 299.10,172.06 L 297.33,172.59 L 295.55,173.13 L 293.79,173.70 L 292.03,174.28 L 290.27,174.87 L 288.53,175.49 L 286.78,176.12 L 285.05,176.77 L 283.32,177.44 L 281.60,178.12 L 279.88,178.83 L 278.17,179.54 L 276.47,180.28 L 274.78,181.03 L 273.09,181.80 L 271.41,182.59 L 269.74,183.39 L 268.08,184.21 L 266.43,185.05 L 264.78,185.90 L 263.15,186.77 L 261.52,187.66 L 259.90,188.56 L 258.29,189.48 L 256.69,190.41 L 255.10,191.36 L 253.52,192.33 L 251.95,193.31 L 250.38,194.31 L 248.83,195.32 L 247.29,196.35 L 245.76,197.40 L 244.24,198.46 L 242.73,199.53 L 241.23,200.62 L 239.74,201.72 L 238.26,202.84 L 236.80,203.98 L 235.34,205.13 L 233.90,206.29 L 232.47,207.47 L 231.05,208.66 L 229.64,209.86 L 228.25,211.08 L 226.86,212.32 L 225.49,213.56 L 224.13,214.83 L 222.79,216.10 L 221.46,217.39 L 220.14,218.69 L 218.83,220.00 L 217.54,221.33 L 216.26,222.67 L 214.99,224.03 L 213.74,225.39 L 212.50,226.77 L 211.27,228.16 L 210.06,229.56 L 208.86,230.98 L 207.68,232.40 L 206.51,233.84 L 205.36,235.29 L 204.22,236.75 L 203.09,238.23 L 201.98,239.71 L 200.89,241.20 L 199.81,242.71 L 198.74,244.23 L 197.69,245.75 L 196.66,247.29 L 195.64,248.84 L 194.63,250.40 L 193.64,251.96 L 192.67,253.54 L 191.72,255.13 L 190.78,256.73 L 189.85,258.33 L 188.94,259.95 L 188.05,261.57 L 187.17,263.21 L 186.31,264.85 L 185.47,266.50 L 184.64,268.16 L 183.83,269.82 L 183.04,271.50 L 182.26,273.18 L 181.50,274.87 L 180.76,276.57 L 180.03,278.28 L 179.33,279.99 L 178.63,281.71 L 177.96,283.43 L 177.30,285.17 L 176.66,286.91 L 176.04,288.65 L 175.44,290.40 L 174.85,292.16 L 174.28,293.92 L 173.73,295.69 L 173.19,297.47 L 172.68,299.25 L 172.18,301.03 L 171.70,302.82 L 171.24,304.62 L 170.79,306.42 L 170.36,308.22 L 169.95,310.03 L 169.56,311.84 L 169.19,313.66 L 168.84,315.47 L 168.50,317.30 L 168.18,319.12 L 167.88,320.95 L 167.60,322.78 L 167.34,324.62 L 167.09,326.46 L 166.87,328.30 L 166.66,330.14 L 166.47,331.98 L 166.30,333.83 L 166.15,335.67 L 166.01,337.52 L 165.90,339.37 L 165.80,341.22 L 165.72,343.07 L 165.66,344.93 L 165.62,346.78 L 165.60,348.63 L 165.59,350.49 L 165.61,352.34 L 165.64,354.19 L 165.69,356.04 L 165.76,357.90 L 165.85,359.75 L 165.96,361.60 L 166.08,363.45 L 166.22,365.29 L 166.39,367.14 L 166.57,368.99 L 166.77,370.83 L 166.98,372.67 L 167.22,374.51 L 167.47,376.34 L 167.75,378.18 L 168.04,380.01 L 168.35,381.83 L 168.67,383.66 L 169.02,385.48 L 169.38,387.30 L 169.77,389.11 L 170.17,390.92 L 170.58,392.72 L 171.02,394.53 L 171.47,396.32 L 171.95,398.11 L 172.44,399.90 L 172.94,401.68' fill='none' stroke='#2563eb' stroke-width='5' stroke-linecap='round' stroke-linejoin='round'/>
+<path d='M 350.00,535.33 L 350.32,535.33 L 351.55,535.32 L 351.87,535.32 L 352.79,535.31 L 354.55,535.26 L 356.89,535.16 L 357.11,535.15 L 359.90,534.91 L 360.81,534.81 L 362.67,534.59 L 363.06,534.54 L 365.13,534.26 L 367.33,533.95 L 368.84,533.72 L 370.49,533.44 L 371.38,533.29 L 373.94,532.82 L 375.70,532.50 L 377.22,532.20 L 378.10,532.03 L 379.58,531.73 L 379.63,531.72 L 383.34,530.90 L 383.91,530.77 L 386.08,530.24 L 388.94,529.51 L 390.19,529.18 L 392.89,528.42 L 394.53,527.95 L 396.63,527.32 L 398.32,526.79 L 400.04,526.24 L 400.36,526.13 L 400.74,526.00 L 402.63,525.31 L 404.98,524.44 L 406.78,523.77 L 407.82,523.36 L 408.51,523.08 L 411.55,521.80 L 413.59,520.94 L 413.59,520.94 L 415.13,520.25 L 416.07,519.82 L 417.52,519.15 L 420.31,517.79 L 421.58,517.16 L 424.77,515.55 L 428.05,513.83 L 429.20,513.21 L 431.04,512.17 L 432.41,511.39 L 435.42,509.62 L 436.78,508.81 L 440.70,506.37 L 442.64,505.13 L 445.65,503.18 L 447.98,501.65 L 451.17,499.51 L 453.63,497.84 L 454.96,496.92 L 455.46,496.56 L 456.51,495.81 L 459.02,494.01 L 460.37,493.01 L 462.58,491.34 L 465.19,489.30 L 467.11,487.77 L 467.59,487.39 L 468.38,486.75 L 469.13,486.10 L 470.54,484.86 L 473.21,482.44 L 474.11,481.60 L 475.12,480.64 L 477.65,478.19 L 479.91,475.93 L 480.89,474.94 L 482.82,472.95 L 483.42,472.32 L 484.47,471.21 L 485.77,469.82 L 487.19,468.25 L 489.12,466.08 L 490.59,464.39 L 491.86,462.93 L 493.32,461.21 L 494.58,459.68 L 495.30,458.79 L 496.61,457.13 L 498.00,455.33 L 499.03,453.96 L 499.82,452.88 L 500.16,452.42 L 501.02,451.22 L 502.37,449.26 L 503.82,447.14 L 505.05,445.29 L 506.46,443.14 L 507.04,442.23 L 508.02,440.62 L 509.35,438.43 L 511.29,435.14 L 512.46,433.13 L 513.98,430.42 L 514.75,429.04 L 514.89,428.77 L 515.94,426.80 L 516.68,425.37 L 517.38,423.97 L 517.68,423.34 L 518.45,421.71 L 519.76,418.83 L 520.67,416.78 L 521.95,413.77 L 522.99,411.27 L 524.17,408.29 L 524.55,407.31 L 524.49,407.46 L 524.76,406.73 L 525.70,404.12 L 526.49,401.82 L 527.09,400.01 L 528.02,397.02 L 528.61,395.09 L 529.03,393.67 L 529.59,391.71 L 529.91,390.59 L 530.46,388.51 L 530.87,386.91 L 531.38,384.95 L 531.63,383.92 L 531.87,382.83 L 532.41,380.26 L 532.70,378.88 L 533.08,377.00 L 533.39,375.31 L 533.68,373.65 L 534.36,369.81 L 534.80,367.11 L 535.09,365.22 L 535.19,364.56 L 535.30,363.75 L 535.58,361.37 L 535.94,358.25 L 536.07,356.93 L 536.22,355.14 L 536.26,354.66 L 536.43,351.99 L 536.50,350.80 L 536.62,348.43 L 536.68,346.65 L 536.69,346.42 L 536.72,344.31 L 536.73,341.07 L 536.73,341.13 L 536.73,338.84 L 536.69,336.40 L 536.67,335.62 L 536.65,334.78 L 536.58,333.02 L 536.50,331.43 L 536.47,331.03 L 536.44,330.52 L 536.45,330.71 L 536.06,326.56 L 535.76,323.68 L 535.43,320.83 L 535.33,320.04 L 534.89,316.68 L 534.80,316.13 L 534.33,313.10 L 534.18,312.23 L 534.12,311.93 L 533.86,310.54 L 533.47,308.63 L 532.99,306.33 L 532.59,304.45 L 532.19,302.68 L 532.07,302.22 L 531.47,299.83 L 530.81,297.42 L 530.44,296.07 L 530.23,295.37 L 529.97,294.53 L 529.21,292.16 L 528.52,290.08 L 527.95,288.40 L 527.68,287.61 L 527.85,288.08 L 526.64,284.87 L 526.51,284.52 L 525.76,282.57 L 525.44,281.77 L 524.69,279.89 L 524.20,278.70 L 522.80,275.45 L 522.31,274.31 L 521.86,273.34 L 521.28,272.13 L 520.55,270.67 L 519.69,269.02 L 519.55,268.74 L 518.73,267.27 L 517.79,265.65 L 516.07,262.82 L 515.97,262.67 L 514.67,260.57 L 514.35,260.07 L 514.09,259.68 L 513.49,258.77 L 512.80,257.76 L 512.34,257.10 L 510.89,255.06 L 509.99,253.83 L 507.78,250.84 L 505.59,247.92 L 503.39,245.06 L 502.18,243.49 L 501.15,242.15 L 500.00,240.69 L 498.53,238.87 L 496.70,236.68 L 495.37,235.14 L 494.23,233.89 L 492.09,231.57 L 491.06,230.51 L 488.46,227.88 L 487.39,226.80 L 486.48,225.89 L 485.76,225.19 L 484.67,224.13 L 483.65,223.18 L 484.31,223.78 L 483.25,222.83 L 481.18,220.98 L 480.02,219.95 L 478.33,218.49 L 477.99,218.21 L 476.61,217.06 L 475.66,216.29 L 473.40,214.47 L 471.49,212.98 L 469.53,211.47 L 468.65,210.81 L 467.99,210.34 L 466.29,209.12 L 464.90,208.17 L 463.13,206.96 L 461.33,205.75 L 459.18,204.35 L 458.85,204.13 L 456.97,202.96 L 455.32,201.95 L 453.25,200.71 L 451.35,199.59 L 450.97,199.37 L 449.37,198.48 L 448.40,197.96 L 448.22,197.86 L 446.88,197.18 L 443.73,195.59 L 442.68,195.08 L 441.52,194.53 L 439.37,193.51 L 437.42,192.62 L 437.02,192.44 L 435.71,191.86 L 433.71,190.98 L 431.07,189.84 L 430.24,189.48 L 429.43,189.13 L 427.50,188.34 L 424.85,187.26 L 422.97,186.51 L 419.58,185.17 L 418.90,184.91 L 417.35,184.32 L 415.49,183.64 L 414.21,183.18 L 413.12,182.80 L 412.37,182.54 L 410.03,181.76 L 409.70,181.66 L 407.68,181.04 L 406.55,180.70 L 404.73,180.18 L 402.32,179.53 L 402.05,179.46 L 401.15,179.24 L 399.62,178.88 L 397.50,178.41 L 395.20,177.92 L 393.86,177.66 L 391.56,177.26 L 391.16,177.19 L 390.46,177.09 L 390.06,177.04 L 389.30,176.94 L 387.05,176.68 L 385.14,176.45 L 381.99,176.10 L 380.64,175.97 L 377.39,175.68 L 376.85,175.63 L 375.45,175.54 L 372.25,175.36 L 372.33,175.36 L 371.68,175.35 L 369.41,175.32 L 367.36,175.34 L 365.52,175.36 L 363.89,175.40 L 362.18,175.45 L 361.15,175.50 L 358.26,175.64 L 356.19,175.79 L 354.80,175.91 L 352.37,176.14 L 351.46,176.23 L 349.30,176.50 L 349.07,176.53 L 347.83,176.72 L 346.82,176.88 L 344.32,177.27 L 340.83,177.84 L 338.49,178.24 L 336.01,178.69 L 335.03,178.87 L 332.76,179.30 L 332.14,179.42 L 329.46,179.95 L 328.43,180.16 L 327.18,180.42 L 325.19,180.85 L 324.02,181.11 L 320.51,181.95 L 318.74,182.39 L 317.78,182.64 L 315.53,183.24 L 312.69,184.03 L 309.50,184.93 L 307.03,185.68 L 307.04,185.67 L 304.73,186.40 L 304.92,186.33 L 304.86,186.35 L 303.35,186.88 L 301.41,187.59 L 299.50,188.32 L 296.16,189.63 L 294.53,190.29 L 293.39,190.76 L 290.02,192.20 L 288.36,192.92 L 286.96,193.56 L 284.87,194.53 L 285.18,194.38 L 282.91,195.48 L 280.55,196.63 L 277.82,198.03 L 276.04,198.96 L 275.40,199.31 L 272.11,201.12 L 270.86,201.81 L 269.66,202.49 L 270.01,202.29 L 268.93,202.94 L 268.10,203.45 L 267.12,204.05 L 266.40,204.50 L 265.37,205.16 L 263.01,206.70 L 263.02,206.69 L 261.17,207.94 L 260.23,208.60 L 259.25,209.30 L 258.10,210.16 L 255.41,212.23 L 253.63,213.63 L 250.96,215.78 L 248.76,217.57 L 247.96,218.25 L 246.26,219.70 L 243.58,222.07 L 242.51,223.02 L 241.63,223.83 L 239.51,225.82 L 237.90,227.37 L 236.42,228.80 L 235.91,229.30 L 234.37,230.84 L 233.10,232.15 L 231.61,233.73 L 230.01,235.46 L 228.31,237.30 L 226.97,238.77 L 224.84,241.15 L 224.37,241.69 L 223.00,243.30 L 221.22,245.44 L 220.22,246.68 L 217.87,249.66 L 217.42,250.23 L 215.60,252.61 L 215.17,253.19 L 214.21,254.49 L 213.05,256.11 L 211.92,257.70 L 210.29,260.05 L 209.26,261.55 L 207.55,264.09 L 205.97,266.45 L 204.86,268.15 L 203.93,269.61 L 202.54,271.82 L 201.41,273.63 L 200.92,274.45 L 199.97,276.05 L 199.70,276.52 L 197.95,279.66 L 197.42,280.63 L 196.41,282.46 L 195.56,284.03 L 194.86,285.32 L 193.79,287.32 L 192.86,289.09 L 192.14,290.52 L 191.13,292.56 L 190.24,294.42 L 189.82,295.31 L 188.41,298.46 L 187.39,300.81 L 186.01,304.07 L 185.34,305.74 L 184.83,307.06 L 184.14,308.90 L 183.00,312.00 L 182.43,313.65 L 181.74,315.70 L 181.01,317.94 L 180.24,320.40 L 179.86,321.66 L 179.23,323.75 L 178.78,325.31 L 177.76,329.06 L 177.01,331.96 L 176.52,333.95 L 175.92,336.43 L 175.65,337.59 L 175.40,338.74 L 174.84,341.45 L 174.24,344.57 L 173.62,347.84 L 173.14,350.56 L 172.78,352.76 L 172.25,356.16 L 172.00,357.91 L 171.96,358.21 L 171.76,359.83 L 171.50,361.95 L 171.41,362.69 L 171.08,366.00 L 170.84,368.50 L 170.64,370.92 L 170.43,373.76 L 170.31,375.77 L 170.21,377.39 L 170.10,379.41 L 170.00,381.48 L 169.95,383.00 L 169.84,386.00 L 169.80,387.45 L 169.78,388.36 L 169.74,390.72 L 169.73,392.48 L 169.73,394.76 L 169.76,396.22 L 169.82,398.64 L 169.85,399.60 L 169.96,402.05 L 170.08,404.00 L 170.16,405.31 L 170.22,406.01 L 170.38,407.91 L 170.59,410.04 L 170.83,412.21 L 171.27,416.00 L 171.54,418.27 L 172.02,421.76 L 172.26,423.31 L 172.43,424.31 L 172.79,426.21 L 173.23,428.35 L 173.35,428.96 L 173.88,431.39 L 174.34,433.45 L 174.63,434.69 L 175.20,437.16 L 175.55,438.62' fill='none' stroke='#d97706' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/>
+<path d='M 350.00,535.33 L 349.80,535.33 L 350.02,535.33 L 349.74,535.33 L 350.81,535.33 L 351.14,535.33 L 352.07,535.32 L 353.79,535.31 L 363.53,535.30 L 364.40,535.28 L 364.43,535.26 L 364.50,535.22 L 365.21,535.18 L 366.12,535.14 L 376.27,535.09 L 376.26,535.02 L 378.17,534.96 L 378.50,534.88 L 379.34,534.80 L 378.94,534.69 L 389.28,534.60 L 389.93,534.50 L 390.90,534.40 L 390.84,534.27 L 392.31,534.17 L 393.89,534.08 L 402.83,533.92 L 402.70,533.76 L 402.09,533.56 L 402.96,533.43 L 412.10,533.25 L 412.10,533.08 L 411.60,523.73 L 412.73,524.11 L 413.12,524.20 L 414.09,524.41 L 415.03,524.58 L 424.68,524.63 L 424.92,524.62 L 425.48,524.67 L 425.62,524.60 L 427.18,524.82 L 428.38,524.95 L 437.34,524.79 L 437.49,524.73 L 437.26,524.56 L 437.06,524.38 L 439.41,516.91 L 448.29,516.91 L 448.23,517.06 L 448.32,517.25 L 449.56,517.99 L 450.32,518.41 L 456.71,518.95 L 455.21,518.29 L 454.60,508.02 L 453.86,507.63 L 461.77,509.82 L 459.54,509.09 L 459.18,509.04 L 466.59,499.49 L 464.96,499.23 L 463.59,498.71 L 463.81,498.28 L 463.22,498.56 L 463.13,499.95 L 471.80,500.50 L 470.24,492.64 L 469.81,493.52 L 468.82,493.81 L 468.64,492.60 L 470.31,493.00 L 470.63,493.47 L 480.37,493.17 L 480.15,493.12 L 480.25,484.06 L 481.07,484.21 L 481.50,484.94 L 490.53,484.71 L 490.76,484.00 L 490.93,484.41 L 490.98,476.24 L 492.04,476.97 L 493.39,477.45 L 493.45,477.29 L 502.83,478.33 L 503.24,477.25 L 503.74,469.22 L 503.83,469.55 L 504.33,468.80 L 505.36,467.79 L 505.97,467.96 L 506.83,466.26 L 515.91,457.06 L 516.23,456.30 L 516.83,457.58 L 517.24,457.79 L 517.58,457.98 L 517.84,456.63 L 518.41,448.63 L 518.80,449.12 L 519.68,448.81 L 528.87,449.01 L 529.02,448.03 L 529.08,440.10 L 528.95,441.89 L 529.06,442.41 L 529.26,442.68 L 529.52,441.31 L 529.62,433.92 L 529.82,432.30 L 529.99,432.22 L 538.85,432.03 L 538.48,432.23 L 538.15,430.79 L 537.90,422.82 L 537.54,422.83 L 537.41,422.35 L 537.27,415.05 L 537.11,422.72 L 536.97,414.27 L 536.78,415.02 L 536.70,415.46 L 536.60,415.44 L 545.37,407.23 L 544.62,407.19 L 543.70,407.29 L 542.98,405.72 L 542.40,404.71 L 541.99,395.71 L 541.59,396.01 L 541.27,395.53 L 540.68,395.25 L 540.51,394.28 L 540.13,392.95 L 540.04,383.43 L 540.00,384.01 L 539.60,385.27 L 539.39,385.41 L 539.11,377.97 L 538.81,378.36 L 538.71,377.59 L 538.52,378.15 L 538.24,377.07 L 537.96,375.59 L 537.74,368.51 L 537.49,368.08 L 537.21,367.07 L 537.04,366.31 L 536.81,364.92 L 536.71,356.43 L 536.59,357.42 L 536.41,357.28 L 536.34,358.49 L 536.20,356.66 L 536.11,349.11 L 536.02,349.97 L 535.93,350.26 L 535.85,350.21 L 535.78,350.17 L 535.73,350.15 L 535.67,341.95 L 535.64,342.69 L 535.61,343.34 L 535.59,343.83 L 535.57,344.21 L 535.55,344.66 L 535.54,336.39 L 535.51,337.92 L 535.50,338.75 L 535.49,339.33 L 535.49,339.39 L 535.48,331.60 L 535.47,332.49 L 535.47,332.75 L 535.47,333.28 L 535.47,333.21 L 535.46,333.68 L 535.46,325.49 L 535.45,326.38 L 535.44,327.74 L 535.44,328.58 L 535.43,329.14 L 535.43,319.05 L 531.86,318.44 L 528.35,318.03 L 526.79,316.71 L 518.09,317.01 L 517.31,316.96 L 516.87,317.05 L 516.19,317.16 L 516.07,307.03 L 515.01,307.11 L 514.39,307.04 L 513.45,305.59 L 513.76,305.21 L 514.19,304.69 L 513.63,295.13 L 513.90,296.35 L 511.77,296.07 L 510.92,294.79 L 511.93,293.58 L 509.49,292.36 L 509.94,291.41 L 503.65,282.95 L 503.49,282.13 L 505.27,282.82 L 505.88,280.77 L 506.02,279.71 L 504.74,278.56 L 505.34,277.75 L 504.23,266.47 L 504.53,266.73 L 505.48,265.87 L 505.36,264.24 L 496.10,262.56 L 495.96,263.05 L 495.59,255.48 L 495.44,255.11 L 495.72,255.33 L 488.05,256.44 L 488.04,256.82 L 487.95,248.00 L 489.22,246.86 L 489.69,246.91 L 491.08,246.55 L 482.56,245.65 L 483.34,238.92 L 484.01,239.27 L 483.84,239.14 L 484.18,237.92 L 482.77,239.09 L 483.06,236.92 L 483.02,235.93 L 483.52,234.24 L 482.88,233.55 L 474.18,224.72 L 474.24,225.69 L 473.57,225.18 L 474.39,224.86 L 474.34,224.75 L 474.48,223.36 L 465.73,223.36 L 466.10,223.27 L 464.65,215.29 L 465.48,216.25 L 465.85,215.38 L 466.45,216.20 L 466.83,215.62 L 457.66,214.15 L 457.85,214.23 L 457.08,212.45 L 456.25,210.75 L 455.70,209.72 L 447.41,201.59 L 448.28,202.01 L 448.73,201.53 L 448.61,202.52 L 446.93,202.52 L 447.22,202.60 L 446.12,202.76 L 446.00,203.05 L 437.82,202.49 L 438.65,201.93 L 437.46,199.77 L 438.69,198.65 L 439.32,188.62 L 441.01,187.58 L 431.46,188.13 L 430.96,187.86 L 431.08,186.44 L 430.38,187.19 L 428.60,186.82 L 419.63,186.91 L 419.72,185.65 L 420.00,185.34 L 419.46,184.09 L 419.59,183.07 L 411.09,182.90 L 410.64,174.32 L 411.17,175.93 L 411.06,176.35 L 411.78,177.02 L 410.62,176.80 L 410.13,177.51 L 400.11,177.67 L 401.11,177.31 L 402.06,177.02 L 401.30,176.36 L 399.97,175.37 L 398.29,174.68 L 390.65,174.75 L 391.35,174.72 L 391.63,173.82 L 392.89,173.01 L 391.58,173.76 L 391.78,172.68 L 381.25,171.49 L 380.00,171.94 L 380.24,171.39 L 380.83,170.67 L 379.68,169.97 L 378.48,169.85 L 369.90,169.63 L 370.55,168.32 L 369.22,167.90 L 369.71,167.64 L 368.65,167.63 L 368.41,166.90 L 358.79,166.47 L 358.91,166.37 L 358.08,167.50 L 357.93,167.41 L 358.74,168.42 L 349.59,169.09 L 350.53,169.20 L 351.41,168.68 L 350.43,168.56 L 348.95,168.40 L 339.85,168.07 L 339.31,168.99 L 339.39,168.58 L 339.29,167.27 L 337.89,167.53 L 336.22,167.41 L 327.11,167.55 L 327.35,168.56 L 327.10,167.97 L 327.74,167.97 L 318.96,169.51 L 318.49,170.39 L 318.33,171.17 L 316.83,171.31 L 316.77,171.20 L 315.47,171.08 L 305.76,171.98 L 305.31,172.06 L 304.46,173.13 L 303.00,172.70 L 303.26,173.71 L 293.30,182.68 L 293.48,183.05 L 293.49,183.67 L 284.81,184.14 L 284.82,184.05 L 284.88,184.28 L 284.37,183.93 L 283.69,183.55 L 283.94,184.01 L 282.83,183.21 L 282.77,183.54 L 273.81,183.21 L 274.08,183.00 L 274.62,183.36 L 273.31,190.23 L 264.40,189.65 L 265.57,188.64 L 266.20,187.45 L 267.70,186.61 L 268.42,186.27 L 268.48,185.64 L 260.42,184.29 L 261.95,183.62 L 262.82,183.17 L 262.33,190.17 L 262.51,189.10 L 254.59,187.90 L 255.11,186.40 L 256.14,184.53 L 257.29,184.66 L 258.34,184.15 L 258.83,183.99 L 259.78,184.27 L 260.85,184.25 L 261.12,183.90 L 260.74,182.53 L 251.32,181.69 L 252.63,181.68 L 253.73,190.91 L 253.76,189.56 L 254.32,191.36 L 245.73,190.98 L 246.23,191.28 L 244.78,191.33 L 245.03,199.24 L 244.49,199.07 L 244.01,200.09 L 234.16,199.37 L 233.87,199.12 L 231.86,199.60 L 231.80,208.63 L 230.62,209.94 L 230.73,209.84 L 230.43,210.40 L 220.45,212.41 L 220.14,214.09 L 219.24,216.55 L 220.06,224.46 L 220.10,224.38 L 219.76,225.43 L 211.58,224.20 L 211.83,223.92 L 211.09,224.79 L 210.01,233.97 L 209.19,232.50 L 209.73,232.73 L 208.57,233.34 L 208.62,232.17 L 200.69,240.71 L 201.03,240.94 L 200.23,240.85 L 200.59,242.24 L 200.72,243.03 L 199.90,252.43 L 199.26,251.40 L 190.59,251.29 L 190.87,251.46 L 191.16,252.20 L 191.42,259.86 L 191.99,260.30 L 191.37,260.55 L 190.51,261.11 L 190.52,261.92 L 190.20,261.61 L 189.33,270.65 L 180.27,270.49 L 180.29,269.37 L 181.69,267.87 L 180.66,268.28 L 181.81,269.69 L 181.40,278.14 L 181.21,277.20 L 180.52,276.39 L 179.42,276.78 L 178.53,286.35 L 171.19,285.92 L 172.49,284.88 L 173.77,284.45 L 174.01,293.45 L 175.11,293.55 L 174.96,294.18 L 174.57,293.51 L 174.49,293.53 L 173.42,301.62 L 174.72,301.26 L 174.78,301.10 L 173.99,302.70 L 174.85,312.00 L 174.86,311.16 L 165.95,309.50 L 166.23,308.36 L 166.50,307.40 L 166.76,315.64 L 166.65,315.79 L 166.68,315.57 L 167.37,322.69 L 167.35,322.64 L 167.22,322.89 L 167.84,330.26 L 167.91,330.01 L 167.94,330.02 L 167.98,330.04 L 168.04,330.06 L 168.10,330.08 L 168.18,339.37 L 168.26,339.40 L 168.36,339.43 L 168.47,339.46 L 168.59,348.75 L 168.73,348.79 L 168.87,348.82 L 169.02,348.85 L 169.19,358.16 L 169.36,358.19 L 169.54,358.23 L 169.73,358.26 L 169.93,358.30 L 170.13,367.60 L 170.34,367.64 L 170.56,367.67 L 170.79,367.71 L 171.02,367.74 L 171.26,377.04 L 171.50,377.08 L 171.75,377.11 L 172.00,377.14 L 172.26,377.18 L 172.52,377.21 L 172.79,386.51 L 173.06,386.54 L 173.33,386.57 L 173.61,395.87 L 173.89,395.90 L 174.17,395.93 L 174.46,395.96 L 174.75,395.99 L 175.04,396.01 L 175.33,405.31 L 175.63,405.33 L 184.90,405.33 L 185.00,405.34' fill='none' stroke='#16a34a' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/>
+<circle cx='535.33' cy='535.33' r='6.5' fill='#111827' stroke='white' stroke-width='2'/>
+<circle cx='535.33' cy='350.00' r='6.5' fill='#111827' stroke='white' stroke-width='2'/>
+<circle cx='350.00' cy='257.33' r='6.5' fill='#111827' stroke='white' stroke-width='2'/>
+<circle cx='257.33' cy='164.67' r='6.5' fill='#111827' stroke='white' stroke-width='2'/>
+<circle cx='350.00' cy='535.33' r='7' fill='#1d4ed8' stroke='white' stroke-width='2.5'/>
+<circle cx='172.94' cy='401.68' r='7' fill='#7c3aed' stroke='white' stroke-width='2.5'/>
+<circle cx='185.00' cy='405.34' r='6' fill='#16a34a' stroke='white' stroke-width='2'/>
+<rect x='664.0' y='96.0' width='182' height='132' rx='18' fill='white' stroke='#d6d3d1'/>
+<line x1='676.0' y1='124.0' x2='702.0' y2='124.0' stroke='#2563eb' stroke-width='5' stroke-linecap='round'/>
+<text x='714.0' y='129.0' font-size='16' font-family='sans-serif' fill='#111827'>True Path</text>
+<line x1='676.0' y1='150.0' x2='702.0' y2='150.0' stroke='#d97706' stroke-width='5' stroke-linecap='round'/>
+<text x='714.0' y='155.0' font-size='16' font-family='sans-serif' fill='#111827'>Dead Reckoning</text>
+<line x1='676.0' y1='176.0' x2='702.0' y2='176.0' stroke='#16a34a' stroke-width='5' stroke-linecap='round'/>
+<text x='714.0' y='181.0' font-size='16' font-family='sans-serif' fill='#111827'>Histogram Estimate</text>
+<circle cx='688.0' cy='202.0' r='5.5' fill='#111827' stroke='white' stroke-width='1.5'/>
+<text x='714.0' y='207.0' font-size='16' font-family='sans-serif' fill='#111827'>RFID Landmark</text>
+<text x='682.0' y='250.0' font-size='16' font-family='sans-serif' font-weight='700' fill='#111827'>Probability</text>
+<rect x='682.0' y='496.50' width='26.0' height='8.30' fill='#fff7ed'/>
+<rect x='682.0' y='488.76' width='26.0' height='8.30' fill='#fff4c9'/>
+<rect x='682.0' y='481.02' width='26.0' height='8.30' fill='#fef3bb'/>
+<rect x='682.0' y='473.27' width='26.0' height='8.30' fill='#fef3af'/>
+<rect x='682.0' y='465.53' width='26.0' height='8.30' fill='#fef2a6'/>
+<rect x='682.0' y='457.79' width='26.0' height='8.30' fill='#fef19d'/>
+<rect x='682.0' y='450.05' width='26.0' height='8.30' fill='#fef196'/>
+<rect x='682.0' y='442.31' width='26.0' height='8.30' fill='#fef08f'/>
+<rect x='682.0' y='434.56' width='26.0' height='8.30' fill='#fded88'/>
+<rect x='682.0' y='426.82' width='26.0' height='8.30' fill='#f9e081'/>
+<rect x='682.0' y='419.08' width='26.0' height='8.30' fill='#f5d37b'/>
+<rect x='682.0' y='411.34' width='26.0' height='8.30' fill='#f1c775'/>
+<rect x='682.0' y='403.60' width='26.0' height='8.30' fill='#edbc6f'/>
+<rect x='682.0' y='395.85' width='26.0' height='8.30' fill='#eab16a'/>
+<rect x='682.0' y='388.11' width='26.0' height='8.30' fill='#e6a764'/>
+<rect x='682.0' y='380.37' width='26.0' height='8.30' fill='#e39d5f'/>
+<rect x='682.0' y='372.63' width='26.0' height='8.30' fill='#e0935a'/>
+<rect x='682.0' y='364.89' width='26.0' height='8.30' fill='#dd8a55'/>
+<rect x='682.0' y='357.15' width='26.0' height='8.30' fill='#da8150'/>
+<rect x='682.0' y='349.40' width='26.0' height='8.30' fill='#d7784c'/>
+<rect x='682.0' y='341.66' width='26.0' height='8.30' fill='#d46f47'/>
+<rect x='682.0' y='333.92' width='26.0' height='8.30' fill='#d16743'/>
+<rect x='682.0' y='326.18' width='26.0' height='8.30' fill='#cf5f3f'/>
+<rect x='682.0' y='318.44' width='26.0' height='8.30' fill='#cc573b'/>
+<rect x='682.0' y='310.69' width='26.0' height='8.30' fill='#ca4f36'/>
+<rect x='682.0' y='302.95' width='26.0' height='8.30' fill='#c74732'/>
+<rect x='682.0' y='295.21' width='26.0' height='8.30' fill='#c5402f'/>
+<rect x='682.0' y='287.47' width='26.0' height='8.30' fill='#c2382b'/>
+<rect x='682.0' y='279.73' width='26.0' height='8.30' fill='#c03127'/>
+<rect x='682.0' y='271.98' width='26.0' height='8.30' fill='#be2a23'/>
+<rect x='682.0' y='264.24' width='26.0' height='8.30' fill='#bb2320'/>
+<rect x='682.0' y='256.50' width='26.0' height='8.30' fill='#b91c1c'/>
+<rect x='682.0' y='264.0' width='26.0' height='240.0' fill='none' stroke='#9ca3af'/>
+<text x='722.0' y='276.0' font-size='13' font-family='monospace' fill='#374151'>max 0.0048</text>
+<text x='722.0' y='502.0' font-size='13' font-family='monospace' fill='#374151'>min 0.0000</text>
+<text x='350.0' y='680.0' text-anchor='middle' font-size='16' font-family='sans-serif' fill='#111827'>x [m]</text>
+<text x='22.0' y='350.0' text-anchor='middle' font-size='16' font-family='sans-serif' fill='#111827' transform='rotate(-90, 22.0, 350.0)'>y [m]</text>
 </svg>
-

--- a/src/localization/histogram_filter.rs
+++ b/src/localization/histogram_filter.rs
@@ -8,6 +8,8 @@
 use gnuplot::{AxesCommon, Caption, Color, Figure};
 use nalgebra::{DMatrix, Vector2, Vector4};
 use rand_distr::{Distribution, Normal};
+use std::fs::File;
+use std::io::Write;
 
 // Simulation parameters
 const DT: f64 = 0.1; // time step [s]
@@ -355,6 +357,316 @@ fn get_observations(
     z
 }
 
+fn lerp_rgb(start: (u8, u8, u8), end: (u8, u8, u8), t: f64) -> (u8, u8, u8) {
+    let t = t.clamp(0.0, 1.0);
+    let blend = |a: u8, b: u8| -> u8 { (a as f64 + (b as f64 - a as f64) * t).round() as u8 };
+    (
+        blend(start.0, end.0),
+        blend(start.1, end.1),
+        blend(start.2, end.2),
+    )
+}
+
+fn heatmap_style(probability: f64, max_probability: f64) -> (String, f64) {
+    if max_probability <= 0.0 || probability <= 0.0 {
+        return ("#fff7ed".to_string(), 0.0);
+    }
+
+    let t = (probability / max_probability).sqrt().clamp(0.0, 1.0);
+    let rgb = if t < 0.5 {
+        lerp_rgb((255, 247, 237), (254, 240, 138), t * 2.0)
+    } else {
+        lerp_rgb((254, 240, 138), (185, 28, 28), (t - 0.5) * 2.0)
+    };
+
+    (
+        format!("#{:02x}{:02x}{:02x}", rgb.0, rgb.1, rgb.2),
+        0.15 + 0.8 * t,
+    )
+}
+
+fn path_data(
+    points: &[(f64, f64)],
+    to_svg_x: &impl Fn(f64) -> f64,
+    to_svg_y: &impl Fn(f64) -> f64,
+) -> String {
+    let mut path = String::new();
+
+    for (i, (x, y)) in points.iter().enumerate() {
+        let sx = to_svg_x(*x);
+        let sy = to_svg_y(*y);
+        if i == 0 {
+            path.push_str(&format!("M {:.2},{:.2}", sx, sy));
+        } else {
+            path.push_str(&format!(" L {:.2},{:.2}", sx, sy));
+        }
+    }
+
+    path
+}
+
+fn build_histogram_filter_svg(
+    area: (f64, f64, f64, f64),
+    rfid: &[(f64, f64)],
+    history_true: &[(f64, f64)],
+    history_dr: &[(f64, f64)],
+    history_est: &[(f64, f64)],
+    x_width: usize,
+    y_width: usize,
+    min_x: f64,
+    min_y: f64,
+    resolution: f64,
+    heatmap_data: &[f64],
+) -> String {
+    let width = 920.0;
+    let height = 700.0;
+    let margin = 72.0;
+    let side_panel_width = 220.0;
+    let available_plot_width = width - 2.0 * margin - side_panel_width;
+    let available_plot_height = height - 2.0 * margin;
+    let x_range = area.2 - area.0;
+    let y_range = area.3 - area.1;
+    let scale = (available_plot_width / x_range)
+        .min(available_plot_height / y_range)
+        .max(1.0);
+    let plot_width = x_range * scale;
+    let plot_height = y_range * scale;
+    let plot_left = margin;
+    let plot_top = margin + (available_plot_height - plot_height) / 2.0;
+
+    let to_svg_x = |x: f64| plot_left + (x - area.0) * scale;
+    let to_svg_y = |y: f64| plot_top + plot_height - (y - area.1) * scale;
+
+    let max_probability = heatmap_data.iter().copied().fold(0.0, f64::max);
+    let legend_x = plot_left + plot_width + 36.0;
+    let legend_y = plot_top + 24.0;
+    let colorbar_x = legend_x + 18.0;
+    let colorbar_y = legend_y + 168.0;
+    let colorbar_height = 240.0;
+    let colorbar_width = 26.0;
+
+    let mut svg = String::new();
+    svg.push_str(&format!(
+        "<?xml version='1.0' encoding='UTF-8'?>\n<svg xmlns='http://www.w3.org/2000/svg' width='{width}' height='{height}' viewBox='0 0 {width} {height}'>\n"
+    ));
+    svg.push_str("<rect width='100%' height='100%' fill='white'/>\n");
+    svg.push_str(&format!(
+        "<text x='{:.1}' y='38' text-anchor='middle' font-size='24' font-family='sans-serif' font-weight='700' fill='#111827'>Histogram Filter Localization</text>\n",
+        width / 2.0
+    ));
+    svg.push_str(&format!(
+        "<rect x='{plot_left:.1}' y='{plot_top:.1}' width='{plot_width:.1}' height='{plot_height:.1}' fill='#fffdf7' stroke='#d6d3d1' stroke-width='2'/>\n"
+    ));
+
+    let x_tick_start = (area.0 / 5.0).ceil() as i32;
+    let x_tick_end = (area.2 / 5.0).floor() as i32;
+    for tick in x_tick_start..=x_tick_end {
+        let x = tick as f64 * 5.0;
+        let sx = to_svg_x(x);
+        svg.push_str(&format!(
+            "<line x1='{sx:.2}' y1='{plot_top:.2}' x2='{sx:.2}' y2='{:.2}' stroke='#ece7dc' stroke-width='1'/>\n",
+            plot_top + plot_height
+        ));
+        svg.push_str(&format!(
+            "<text x='{sx:.2}' y='{:.2}' text-anchor='middle' font-size='14' font-family='sans-serif' fill='#374151'>{x:.0}</text>\n",
+            plot_top + plot_height + 24.0
+        ));
+    }
+
+    let y_tick_start = (area.1 / 5.0).ceil() as i32;
+    let y_tick_end = (area.3 / 5.0).floor() as i32;
+    for tick in y_tick_start..=y_tick_end {
+        let y = tick as f64 * 5.0;
+        let sy = to_svg_y(y);
+        svg.push_str(&format!(
+            "<line x1='{plot_left:.2}' y1='{sy:.2}' x2='{:.2}' y2='{sy:.2}' stroke='#ece7dc' stroke-width='1'/>\n",
+            plot_left + plot_width
+        ));
+        svg.push_str(&format!(
+            "<text x='{:.2}' y='{:.2}' text-anchor='end' font-size='14' font-family='sans-serif' fill='#374151'>{y:.0}</text>\n",
+            plot_left - 10.0,
+            sy + 5.0
+        ));
+    }
+
+    let cell_width = resolution * scale;
+    let cell_height = resolution * scale;
+    for iy in 0..y_width {
+        for ix in 0..x_width {
+            let probability = heatmap_data[iy * x_width + ix];
+            if probability <= max_probability * 0.01 {
+                continue;
+            }
+
+            let cell_x = min_x + ix as f64 * resolution;
+            let cell_y = min_y + iy as f64 * resolution;
+            let sx = to_svg_x(cell_x);
+            let sy = to_svg_y(cell_y + resolution);
+            let (fill, opacity) = heatmap_style(probability, max_probability);
+            svg.push_str(&format!(
+                "<rect x='{sx:.2}' y='{sy:.2}' width='{cell_width:.2}' height='{cell_height:.2}' fill='{fill}' fill-opacity='{opacity:.3}' stroke='none'/>\n"
+            ));
+        }
+    }
+
+    let true_path = path_data(history_true, &to_svg_x, &to_svg_y);
+    let dr_path = path_data(history_dr, &to_svg_x, &to_svg_y);
+    let est_path = path_data(history_est, &to_svg_x, &to_svg_y);
+
+    if !true_path.is_empty() {
+        svg.push_str(&format!(
+            "<path d='{true_path}' fill='none' stroke='#2563eb' stroke-width='5' stroke-linecap='round' stroke-linejoin='round'/>\n"
+        ));
+    }
+    if !dr_path.is_empty() {
+        svg.push_str(&format!(
+            "<path d='{dr_path}' fill='none' stroke='#d97706' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/>\n"
+        ));
+    }
+    if !est_path.is_empty() {
+        svg.push_str(&format!(
+            "<path d='{est_path}' fill='none' stroke='#16a34a' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/>\n"
+        ));
+    }
+
+    for (x, y) in rfid {
+        let sx = to_svg_x(*x);
+        let sy = to_svg_y(*y);
+        svg.push_str(&format!(
+            "<circle cx='{sx:.2}' cy='{sy:.2}' r='6.5' fill='#111827' stroke='white' stroke-width='2'/>\n"
+        ));
+    }
+
+    if let Some((start_x, start_y)) = history_true.first() {
+        svg.push_str(&format!(
+            "<circle cx='{:.2}' cy='{:.2}' r='7' fill='#1d4ed8' stroke='white' stroke-width='2.5'/>\n",
+            to_svg_x(*start_x),
+            to_svg_y(*start_y)
+        ));
+    }
+    if let Some((goal_x, goal_y)) = history_true.last() {
+        svg.push_str(&format!(
+            "<circle cx='{:.2}' cy='{:.2}' r='7' fill='#7c3aed' stroke='white' stroke-width='2.5'/>\n",
+            to_svg_x(*goal_x),
+            to_svg_y(*goal_y)
+        ));
+    }
+    if let Some((est_x, est_y)) = history_est.last() {
+        svg.push_str(&format!(
+            "<circle cx='{:.2}' cy='{:.2}' r='6' fill='#16a34a' stroke='white' stroke-width='2'/>\n",
+            to_svg_x(*est_x),
+            to_svg_y(*est_y)
+        ));
+    }
+
+    svg.push_str(&format!(
+        "<rect x='{legend_x:.1}' y='{legend_y:.1}' width='182' height='132' rx='18' fill='white' stroke='#d6d3d1'/>\n"
+    ));
+    let legend_items = [
+        ("#2563eb", "True Path", false),
+        ("#d97706", "Dead Reckoning", false),
+        ("#16a34a", "Histogram Estimate", false),
+        ("#111827", "RFID Landmark", true),
+    ];
+    for (index, (color, label, point)) in legend_items.iter().enumerate() {
+        let row_y = legend_y + 28.0 + index as f64 * 26.0;
+        if *point {
+            svg.push_str(&format!(
+                "<circle cx='{:.1}' cy='{row_y:.1}' r='5.5' fill='{color}' stroke='white' stroke-width='1.5'/>\n",
+                legend_x + 24.0
+            ));
+        } else {
+            svg.push_str(&format!(
+                "<line x1='{:.1}' y1='{row_y:.1}' x2='{:.1}' y2='{row_y:.1}' stroke='{color}' stroke-width='5' stroke-linecap='round'/>\n",
+                legend_x + 12.0,
+                legend_x + 38.0
+            ));
+        }
+        svg.push_str(&format!(
+            "<text x='{:.1}' y='{:.1}' font-size='16' font-family='sans-serif' fill='#111827'>{label}</text>\n",
+            legend_x + 50.0,
+            row_y + 5.0
+        ));
+    }
+
+    svg.push_str(&format!(
+        "<text x='{:.1}' y='{:.1}' font-size='16' font-family='sans-serif' font-weight='700' fill='#111827'>Probability</text>\n",
+        legend_x + 18.0,
+        colorbar_y - 14.0
+    ));
+    for step in 0..32 {
+        let t0 = step as f64 / 31.0;
+        let (fill, _) = heatmap_style(t0.max(1e-6), 1.0);
+        let y = colorbar_y + colorbar_height * (1.0 - t0) - colorbar_height / 32.0;
+        svg.push_str(&format!(
+            "<rect x='{colorbar_x:.1}' y='{y:.2}' width='{colorbar_width:.1}' height='{:.2}' fill='{fill}'/>\n",
+            colorbar_height / 32.0 + 0.8
+        ));
+    }
+    svg.push_str(&format!(
+        "<rect x='{colorbar_x:.1}' y='{colorbar_y:.1}' width='{colorbar_width:.1}' height='{colorbar_height:.1}' fill='none' stroke='#9ca3af'/>\n"
+    ));
+    svg.push_str(&format!(
+        "<text x='{:.1}' y='{:.1}' font-size='13' font-family='monospace' fill='#374151'>max {:.4}</text>\n",
+        colorbar_x + colorbar_width + 14.0,
+        colorbar_y + 12.0,
+        max_probability
+    ));
+    svg.push_str(&format!(
+        "<text x='{:.1}' y='{:.1}' font-size='13' font-family='monospace' fill='#374151'>min 0.0000</text>\n",
+        colorbar_x + colorbar_width + 14.0,
+        colorbar_y + colorbar_height - 2.0
+    ));
+
+    svg.push_str(&format!(
+        "<text x='{:.1}' y='{:.1}' text-anchor='middle' font-size='16' font-family='sans-serif' fill='#111827'>x [m]</text>\n",
+        plot_left + plot_width / 2.0,
+        plot_top + plot_height + 52.0
+    ));
+    svg.push_str(&format!(
+        "<text x='{:.1}' y='{:.1}' text-anchor='middle' font-size='16' font-family='sans-serif' fill='#111827' transform='rotate(-90, {:.1}, {:.1})'>y [m]</text>\n",
+        plot_left - 50.0,
+        plot_top + plot_height / 2.0,
+        plot_left - 50.0,
+        plot_top + plot_height / 2.0
+    ));
+    svg.push_str("</svg>\n");
+
+    svg
+}
+
+fn save_histogram_filter_svg(
+    filename: &str,
+    area: (f64, f64, f64, f64),
+    rfid: &[(f64, f64)],
+    history_true: &[(f64, f64)],
+    history_dr: &[(f64, f64)],
+    history_est: &[(f64, f64)],
+    x_width: usize,
+    y_width: usize,
+    min_x: f64,
+    min_y: f64,
+    resolution: f64,
+    heatmap_data: &[f64],
+) -> std::io::Result<()> {
+    let svg = build_histogram_filter_svg(
+        area,
+        rfid,
+        history_true,
+        history_dr,
+        history_est,
+        x_width,
+        y_width,
+        min_x,
+        min_y,
+        resolution,
+        heatmap_data,
+    );
+    let mut file = File::create(filename)?;
+    file.write_all(svg.as_bytes())?;
+    Ok(())
+}
+
 fn main() {
     println!("Histogram Filter 2D Localization start!");
 
@@ -390,6 +702,7 @@ fn main() {
     // History for plotting
     let mut h_true: Vec<(f64, f64)> = vec![(0.0, 0.0)];
     let mut h_dr: Vec<(f64, f64)> = vec![(0.0, 0.0)];
+    let mut h_est: Vec<(f64, f64)> = vec![(0.0, 0.0)];
 
     let mut time = 0.0;
     let mut fig = Figure::new();
@@ -420,6 +733,7 @@ fn main() {
         // Store history
         h_true.push((x_true[0], x_true[1]));
         h_dr.push((x_dr[0], x_dr[1]));
+        h_est.push(hf.get_estimated_position());
 
         // Animation
         if SHOW_ANIMATION {
@@ -504,7 +818,46 @@ fn main() {
         .lines(&true_x, &true_y, &[Caption("True"), Color("blue")])
         .lines(&dr_x, &dr_y, &[Caption("Dead Reckoning"), Color("orange")]);
 
-    fig.save_to_svg("./img/localization/histogram_filter.svg", 640, 480)
-        .unwrap();
+    save_histogram_filter_svg(
+        "./img/localization/histogram_filter.svg",
+        area,
+        &rfid,
+        &h_true,
+        &h_dr,
+        &h_est,
+        x_width,
+        y_width,
+        min_x,
+        min_y,
+        resolution,
+        &heatmap_data,
+    )
+    .unwrap();
     println!("Plot saved to ./img/localization/histogram_filter.svg");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_histogram_svg_uses_white_background_and_legend_box() {
+        let svg = build_histogram_filter_svg(
+            (-2.0, -2.0, 2.0, 2.0),
+            &[(0.0, 0.0)],
+            &[(0.0, 0.0), (1.0, 0.5)],
+            &[(0.0, 0.0), (0.8, 0.2)],
+            &[(0.0, 0.0), (0.9, 0.4)],
+            2,
+            2,
+            -2.0,
+            -2.0,
+            2.0,
+            &[0.0, 0.1, 0.2, 0.3],
+        );
+
+        assert!(svg.contains("<rect width='100%' height='100%' fill='white'/>"));
+        assert!(svg.contains("Histogram Estimate"));
+        assert!(svg.contains("Probability"));
+    }
 }


### PR DESCRIPTION
## Summary
- replace the gnuplot-exported histogram filter SVG with a white-background custom SVG renderer
- add the missing histogram estimate trajectory and a fixed white legend panel
- update the README caption to match the rendered dead-reckoning color

## Verification
- cargo fmt --all --check
- cargo test --bin histogram_filter
- cargo run --bin histogram_filter
- cargo test --all-targets
- cargo clippy --all-targets -- -W clippy::all