### PR TITLE
Add library-first roadmap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ cargo run --bin inverted_pendulum_lqr
 cargo run --bin two_joint_arm_control
 ```
 
+## Library-First Roadmap
+
+This repository has started to grow beyond a pure showcase port of PythonRobotics.
+The next step is to make `rust_robotics` more practical as a reusable library while
+keeping examples and visualization as first-class documentation assets.
+
+- Roadmap: [docs/roadmaps/library-first-plan.md](./docs/roadmaps/library-first-plan.md)
+- ADR-001: [Adopt a library-first product direction](./docs/adr/ADR-001-library-first-product.md)
+- ADR-002: [Split the project into a workspace with explicit crate boundaries](./docs/adr/ADR-002-workspace-split-and-crate-boundaries.md)
+
+The short version of the direction is:
+
+1. make the library the product
+2. keep demos/examples as thin clients of public APIs
+3. separate visualization from headless algorithm execution
+4. publish a smaller stable subset before promising every module equally
+5. evolve toward workspace-based crate boundaries as the API matures
+
 # Table of Contents
    * [Localization](#localization)
       * [Extended Kalman Filter Localization](#extended-kalman-filter-localization)

--- a/docs/adr/ADR-001-library-first-product.md
+++ b/docs/adr/ADR-001-library-first-product.md
@@ -1,0 +1,61 @@
+# ADR-001: Adopt a Library-First Product Direction
+
+- Status: Proposed
+- Date: 2026-03-11
+- Related: [Library-first roadmap](../roadmaps/library-first-plan.md)
+
+## Context
+
+`rust_robotics` began as a Rust implementation of PythonRobotics-style examples and remains highly valuable as a showcase repository. The project now also contains:
+
+- a public library crate surface
+- shared types and traits
+- reusable algorithm modules
+- a growing automated test suite
+
+This creates a fork in the road. The project can continue to optimize mainly for demos, or it can treat the reusable library surface as the primary product while still keeping demos as a major strength.
+
+## Decision
+
+The project will be developed as a library-first robotics algorithms project.
+
+This means:
+
+1. the library is the product
+2. examples and demos are thin clients of public APIs
+3. headless execution is the default assumption for core algorithms
+4. visualization is optional and should not define core architecture
+5. algorithm maturity must be explicit in code structure and documentation
+
+## Consequences
+
+### Positive
+
+- better reuse by downstream crates
+- clearer public API ownership
+- easier semver and publishing strategy
+- cleaner future integration paths such as ROS2 adapters
+- easier testing and benchmarking
+
+### Negative
+
+- more up-front architectural work
+- migration pressure on legacy demo-oriented APIs
+- examples may need to be rewritten to use cleaner public interfaces
+
+## Non-Goals
+
+This decision does not imply:
+
+- every algorithm becomes production-ready immediately
+- demos should be removed
+- all legacy signatures remain forever
+- ROS2-specific concerns belong in the core crate
+
+## Follow-Up
+
+The immediate follow-up is to define:
+
+- architecture boundaries
+- maturity tiers
+- migration sequence for the first stable subset

--- a/docs/adr/ADR-002-workspace-split-and-crate-boundaries.md
+++ b/docs/adr/ADR-002-workspace-split-and-crate-boundaries.md
@@ -1,0 +1,93 @@
+# ADR-002: Move Toward Explicit Crate Boundaries
+
+- Status: Proposed
+- Date: 2026-03-11
+- Related: [Library-first roadmap](../roadmaps/library-first-plan.md)
+- Depends on: [ADR-001](./ADR-001-library-first-product.md)
+
+## Context
+
+The current repository is a single crate that mixes:
+
+- reusable algorithm logic
+- legacy binary entry points
+- visualization helpers
+- showcase-oriented assets
+
+This is workable for a demo-focused repository, but it makes library growth harder:
+
+- the dependency boundary is broad
+- visualization remains close to core execution paths
+- stable and experimental APIs are difficult to isolate
+- users cannot depend on a smaller subset cleanly
+
+## Decision
+
+The project should move toward explicit crate boundaries, likely through a workspace, as the library-first migration progresses.
+
+The intended shape is approximately:
+
+```text
+rust_robotics/
+  crates/
+    rust_robotics_core/
+    rust_robotics_planning/
+    rust_robotics_localization/
+    rust_robotics_mapping/
+    rust_robotics_control/
+    rust_robotics_slam/
+    rust_robotics_viz/
+    rust_robotics/
+```
+
+## Boundary Rules
+
+### `rust_robotics_core`
+
+Owns:
+
+- shared types
+- traits
+- common error types
+
+Must not own:
+
+- plotting
+- algorithm-family-specific implementations
+
+### Domain crates
+
+Planning, localization, mapping, control, and SLAM should own their respective algorithm implementations and public configs/results.
+
+### `rust_robotics_viz`
+
+Owns:
+
+- plotting
+- rendering helpers
+- showcase-oriented output adapters
+
+Must not own:
+
+- core algorithm behavior
+
+### Umbrella crate
+
+The top-level `rust_robotics` crate can remain as a friendly re-export layer for stable subsets.
+
+## Rationale
+
+This direction is preferred because it:
+
+- keeps core execution headless by default
+- supports smaller dependency footprints
+- allows maturity to evolve by domain
+- makes future publishing strategy more realistic
+
+## Migration Notes
+
+This is a direction, not a demand for one giant refactor. A staged migration is preferred:
+
+1. define the boundaries
+2. migrate a stable subset first
+3. keep compatibility shims only where they reduce churn meaningfully

--- a/docs/roadmaps/library-first-plan.md
+++ b/docs/roadmaps/library-first-plan.md
@@ -1,0 +1,279 @@
+# RustRobotics Library-First Plan
+
+## Status
+
+- Date: 2026-03-11
+- Scope: direction-setting document for shifting `rust_robotics` from showcase-first to library-first
+- Intended audience: maintainers and contributors deciding how to evolve the crate architecture
+
+## Summary
+
+`rust_robotics` already has the beginnings of a reusable library:
+
+- a public `lib.rs`
+- shared types and traits
+- a meaningful test suite
+- some algorithms already migrated toward reusable module APIs
+
+At the same time, the repository still behaves mostly like a showcase project:
+
+- the README is demo-first
+- many legacy `[[bin]]` targets remain in `Cargo.toml`
+- visualization utilities are part of the default public surface
+- examples, demos, and core algorithms still share one broad dependency boundary
+
+The recommendation is to invert the layering:
+
+1. make the library the product
+2. make demos/examples thin wrappers around public APIs
+3. keep visualization and showcase assets as optional layers
+
+## Why This Direction Matters
+
+Staying sample-first is attractive in the short term, but it creates limits:
+
+- users copy code instead of depending on the crate
+- API quality drifts toward demo convenience
+- fixes do not accumulate well for downstream users
+- headless reuse becomes harder because plotting and file output assumptions leak into the codebase
+- semver, publishing, and support levels remain vague
+
+A library-first direction makes the repository more useful for:
+
+- robotics application development
+- simulation loops
+- evaluation tooling
+- future ROS2 or adapter crates
+- downstream crates that want stable types and tested behavior
+
+## Product Thesis
+
+`rust_robotics` should become a library-first robotics algorithms project with:
+
+- a stable, typed, headless core
+- explicit public APIs
+- examples as documentation, not architecture
+- visualization as an optional concern
+- clear maturity levels for each algorithm family
+
+## Current Observations
+
+Observed from the current repository state:
+
+- there is one crate with a wide surface area
+- the project contains both clean library modules and legacy binary-oriented paths
+- tests already exist for many modules, which is a strong base
+- CI currently validates the whole repository, but it does not distinguish core library guarantees from showcase guarantees
+
+This means the right question is not whether the project can become a library. It already can. The real question is whether the architecture and documentation will catch up to that direction.
+
+## Target Principles
+
+### Principle 1: Headless-first core
+
+Core algorithms should run without:
+
+- plotting
+- filesystem side effects
+- image generation
+- interactive UI assumptions
+
+### Principle 2: Public API before demo wrappers
+
+Preferred interfaces should use:
+
+- typed config structs
+- typed state and measurement structs
+- typed result objects where appropriate
+- structured error handling
+
+Legacy helper APIs can remain temporarily, but they should not be the primary documented path.
+
+### Principle 3: Algorithm maturity is explicit
+
+Not every algorithm needs the same support level immediately. The repository should classify modules such as:
+
+- Stable
+- Experimental
+- Showcase
+
+### Principle 4: Examples prove ergonomics
+
+Every example should be expressible as a thin client of public library APIs. If an example requires private logic or demo-only interfaces, the library surface is incomplete.
+
+## Recommended End State
+
+The long-term target should be a workspace with clearer crate boundaries.
+
+Example target shape:
+
+```text
+rust_robotics/
+  Cargo.toml
+  crates/
+    rust_robotics_core/
+    rust_robotics_planning/
+    rust_robotics_localization/
+    rust_robotics_mapping/
+    rust_robotics_control/
+    rust_robotics_slam/
+    rust_robotics_viz/
+    rust_robotics/
+  examples/
+  benches/
+  docs/
+```
+
+This does not need to happen in one PR, but it should be the architectural direction if the library-first goal is accepted.
+
+## Suggested Maturity Tiers
+
+### Tier 1: Stable candidates
+
+These are the most natural first candidates for library-quality support:
+
+- A*
+- Theta*
+- JPS
+- DWA
+- EKF
+- UKF
+- particle filter
+- pure pursuit
+- Stanley control
+- LQR steer control
+- grid map utilities
+- behavior tree
+- state machine
+
+### Tier 2: Experimental candidates
+
+- RRT family
+- PRM
+- state lattice
+- Frenet optimal trajectory
+- MPC variants
+- histogram filter
+- some mapping modules
+
+### Tier 3: Showcase/research candidates
+
+- inverted pendulum demos
+- some arm navigation examples
+- graph-based SLAM until the API is clarified
+- FastSLAM and ICP if they remain more demonstrative than integration-oriented
+
+## Migration Roadmap
+
+### Phase 0: Inventory and ownership
+
+Goal:
+
+- classify every module
+
+Tasks:
+
+- inventory algorithms and current API style
+- mark each module with a maturity target
+- decide which modules are first-publish candidates
+
+### Phase 1: Documentation and direction-setting
+
+Goal:
+
+- make the architectural direction visible
+
+Tasks:
+
+- add roadmap and ADRs
+- link them from the README
+- define public support language
+
+### Phase 2: Dependency boundary cleanup
+
+Goal:
+
+- separate headless algorithm code from visualization and showcase concerns
+
+Tasks:
+
+- reduce legacy `[[bin]]` usage
+- move more runnable content to examples
+- isolate visualization behind a crate or feature boundary
+
+### Phase 3: Stable subset hardening
+
+Goal:
+
+- make a small subset truly reusable
+
+Tasks:
+
+- standardize configs and result types
+- add config validation
+- document assumptions and failure modes
+- add deterministic paths for stochastic algorithms
+
+### Phase 4: Publishing readiness
+
+Goal:
+
+- make at least one stable subset publishable with confidence
+
+Tasks:
+
+- fill in crate metadata
+- document semver expectations
+- split CI by concern where necessary
+- benchmark representative algorithms
+
+## Immediate Priorities
+
+The highest-value near-term work is:
+
+1. write and accept the architectural direction
+2. pick the first stable subset
+3. separate visualization from core execution
+4. migrate examples to thin wrappers over public APIs
+5. improve docs so the crate is described as a library first
+
+## Risks
+
+### Risk: over-splitting too early
+
+Mitigation:
+
+- split by dependency boundary, not by folder aesthetics
+
+### Risk: preserving every legacy API forever
+
+Mitigation:
+
+- use deprecation windows and migration guides
+
+### Risk: treating every algorithm as equally mature
+
+Mitigation:
+
+- publish support tiers and focus on a stable subset first
+
+## First Deliverables
+
+The first concrete outputs after accepting this direction should be:
+
+- accepted ADRs for product direction and crate boundaries
+- a stable-subset shortlist
+- an implementation plan for visualization separation
+- a small PR sequence rather than a single giant refactor
+
+## Recommendation
+
+`rust_robotics` should move toward being a practical library rather than remaining primarily a showcase repository.
+
+The right approach is not to discard the showcase value. The right approach is to subordinate it to a stronger architecture:
+
+- library first
+- examples second
+- visualization optional
+- maturity explicit
+- stable subset delivered early


### PR DESCRIPTION
## Summary
- add a library-first roadmap document under `docs/roadmaps`
- add ADRs for the product direction and future crate boundaries
- link the roadmap from the README so contributors can follow the intended migration path

## Testing
- cargo test --lib