### PR TITLE
Add headless core mode and validated stable library APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Run tests for all targets
       run: cargo test --all-targets
 
+    - name: Run headless core tests
+      run: cargo test --all-targets --no-default-features
+
     - name: Clippy (warnings only)
       run: cargo clippy --all-targets -- -W clippy::all
       continue-on-error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ name = "headless_navigation_loop"
 path = "examples/integration/headless_navigation_loop.rs"
 
 [[example]]
+name = "headless_localizers"
+path = "examples/localization/headless_localizers.rs"
+
+[[example]]
 name = "state_lattice"
 path = "examples/path_planning/state_lattice.rs"
 required-features = ["showcase", "viz"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ path = "examples/path_planning/jps.rs"
 required-features = ["showcase", "viz"]
 
 [[example]]
+name = "headless_grid_planners"
+path = "examples/path_planning/headless_grid_planners.rs"
+
+[[example]]
 name = "state_lattice"
 path = "examples/path_planning/state_lattice.rs"
 required-features = ["showcase", "viz"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ name = "headless_grid_planners"
 path = "examples/path_planning/headless_grid_planners.rs"
 
 [[example]]
+name = "headless_navigation_loop"
+path = "examples/integration/headless_navigation_loop.rs"
+
+[[example]]
 name = "state_lattice"
 path = "examples/path_planning/state_lattice.rs"
 required-features = ["showcase", "viz"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,189 +3,248 @@ name = "rust_robotics"
 version = "0.1.0"
 authors = ["ryohei sasaki <rsasaki0109@gmail.com>"]
 edition = "2021"
+autobins = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["showcase", "viz"]
+showcase = []
+viz = ["dep:gnuplot", "dep:plotlib"]
+
 [dependencies]
 nalgebra = "0.33"
-plotlib = "0.5"
+plotlib = { version = "0.5", optional = true }
 rand = "0.8"
 rand_distr = "0.4"
 itertools = "0.13"
-gnuplot = "0.0.43"
+gnuplot = { version = "0.0.43", optional = true }
 ordered-float = "4.2"
 
 # Examples (refactored)
 [[example]]
 name = "a_star"
 path = "examples/path_planning/a_star.rs"
+required-features = ["showcase", "viz"]
 
 [[example]]
 name = "theta_star"
 path = "examples/path_planning/theta_star.rs"
+required-features = ["showcase", "viz"]
 
 [[example]]
 name = "jps"
 path = "examples/path_planning/jps.rs"
+required-features = ["showcase", "viz"]
 
 [[example]]
 name = "state_lattice"
 path = "examples/path_planning/state_lattice.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "ekf"
 path = "src/bin/ekf.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "dwa"
 path = "src/bin/dwa.rs"
+required-features = ["showcase", "viz"]
+
+[[bin]]
+name = "behavior_tree"
+path = "src/bin/behavior_tree.rs"
+required-features = ["showcase", "viz"]
+
+[[bin]]
+name = "grid_a_star_3d"
+path = "src/bin/grid_a_star_3d.rs"
+required-features = ["showcase", "viz"]
 
 # Legacy binaries (will be migrated to examples)
 
 [[bin]]
 name = "ndt"
 path = "src/mapping/ndt.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "rrt"
 path = "src/bin/rrt.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "dijkstra"
 path = "src/path_planning/dijkstra.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "particle_filter"
 path = "src/bin/particle_filter.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "rrt_star"
 path = "src/path_planning/rrt_star.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "potential_field"
 path = "src/path_planning/potential_field.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "informed_rrt_star"
 path = "src/path_planning/informed_rrt_star.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "quintic_polynomials"
 path = "src/path_planning/quintic_polynomials.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "csp"
 path = "src/path_planning/csp.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "cubic_spline"
 path = "src/path_planning/cubic_spline_planner.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "d_star_lite"
 path = "src/path_planning/d_star_lite.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "reeds_shepp"
 path = "src/path_planning/reeds_shepp_path.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "bezier_planning"
 path = "src/path_planning/bezier_path_planning.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "bezier_path"
 path = "src/path_planning/bezier_path.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "lqr_steer_control"
 path = "src/bin/lqr_steer_control.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "pure_pursuit"
 path = "src/bin/pure_pursuit.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "stanley_controller"
 path = "src/bin/stanley_controller.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "move_to_pose"
 path = "src/bin/move_to_pose.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "model_predictive_trajectory_generator"
 path = "src/path_tracking/model_predictive_trajectory_generator.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "inverted_pendulum_lqr"
 path = "src/control/lqr_control.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "inverted_pendulum_mpc"
 path = "src/control/mpc_control.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "two_joint_arm_control"
 path = "src/arm_navigation/two_joint_arm_control.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "icp_matching"
 path = "src/slam/icp_matching.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "state_machine"
 path = "src/bin/state_machine.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "unscented_kalman_filter"
 path = "src/bin/unscented_kalman_filter.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "histogram_filter"
 path = "src/localization/histogram_filter.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "gaussian_grid_map"
 path = "src/mapping/gaussian_grid_map.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "ray_casting_grid_map"
 path = "src/mapping/ray_casting_grid_map.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "fastslam1"
 path = "src/slam/fastslam1.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "ekf_slam"
 path = "src/slam/ekf_slam.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "graph_based_slam"
 path = "src/slam/graph_based_slam.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "prm"
 path = "src/path_planning/prm.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "voronoi_road_map"
 path = "src/path_planning/voronoi_road_map.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "frenet_optimal_trajectory"
 path = "src/path_planning/frenet_optimal_trajectory.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "mpc"
 path = "src/path_tracking/mpc.rs"
+required-features = ["showcase", "viz"]
 
 [[bin]]
 name = "cgmres_nmpc"
 path = "src/path_tracking/cgmres_nmpc.rs"
+required-features = ["showcase", "viz"]
 
 [[example]]
 name = "rear_wheel_feedback"
 path = "examples/path_tracking/rear_wheel_feedback.rs"
+required-features = ["showcase", "viz"]

--- a/examples/integration/headless_navigation_loop.rs
+++ b/examples/integration/headless_navigation_loop.rs
@@ -1,0 +1,61 @@
+//! Headless integration example that combines DWA and EKF.
+
+use rust_robotics::prelude::*;
+
+fn create_obstacles() -> Obstacles {
+    Obstacles::from_points(vec![Point2D::new(5.0, 5.0), Point2D::new(6.0, 6.0)])
+}
+
+fn main() -> RoboticsResult<()> {
+    let obstacles = create_obstacles();
+    let goal = Point2D::new(3.0, 0.0);
+
+    let mut planner = DWAPlanner::try_new(DWAConfig::default())?;
+    planner.try_set_state(DWAState::new(0.0, 0.0, 0.0, 0.0, 0.0))?;
+    planner.try_set_goal(goal)?;
+    planner.set_obstacles_from_obstacles(&obstacles)?;
+
+    let mut ekf = EKFLocalizer::with_initial_state_2d(
+        State2D::new(0.0, 0.0, 0.0, 0.0),
+        EKFConfig::default(),
+    )?;
+
+    for step in 0..120 {
+        if planner.is_goal_reached() {
+            break;
+        }
+
+        let control = planner.try_step()?;
+        let true_state = planner.state_2d();
+        let measurement = Point2D::new(
+            true_state.x + ((step % 5) as f64 - 2.0) * 0.02,
+            true_state.y + (((step * 2) % 5) as f64 - 2.0) * 0.02,
+        );
+        let estimate = ekf.estimate_state(
+            measurement,
+            DWAPlanner::control_to_input(&control),
+            planner.config().dt,
+        )?;
+
+        if step % 25 == 0 {
+            println!(
+                "step={step:03} true=({:.2}, {:.2}) est=({:.2}, {:.2})",
+                true_state.x, true_state.y, estimate.x, estimate.y
+            );
+        }
+    }
+
+    let true_state = planner.state_2d();
+    let estimate = ekf.state_2d();
+    println!(
+        "goal_reached={} true=({:.2}, {:.2}) estimate=({:.2}, {:.2}) distance_to_goal={:.2}",
+        planner.is_goal_reached(),
+        true_state.x,
+        true_state.y,
+        estimate.x,
+        estimate.y,
+        planner.distance_to_goal()
+    );
+
+    Ok(())
+}

--- a/examples/localization/headless_localizers.rs
+++ b/examples/localization/headless_localizers.rs
@@ -1,0 +1,82 @@
+//! Headless localization example using EKF, UKF, and Particle Filter.
+
+use rust_robotics::prelude::*;
+
+fn propagate_state(state: &mut State2D, control: ControlInput, dt: f64) {
+    state.x += control.v * state.yaw.cos() * dt;
+    state.y += control.v * state.yaw.sin() * dt;
+    state.yaw += control.omega * dt;
+    state.v = control.v;
+}
+
+fn build_pf_measurements(state: &State2D, landmarks: &Obstacles) -> PFMeasurement {
+    landmarks
+        .points
+        .iter()
+        .map(|landmark| {
+            let dx = state.x - landmark.x;
+            let dy = state.y - landmark.y;
+            (((dx * dx + dy * dy).sqrt()), landmark.x, landmark.y)
+        })
+        .collect()
+}
+
+fn main() -> RoboticsResult<()> {
+    let landmarks = Obstacles::from_points(vec![
+        Point2D::new(5.0, 0.0),
+        Point2D::new(0.0, 5.0),
+        Point2D::new(5.0, 5.0),
+    ]);
+    let mut true_state = State2D::origin();
+    let control = ControlInput::new(1.0, 0.1);
+
+    let mut ekf = EKFLocalizer::with_initial_state_2d(State2D::origin(), EKFConfig::default())?;
+    let mut ukf = UKFLocalizer::with_initial_state_2d(State2D::origin(), UKFConfig::default())?;
+    let mut pf = ParticleFilterLocalizer::with_initial_state_2d(
+        State2D::origin(),
+        ParticleFilterConfig::default(),
+    )?;
+    pf.set_landmarks_from_obstacles(&landmarks)?;
+
+    for step in 0..40 {
+        propagate_state(&mut true_state, control, 0.1);
+
+        let position_measurement = Point2D::new(
+            true_state.x + ((step % 5) as f64 - 2.0) * 0.03,
+            true_state.y + (((step * 2) % 5) as f64 - 2.0) * 0.03,
+        );
+        let pf_measurement = build_pf_measurements(&true_state, &landmarks);
+
+        let ekf_state = ekf.estimate_state(position_measurement, control, 0.1)?;
+        let ukf_state = ukf.estimate_state(control, position_measurement)?;
+        let pf_state = pf.try_step_state(control, &pf_measurement)?;
+
+        if step % 10 == 0 {
+            println!(
+                "step={step:02} true=({:.2}, {:.2}) ekf=({:.2}, {:.2}) ukf=({:.2}, {:.2}) pf=({:.2}, {:.2})",
+                true_state.x,
+                true_state.y,
+                ekf_state.x,
+                ekf_state.y,
+                ukf_state.x,
+                ukf_state.y,
+                pf_state.x,
+                pf_state.y
+            );
+        }
+    }
+
+    println!(
+        "final true=({:.2}, {:.2}) ekf=({:.2}, {:.2}) ukf=({:.2}, {:.2}) pf=({:.2}, {:.2})",
+        true_state.x,
+        true_state.y,
+        ekf.state_2d().x,
+        ekf.state_2d().y,
+        ukf.state_2d().x,
+        ukf.state_2d().y,
+        pf.state_2d().x,
+        pf.state_2d().y
+    );
+
+    Ok(())
+}

--- a/examples/path_planning/a_star.rs
+++ b/examples/path_planning/a_star.rs
@@ -2,7 +2,7 @@
 //!
 //! Demonstrates the A* path planning algorithm on a simple grid with obstacles.
 
-use rust_robotics::common::{PathPlanner, Point2D};
+use rust_robotics::common::Point2D;
 use rust_robotics::path_planning::a_star::{AStarConfig, AStarPlanner};
 use rust_robotics::utils::{PathStyle, Visualizer};
 

--- a/examples/path_planning/headless_grid_planners.rs
+++ b/examples/path_planning/headless_grid_planners.rs
@@ -1,0 +1,79 @@
+//! Headless grid-based planning example.
+//!
+//! This example demonstrates how to use the library-first planning APIs
+//! without enabling visualization dependencies.
+
+use rust_robotics::path_planning::{
+    AStarConfig, AStarPlanner, JPSConfig, JPSPlanner, ThetaStarConfig, ThetaStarPlanner,
+};
+use rust_robotics::{Obstacles, Point2D, RoboticsResult};
+
+fn create_obstacles() -> Obstacles {
+    let mut obstacles = Obstacles::new();
+
+    for i in 0..=20 {
+        obstacles.push(Point2D::new(i as f64, 0.0));
+        obstacles.push(Point2D::new(i as f64, 20.0));
+        obstacles.push(Point2D::new(0.0, i as f64));
+        obstacles.push(Point2D::new(20.0, i as f64));
+    }
+
+    for i in 5..15 {
+        obstacles.push(Point2D::new(10.0, i as f64));
+    }
+
+    obstacles
+}
+
+fn main() -> RoboticsResult<()> {
+    let obstacles = create_obstacles();
+    let start = Point2D::new(2.0, 10.0);
+    let goal = Point2D::new(18.0, 10.0);
+
+    let a_star = AStarPlanner::from_obstacle_points(
+        &obstacles,
+        AStarConfig {
+            resolution: 1.0,
+            robot_radius: 0.5,
+            heuristic_weight: 1.0,
+        },
+    )?;
+    let jps = JPSPlanner::from_obstacle_points(
+        &obstacles,
+        JPSConfig {
+            resolution: 1.0,
+            robot_radius: 0.5,
+            heuristic_weight: 1.0,
+        },
+    )?;
+    let theta_star = ThetaStarPlanner::from_obstacle_points(
+        &obstacles,
+        ThetaStarConfig {
+            resolution: 1.0,
+            robot_radius: 0.5,
+            heuristic_weight: 1.0,
+        },
+    )?;
+
+    let a_star_path = a_star.plan(start, goal)?;
+    let jps_path = jps.plan(start, goal)?;
+    let theta_star_path = theta_star.plan(start, goal)?;
+
+    println!(
+        "A*: {} waypoints, length {:.2}",
+        a_star_path.len(),
+        a_star_path.total_length()
+    );
+    println!(
+        "JPS: {} waypoints, length {:.2}",
+        jps_path.len(),
+        jps_path.total_length()
+    );
+    println!(
+        "Theta*: {} waypoints, length {:.2}",
+        theta_star_path.len(),
+        theta_star_path.total_length()
+    );
+
+    Ok(())
+}

--- a/examples/path_planning/jps.rs
+++ b/examples/path_planning/jps.rs
@@ -4,7 +4,7 @@
 //! JPS is an optimization of A* that significantly reduces the number of
 //! nodes expanded by identifying "jump points".
 
-use rust_robotics::common::{Path2D, PathPlanner, Point2D};
+use rust_robotics::common::{Path2D, Point2D};
 use rust_robotics::path_planning::a_star::{AStarConfig, AStarPlanner};
 use rust_robotics::path_planning::jps::{JPSConfig, JPSPlanner};
 use std::fs::File;

--- a/examples/path_planning/theta_star.rs
+++ b/examples/path_planning/theta_star.rs
@@ -6,7 +6,7 @@
 //! Theta* extends A* by allowing paths to connect any two visible nodes,
 //! resulting in shorter, more natural paths compared to standard A*.
 
-use rust_robotics::common::{Path2D, PathPlanner, Point2D};
+use rust_robotics::common::{Path2D, Point2D};
 use rust_robotics::path_planning::a_star::{AStarConfig, AStarPlanner};
 use rust_robotics::path_planning::theta_star::{ThetaStarConfig, ThetaStarPlanner};
 use std::fs::File;

--- a/src/arm_navigation/mod.rs
+++ b/src/arm_navigation/mod.rs
@@ -1,5 +1,7 @@
 // Arm Navigation algorithms module
 
+#[cfg(feature = "viz")]
 pub mod two_joint_arm_control;
 
+#[cfg(feature = "viz")]
 pub use two_joint_arm_control::*;

--- a/src/common/traits.rs
+++ b/src/common/traits.rs
@@ -131,6 +131,7 @@ pub trait Controller {
 }
 
 /// Trait for visualizable algorithms
+#[cfg(feature = "viz")]
 pub trait Visualizable {
     /// Draw current state to visualizer
     fn visualize(&self, vis: &mut crate::utils::Visualizer);

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -2,6 +2,8 @@
 
 use nalgebra::{Matrix2, Matrix4, Vector2, Vector3, Vector4};
 
+use crate::common::error::{RoboticsError, RoboticsResult};
+
 /// 2D point representation
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Point2D {
@@ -287,18 +289,37 @@ impl Obstacles {
         Self { points }
     }
 
-    pub fn from_xy(x: &[f64], y: &[f64]) -> Self {
-        assert_eq!(x.len(), y.len());
+    pub fn try_from_xy(x: &[f64], y: &[f64]) -> RoboticsResult<Self> {
+        if x.len() != y.len() {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "obstacle x/y coordinates must have matching lengths, got {} and {}",
+                x.len(),
+                y.len()
+            )));
+        }
+
         let points = x
             .iter()
             .zip(y.iter())
             .map(|(&x, &y)| Point2D::new(x, y))
             .collect();
-        Self { points }
+        Ok(Self { points })
+    }
+
+    pub fn from_xy(x: &[f64], y: &[f64]) -> Self {
+        Self::try_from_xy(x, y).expect("obstacle x/y coordinates must have matching lengths")
     }
 
     pub fn push(&mut self, point: Point2D) {
         self.points.push(point);
+    }
+
+    pub fn len(&self) -> usize {
+        self.points.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.points.is_empty()
     }
 
     pub fn x_coords(&self) -> Vec<f64> {
@@ -360,6 +381,23 @@ mod tests {
         let mut pose = Pose2D::new(0.0, 0.0, 4.0);
         pose.normalize_yaw();
         assert!(pose.yaw >= -std::f64::consts::PI && pose.yaw <= std::f64::consts::PI);
+    }
+
+    #[test]
+    fn test_obstacles_try_from_xy_rejects_mismatched_lengths() {
+        let err = Obstacles::try_from_xy(&[0.0, 1.0], &[0.0]).unwrap_err();
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_obstacles_len_and_is_empty() {
+        let mut obstacles = Obstacles::new();
+        assert!(obstacles.is_empty());
+        assert_eq!(obstacles.len(), 0);
+
+        obstacles.push(Point2D::new(1.0, 2.0));
+        assert!(!obstacles.is_empty());
+        assert_eq!(obstacles.len(), 1);
     }
 
     #[test]

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! Includes various control algorithms such as LQR and MPC.
 
+#[cfg(feature = "viz")]
 pub mod lqr_control;
+#[cfg(feature = "viz")]
 pub mod mpc_control;
 
 // Re-exports will be added after refactoring

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate self as rust_robotics;
 
 // Core modules
 pub mod common;
+pub mod prelude;
 pub mod utils;
 
 // Algorithm modules

--- a/src/localization/ekf.rs
+++ b/src/localization/ekf.rs
@@ -3,7 +3,9 @@
 //! Implements state estimation using the Extended Kalman Filter algorithm
 //! for robot localization with nonlinear motion and observation models.
 
-use crate::common::{RoboticsError, StateEstimator};
+use crate::common::{
+    ControlInput, Point2D, RoboticsError, RoboticsResult, State2D, StateEstimator,
+};
 use nalgebra::{Matrix2, Matrix2x4, Matrix4, Matrix4x2, Vector2, Vector4};
 
 /// State representation for EKF (x, y, yaw, velocity)
@@ -38,6 +40,37 @@ impl Default for EKFConfig {
     }
 }
 
+impl EKFConfig {
+    pub fn validate(&self) -> RoboticsResult<()> {
+        if self.q.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "EKF process noise matrix must contain only finite values".to_string(),
+            ));
+        }
+        if self.r.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "EKF measurement noise matrix must contain only finite values".to_string(),
+            ));
+        }
+        for i in 0..4 {
+            if self.q[(i, i)] < 0.0 {
+                return Err(RoboticsError::InvalidParameter(
+                    "EKF process noise diagonal entries must be non-negative".to_string(),
+                ));
+            }
+        }
+        for i in 0..2 {
+            if self.r[(i, i)] < 0.0 {
+                return Err(RoboticsError::InvalidParameter(
+                    "EKF measurement noise diagonal entries must be non-negative".to_string(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Extended Kalman Filter for robot localization
 pub struct EKFLocalizer {
     /// Current state estimate [x, y, yaw, v]
@@ -51,11 +84,19 @@ pub struct EKFLocalizer {
 impl EKFLocalizer {
     /// Create a new EKF localizer
     pub fn new(config: EKFConfig) -> Self {
-        EKFLocalizer {
+        Self::try_new(config).expect(
+            "invalid EKF configuration: noise matrices must be finite and have non-negative diagonals",
+        )
+    }
+
+    /// Create a new validated EKF localizer
+    pub fn try_new(config: EKFConfig) -> RoboticsResult<Self> {
+        config.validate()?;
+        Ok(EKFLocalizer {
             state: EKFState::zeros(),
             covariance: Matrix4::identity(),
             config,
-        }
+        })
     }
 
     /// Create with default configuration
@@ -65,11 +106,30 @@ impl EKFLocalizer {
 
     /// Create with initial state
     pub fn with_initial_state(initial_state: EKFState, config: EKFConfig) -> Self {
-        EKFLocalizer {
+        Self::try_with_initial_state(initial_state, config)
+            .expect("invalid EKF initialization: state must be finite and config must be valid")
+    }
+
+    /// Create with validated initial state
+    pub fn try_with_initial_state(
+        initial_state: EKFState,
+        config: EKFConfig,
+    ) -> RoboticsResult<Self> {
+        config.validate()?;
+        Self::validate_state_vector(&initial_state)?;
+        Ok(EKFLocalizer {
             state: initial_state,
             covariance: Matrix4::identity(),
             config,
-        }
+        })
+    }
+
+    /// Create with common State2D type
+    pub fn with_initial_state_2d(
+        initial_state: State2D,
+        config: EKFConfig,
+    ) -> RoboticsResult<Self> {
+        Self::try_with_initial_state(initial_state.to_vector(), config)
     }
 
     /// Get reference to state covariance
@@ -77,14 +137,59 @@ impl EKFLocalizer {
         &self.covariance
     }
 
+    /// Get current estimate as State2D
+    pub fn state_2d(&self) -> State2D {
+        State2D::new(self.state[0], self.state[1], self.state[2], self.state[3])
+    }
+
     /// Set process noise covariance
     pub fn set_process_noise(&mut self, q: Matrix4<f64>) {
+        self.try_set_process_noise(q)
+            .expect("invalid EKF process noise matrix")
+    }
+
+    /// Set process noise covariance with validation
+    pub fn try_set_process_noise(&mut self, q: Matrix4<f64>) -> RoboticsResult<()> {
+        if q.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "EKF process noise matrix must contain only finite values".to_string(),
+            ));
+        }
+        for i in 0..4 {
+            if q[(i, i)] < 0.0 {
+                return Err(RoboticsError::InvalidParameter(
+                    "EKF process noise diagonal entries must be non-negative".to_string(),
+                ));
+            }
+        }
+
         self.config.q = q;
+        Ok(())
     }
 
     /// Set measurement noise covariance
     pub fn set_measurement_noise(&mut self, r: Matrix2<f64>) {
+        self.try_set_measurement_noise(r)
+            .expect("invalid EKF measurement noise matrix")
+    }
+
+    /// Set measurement noise covariance with validation
+    pub fn try_set_measurement_noise(&mut self, r: Matrix2<f64>) -> RoboticsResult<()> {
+        if r.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "EKF measurement noise matrix must contain only finite values".to_string(),
+            ));
+        }
+        for i in 0..2 {
+            if r[(i, i)] < 0.0 {
+                return Err(RoboticsError::InvalidParameter(
+                    "EKF measurement noise diagonal entries must be non-negative".to_string(),
+                ));
+            }
+        }
+
         self.config.r = r;
+        Ok(())
     }
 
     /// Motion model: predict state based on control input
@@ -139,6 +244,10 @@ impl EKFLocalizer {
         control: &EKFControl,
         dt: f64,
     ) -> Result<&EKFState, RoboticsError> {
+        Self::validate_measurement_vector(measurement)?;
+        Self::validate_control_vector(control)?;
+        Self::validate_dt(dt)?;
+
         // Predict
         let x_pred = Self::motion_model(&self.state, control, dt);
         let j_f = Self::jacobian_f(&x_pred, control, dt);
@@ -159,6 +268,17 @@ impl EKFLocalizer {
         self.covariance = (Matrix4::identity() - k * j_h) * p_pred;
 
         Ok(&self.state)
+    }
+
+    /// EKF estimate step using common crate types
+    pub fn estimate_state(
+        &mut self,
+        measurement: Point2D,
+        control: ControlInput,
+        dt: f64,
+    ) -> RoboticsResult<State2D> {
+        self.estimate(&measurement.to_vector(), &control.to_vector(), dt)?;
+        Ok(self.state_2d())
     }
 
     /// Legacy interface for EKF estimation (standalone function style)
@@ -184,6 +304,47 @@ impl EKFLocalizer {
         let new_p_est = (Matrix4::identity() - k * j_h) * p_pred;
 
         (new_x_est, new_p_est)
+    }
+
+    fn validate_state_vector(state: &EKFState) -> RoboticsResult<()> {
+        if state.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "EKF state must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_measurement_vector(measurement: &EKFMeasurement) -> RoboticsResult<()> {
+        if measurement.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "EKF measurement must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_control_vector(control: &EKFControl) -> RoboticsResult<()> {
+        if control.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "EKF control input must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_dt(dt: f64) -> RoboticsResult<()> {
+        if !dt.is_finite() || dt <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "EKF dt must be positive and finite, got {}",
+                dt
+            )));
+        }
+
+        Ok(())
     }
 }
 
@@ -279,5 +440,53 @@ mod tests {
 
         assert!(new_x[0] > 0.0);
         assert!(new_p[(0, 0)] > 0.0);
+    }
+
+    #[test]
+    fn test_ekf_try_new_rejects_invalid_config() {
+        let mut config = EKFConfig::default();
+        config.q[(0, 0)] = -1.0;
+
+        let err = match EKFLocalizer::try_new(config) {
+            Ok(_) => panic!("expected invalid config to be rejected"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_ekf_with_initial_state_2d() {
+        let ekf = EKFLocalizer::with_initial_state_2d(
+            State2D::new(1.0, 2.0, 0.3, 0.5),
+            EKFConfig::default(),
+        )
+        .unwrap();
+
+        let state = ekf.state_2d();
+        assert_eq!(state.x, 1.0);
+        assert_eq!(state.y, 2.0);
+        assert_eq!(state.yaw, 0.3);
+        assert_eq!(state.v, 0.5);
+    }
+
+    #[test]
+    fn test_ekf_estimate_state_with_common_types() {
+        let mut ekf = EKFLocalizer::with_defaults();
+        let state = ekf
+            .estimate_state(Point2D::new(0.1, 0.0), ControlInput::new(1.0, 0.0), 0.1)
+            .unwrap();
+
+        assert!(state.x > 0.0);
+    }
+
+    #[test]
+    fn test_ekf_estimate_rejects_invalid_dt() {
+        let mut ekf = EKFLocalizer::with_defaults();
+        let err = match ekf.estimate(&EKFMeasurement::new(0.0, 0.0), &EKFControl::zeros(), 0.0) {
+            Ok(_) => panic!("expected invalid dt to be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
     }
 }

--- a/src/localization/mod.rs
+++ b/src/localization/mod.rs
@@ -1,6 +1,7 @@
 // Localization algorithms module
 
 pub mod ekf;
+#[cfg(feature = "viz")]
 pub mod histogram_filter;
 pub mod particle_filter;
 pub mod unscented_kalman_filter;

--- a/src/localization/particle_filter.rs
+++ b/src/localization/particle_filter.rs
@@ -8,7 +8,9 @@ use rand::Rng;
 use rand_distr::{Distribution, Normal};
 use std::f64::consts::PI;
 
-use crate::common::{Point2D, StateEstimator};
+use crate::common::{
+    ControlInput, Obstacles, Point2D, RoboticsError, RoboticsResult, State2D, StateEstimator,
+};
 
 /// State representation for Particle Filter (x, y, yaw, velocity)
 pub type PFState = Vector4<f64>;
@@ -75,28 +77,82 @@ impl Default for ParticleFilterConfig {
     }
 }
 
+impl ParticleFilterConfig {
+    pub fn validate(&self) -> RoboticsResult<()> {
+        if self.n_particles == 0 {
+            return Err(RoboticsError::InvalidParameter(
+                "particle filter requires at least one particle".to_string(),
+            ));
+        }
+        if !self.resample_threshold.is_finite()
+            || self.resample_threshold < 0.0
+            || self.resample_threshold > 1.0
+        {
+            return Err(RoboticsError::InvalidParameter(
+                "particle filter resample_threshold must be within [0.0, 1.0]".to_string(),
+            ));
+        }
+        if !self.range_noise.is_finite() || self.range_noise <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "particle filter range_noise must be positive and finite".to_string(),
+            ));
+        }
+        if !self.velocity_noise.is_finite() || self.velocity_noise < 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "particle filter velocity_noise must be non-negative and finite".to_string(),
+            ));
+        }
+        if !self.yaw_rate_noise.is_finite() || self.yaw_rate_noise < 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "particle filter yaw_rate_noise must be non-negative and finite".to_string(),
+            ));
+        }
+        if !self.dt.is_finite() || self.dt <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "particle filter dt must be positive and finite".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
 /// Particle Filter for robot localization
 pub struct ParticleFilterLocalizer {
     particles: Vec<Particle>,
     config: ParticleFilterConfig,
     landmarks: Vec<Point2D>,
     last_control: PFControl,
+    state_estimate: PFState,
+    covariance_dyn: nalgebra::DMatrix<f64>,
 }
 
 impl ParticleFilterLocalizer {
     /// Create a new Particle Filter localizer
     pub fn new(config: ParticleFilterConfig) -> Self {
+        Self::try_new(config).expect(
+            "invalid particle filter configuration: particle count, noises, and dt must be valid",
+        )
+    }
+
+    /// Create a validated Particle Filter localizer
+    pub fn try_new(config: ParticleFilterConfig) -> RoboticsResult<Self> {
+        config.validate()?;
         let n = config.n_particles;
         let particles = (0..n)
             .map(|_| Particle::new(0.0, 0.0, 0.0, 0.0, n))
             .collect();
 
-        ParticleFilterLocalizer {
+        let mut pf = ParticleFilterLocalizer {
             particles,
             config,
             landmarks: Vec::new(),
             last_control: PFControl::zeros(),
-        }
+            state_estimate: PFState::zeros(),
+            covariance_dyn: nalgebra::DMatrix::zeros(4, 4),
+        };
+        pf.refresh_cache();
+        Ok(pf)
     }
 
     /// Create with default configuration
@@ -106,6 +162,18 @@ impl ParticleFilterLocalizer {
 
     /// Create with initial state
     pub fn with_initial_state(initial_state: PFState, config: ParticleFilterConfig) -> Self {
+        Self::try_with_initial_state(initial_state, config)
+            .expect("invalid particle filter initialization: state and configuration must be valid")
+    }
+
+    /// Create with validated initial state
+    pub fn try_with_initial_state(
+        initial_state: PFState,
+        config: ParticleFilterConfig,
+    ) -> RoboticsResult<Self> {
+        config.validate()?;
+        Self::validate_state(&initial_state)?;
+
         let mut rng = rand::thread_rng();
         let n = config.n_particles;
         let mut particles = Vec::with_capacity(n);
@@ -118,17 +186,42 @@ impl ParticleFilterLocalizer {
             particles.push(Particle::new(x, y, yaw, v, n));
         }
 
-        ParticleFilterLocalizer {
+        let mut pf = ParticleFilterLocalizer {
             particles,
             config,
             landmarks: Vec::new(),
             last_control: PFControl::zeros(),
-        }
+            state_estimate: PFState::zeros(),
+            covariance_dyn: nalgebra::DMatrix::zeros(4, 4),
+        };
+        pf.refresh_cache();
+        Ok(pf)
+    }
+
+    /// Create with common State2D type
+    pub fn with_initial_state_2d(
+        initial_state: State2D,
+        config: ParticleFilterConfig,
+    ) -> RoboticsResult<Self> {
+        Self::try_with_initial_state(initial_state.to_vector(), config)
     }
 
     /// Set landmarks for observation
     pub fn set_landmarks(&mut self, landmarks: Vec<Point2D>) {
+        self.try_set_landmarks(landmarks)
+            .expect("particle filter landmarks must contain only finite values")
+    }
+
+    /// Set landmarks with validation
+    pub fn try_set_landmarks(&mut self, landmarks: Vec<Point2D>) -> RoboticsResult<()> {
+        Self::validate_points(&landmarks, "particle filter landmarks")?;
         self.landmarks = landmarks;
+        Ok(())
+    }
+
+    /// Set landmarks from typed point container
+    pub fn set_landmarks_from_obstacles(&mut self, landmarks: &Obstacles) -> RoboticsResult<()> {
+        self.try_set_landmarks(landmarks.points.clone())
     }
 
     /// Get landmarks
@@ -143,14 +236,44 @@ impl ParticleFilterLocalizer {
 
     /// Prediction step: propagate particles with motion model
     pub fn predict_with_control(&mut self, control: &PFControl) {
+        self.try_predict_with_control(control)
+            .expect("invalid particle filter prediction input")
+    }
+
+    /// Prediction step with validation
+    pub fn try_predict_with_control(&mut self, control: &PFControl) -> RoboticsResult<()> {
+        Self::validate_control(control)?;
+
         let mut rng = rand::thread_rng();
-        let normal_v = Normal::new(0.0, self.config.velocity_noise.powi(2)).unwrap();
-        let normal_yaw = Normal::new(0.0, self.config.yaw_rate_noise.powi(2)).unwrap();
+        let normal_v = if self.config.velocity_noise > 0.0 {
+            Some(Normal::new(0.0, self.config.velocity_noise).map_err(|_| {
+                RoboticsError::InvalidParameter(
+                    "particle filter velocity_noise must be a valid standard deviation".to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+        let normal_yaw = if self.config.yaw_rate_noise > 0.0 {
+            Some(Normal::new(0.0, self.config.yaw_rate_noise).map_err(|_| {
+                RoboticsError::InvalidParameter(
+                    "particle filter yaw_rate_noise must be a valid standard deviation".to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
         let dt = self.config.dt;
 
         for particle in &mut self.particles {
-            let v_noise = normal_v.sample(&mut rng);
-            let yaw_noise = normal_yaw.sample(&mut rng);
+            let v_noise = normal_v
+                .as_ref()
+                .map(|normal| normal.sample(&mut rng))
+                .unwrap_or(0.0);
+            let yaw_noise = normal_yaw
+                .as_ref()
+                .map(|normal| normal.sample(&mut rng))
+                .unwrap_or(0.0);
 
             let v_noisy = control[0] + v_noise;
             let yaw_rate_noisy = control[1] + yaw_noise;
@@ -162,10 +285,23 @@ impl ParticleFilterLocalizer {
         }
 
         self.last_control = *control;
+        self.refresh_cache();
+        Ok(())
     }
 
     /// Update step: update weights based on observations
     pub fn update_with_observations(&mut self, observations: &PFMeasurement) {
+        self.try_update_with_observations(observations)
+            .expect("invalid particle filter observations")
+    }
+
+    /// Update step with validation
+    pub fn try_update_with_observations(
+        &mut self,
+        observations: &PFMeasurement,
+    ) -> RoboticsResult<()> {
+        Self::validate_observations(observations)?;
+
         for particle in &mut self.particles {
             let mut w = 1.0;
 
@@ -182,6 +318,8 @@ impl ParticleFilterLocalizer {
         }
 
         self.normalize_weights();
+        self.refresh_cache();
+        Ok(())
     }
 
     /// Resample particles if effective particle count is low
@@ -191,11 +329,46 @@ impl ParticleFilterLocalizer {
 
         if n_eff < threshold {
             self.resample_particles();
+            self.refresh_cache();
         }
     }
 
     /// Compute weighted state estimate
     pub fn estimate(&self) -> PFState {
+        self.state_estimate
+    }
+
+    /// Get current estimate as State2D
+    pub fn state_2d(&self) -> State2D {
+        State2D::new(
+            self.state_estimate[0],
+            self.state_estimate[1],
+            self.state_estimate[2],
+            self.state_estimate[3],
+        )
+    }
+
+    /// Compute state covariance
+    pub fn calc_covariance(&self) -> Matrix4<f64> {
+        Matrix4::from_fn(|i, j| self.covariance_dyn[(i, j)])
+    }
+
+    /// Predict with common control type
+    pub fn try_predict_input(&mut self, control: ControlInput) -> RoboticsResult<()> {
+        self.try_predict_with_control(&control.to_vector())
+    }
+
+    /// Full step with common control type returning State2D
+    pub fn try_step_state(
+        &mut self,
+        control: ControlInput,
+        observations: &PFMeasurement,
+    ) -> RoboticsResult<State2D> {
+        self.try_step(&control.to_vector(), observations)?;
+        Ok(self.state_2d())
+    }
+
+    fn compute_estimate(&self) -> PFState {
         let mut x_est = 0.0;
         let mut y_est = 0.0;
         let mut yaw_est = 0.0;
@@ -211,9 +384,7 @@ impl ParticleFilterLocalizer {
         Vector4::new(x_est, y_est, yaw_est, v_est)
     }
 
-    /// Compute state covariance
-    pub fn calc_covariance(&self) -> Matrix4<f64> {
-        let x_est = self.estimate();
+    fn compute_covariance(&self, x_est: &PFState) -> Matrix4<f64> {
         let mut cov = Matrix4::zeros();
 
         for particle in &self.particles {
@@ -247,6 +418,11 @@ impl ParticleFilterLocalizer {
         if sum_w > 0.0 {
             for particle in &mut self.particles {
                 particle.w /= sum_w;
+            }
+        } else {
+            let uniform_weight = 1.0 / self.particles.len() as f64;
+            for particle in &mut self.particles {
+                particle.w = uniform_weight;
             }
         }
     }
@@ -293,10 +469,72 @@ impl ParticleFilterLocalizer {
 
     /// Full estimation step (predict + update + resample)
     pub fn step(&mut self, control: &PFControl, observations: &PFMeasurement) -> PFState {
-        self.predict_with_control(control);
-        self.update_with_observations(observations);
+        self.try_step(control, observations)
+            .expect("invalid particle filter step input")
+    }
+
+    /// Full validated estimation step (predict + update + resample)
+    pub fn try_step(
+        &mut self,
+        control: &PFControl,
+        observations: &PFMeasurement,
+    ) -> RoboticsResult<PFState> {
+        self.try_predict_with_control(control)?;
+        self.try_update_with_observations(observations)?;
         self.resample();
-        self.estimate()
+        Ok(self.estimate())
+    }
+
+    fn refresh_cache(&mut self) {
+        self.state_estimate = self.compute_estimate();
+        let covariance = self.compute_covariance(&self.state_estimate);
+        self.covariance_dyn = nalgebra::DMatrix::from_fn(4, 4, |i, j| covariance[(i, j)]);
+    }
+
+    fn validate_state(state: &PFState) -> RoboticsResult<()> {
+        if state.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "particle filter state must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_control(control: &PFControl) -> RoboticsResult<()> {
+        if control.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "particle filter control input must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_points(points: &[Point2D], label: &str) -> RoboticsResult<()> {
+        if points
+            .iter()
+            .any(|point| !point.x.is_finite() || !point.y.is_finite())
+        {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "{label} must contain only finite values"
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn validate_observations(observations: &PFMeasurement) -> RoboticsResult<()> {
+        if observations
+            .iter()
+            .any(|(d, x, y)| !d.is_finite() || !x.is_finite() || !y.is_finite() || *d < 0.0)
+        {
+            return Err(RoboticsError::InvalidParameter(
+                "particle filter observations must have finite, non-negative distances".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -315,14 +553,11 @@ impl StateEstimator for ParticleFilterLocalizer {
     }
 
     fn get_state(&self) -> &Self::State {
-        // Note: We need to return a reference, but estimate() computes on the fly
-        // This is a limitation of the trait design
-        // For now, we'll use a workaround
-        unimplemented!("Use estimate() method instead for ParticleFilter")
+        &self.state_estimate
     }
 
     fn get_covariance(&self) -> Option<&nalgebra::DMatrix<f64>> {
-        None // Use calc_covariance() for fixed-size covariance
+        Some(&self.covariance_dyn)
     }
 }
 
@@ -397,5 +632,65 @@ mod tests {
         // Covariance should be positive semi-definite (diagonal > 0)
         assert!(cov[(0, 0)] >= 0.0);
         assert!(cov[(1, 1)] >= 0.0);
+    }
+
+    #[test]
+    fn test_particle_filter_try_new_rejects_invalid_config() {
+        let config = ParticleFilterConfig {
+            n_particles: 0,
+            ..Default::default()
+        };
+
+        let err = match ParticleFilterLocalizer::try_new(config) {
+            Ok(_) => panic!("expected invalid config to be rejected"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_particle_filter_with_initial_state_2d() {
+        let pf = ParticleFilterLocalizer::with_initial_state_2d(
+            State2D::new(1.0, 2.0, 0.3, 0.4),
+            ParticleFilterConfig::default(),
+        )
+        .unwrap();
+
+        let state = pf.state_2d();
+        assert!((state.x - 1.0).abs() < 2.0);
+        assert!((state.y - 2.0).abs() < 2.0);
+    }
+
+    #[test]
+    fn test_particle_filter_set_landmarks_from_obstacles() {
+        let mut pf = ParticleFilterLocalizer::with_defaults();
+        let landmarks =
+            Obstacles::from_points(vec![Point2D::new(1.0, 1.0), Point2D::new(2.0, 2.0)]);
+
+        pf.set_landmarks_from_obstacles(&landmarks).unwrap();
+        assert_eq!(pf.get_landmarks().len(), 2);
+    }
+
+    #[test]
+    fn test_particle_filter_try_step_state() {
+        let mut pf = ParticleFilterLocalizer::with_defaults();
+        let state = pf
+            .try_step_state(ControlInput::new(1.0, 0.1), &vec![(10.0, 10.0, 0.0)])
+            .unwrap();
+
+        assert!(state.x.is_finite());
+        assert!(state.y.is_finite());
+    }
+
+    #[test]
+    fn test_particle_filter_state_estimator_trait_access() {
+        let mut pf = ParticleFilterLocalizer::with_defaults();
+        pf.predict(&PFControl::new(1.0, 0.0), 0.1);
+        pf.update(&vec![(10.0, 0.0, 0.0)]);
+
+        let state = pf.get_state();
+        let covariance = pf.get_covariance().unwrap();
+        assert!(state[0].is_finite());
+        assert_eq!(covariance.nrows(), 4);
     }
 }

--- a/src/localization/unscented_kalman_filter.rs
+++ b/src/localization/unscented_kalman_filter.rs
@@ -8,7 +8,9 @@ use nalgebra::{DMatrix, DVector, Matrix2, Matrix4, Vector2, Vector4};
 use rand::Rng;
 use std::f64::consts::PI;
 
-use crate::common::StateEstimator;
+use crate::common::{
+    ControlInput, Point2D, RoboticsError, RoboticsResult, State2D, StateEstimator,
+};
 
 /// State representation for UKF (x, y, yaw, velocity)
 pub type UKFState = Vector4<f64>;
@@ -37,6 +39,28 @@ impl Default for UKFParams {
             beta: 2.0,
             kappa: 0.0,
         }
+    }
+}
+
+impl UKFParams {
+    pub fn validate(&self) -> RoboticsResult<()> {
+        if !self.alpha.is_finite() || self.alpha <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF alpha must be positive and finite".to_string(),
+            ));
+        }
+        if !self.beta.is_finite() || self.beta < 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF beta must be non-negative and finite".to_string(),
+            ));
+        }
+        if !self.kappa.is_finite() {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF kappa must be finite".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -72,6 +96,44 @@ impl Default for UKFConfig {
     }
 }
 
+impl UKFConfig {
+    pub fn validate(&self) -> RoboticsResult<()> {
+        self.params.validate()?;
+
+        if self.process_noise.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF process noise must contain only finite values".to_string(),
+            ));
+        }
+        if self.process_noise.iter().any(|value| *value < 0.0) {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF process noise entries must be non-negative".to_string(),
+            ));
+        }
+        if self
+            .observation_noise
+            .iter()
+            .any(|value| !value.is_finite())
+        {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF observation noise must contain only finite values".to_string(),
+            ));
+        }
+        if self.observation_noise.iter().any(|value| *value < 0.0) {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF observation noise entries must be non-negative".to_string(),
+            ));
+        }
+        if !self.dt.is_finite() || self.dt <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF dt must be positive and finite".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
 /// UKF weights for mean and covariance computation
 #[derive(Debug, Clone)]
 pub struct UKFWeights {
@@ -86,30 +148,54 @@ pub struct UKFWeights {
 impl UKFWeights {
     /// Create weights for given state dimension and parameters
     pub fn new(nx: usize, params: &UKFParams) -> Self {
+        Self::try_new(nx, params)
+            .expect("invalid UKF params: weights must be numerically well-defined")
+    }
+
+    /// Create validated weights for given state dimension and parameters
+    pub fn try_new(nx: usize, params: &UKFParams) -> RoboticsResult<Self> {
+        params.validate()?;
+        if nx == 0 {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF state dimension must be greater than zero".to_string(),
+            ));
+        }
+
         let lambda = params.alpha.powi(2) * (nx as f64 + params.kappa) - nx as f64;
+        let scale = lambda + nx as f64;
+        if !scale.is_finite() || scale <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF scaling parameters produce a non-positive sigma spread".to_string(),
+            ));
+        }
         let n_sigma = 2 * nx + 1;
 
         let mut wm = Vec::with_capacity(n_sigma);
         let mut wc = Vec::with_capacity(n_sigma);
 
         // First weight (mean point)
-        wm.push(lambda / (lambda + nx as f64));
-        wc.push((lambda / (lambda + nx as f64)) + (1.0 - params.alpha.powi(2) + params.beta));
+        wm.push(lambda / scale);
+        wc.push((lambda / scale) + (1.0 - params.alpha.powi(2) + params.beta));
 
         // Remaining weights (sigma points)
-        let weight = 1.0 / (2.0 * (nx as f64 + lambda));
+        let weight = 1.0 / (2.0 * scale);
         for _ in 0..(2 * nx) {
             wm.push(weight);
             wc.push(weight);
         }
 
-        let gamma = (nx as f64 + lambda).sqrt();
+        let gamma = scale.sqrt();
+        if !gamma.is_finite() {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF gamma must be finite".to_string(),
+            ));
+        }
 
-        Self {
+        Ok(Self {
             wm: DVector::from_vec(wm),
             wc: DVector::from_vec(wc),
             gamma,
-        }
+        })
     }
 }
 
@@ -125,6 +211,8 @@ pub struct UKFLocalizer {
     r: Matrix2<f64>,
     /// UKF weights
     weights: UKFWeights,
+    /// Dynamic covariance cache for trait-based access
+    covariance_dyn: DMatrix<f64>,
     /// Configuration
     config: UKFConfig,
     /// Last control input
@@ -134,20 +222,30 @@ pub struct UKFLocalizer {
 impl UKFLocalizer {
     /// Create a new UKF localizer
     pub fn new(config: UKFConfig) -> Self {
-        let weights = UKFWeights::new(4, &config.params);
+        Self::try_new(config)
+            .expect("invalid UKF configuration: parameters, noise values, and dt must be valid")
+    }
+
+    /// Create a validated UKF localizer
+    pub fn try_new(config: UKFConfig) -> RoboticsResult<Self> {
+        config.validate()?;
+        let weights = UKFWeights::try_new(4, &config.params)?;
 
         let q = Matrix4::from_diagonal(&config.process_noise);
         let r = Matrix2::from_diagonal(&config.observation_noise);
 
-        Self {
+        let mut ukf = Self {
             x: UKFState::zeros(),
             p: Matrix4::identity(),
             q,
             r,
             weights,
+            covariance_dyn: DMatrix::identity(4, 4),
             config,
             last_control: UKFControl::zeros(),
-        }
+        };
+        ukf.refresh_covariance_cache();
+        Ok(ukf)
     }
 
     /// Create with default configuration
@@ -157,14 +255,38 @@ impl UKFLocalizer {
 
     /// Create with initial state
     pub fn with_initial_state(initial_state: UKFState, config: UKFConfig) -> Self {
-        let mut ukf = Self::new(config);
+        Self::try_with_initial_state(initial_state, config)
+            .expect("invalid UKF initialization: state and configuration must be valid")
+    }
+
+    /// Create with validated initial state
+    pub fn try_with_initial_state(
+        initial_state: UKFState,
+        config: UKFConfig,
+    ) -> RoboticsResult<Self> {
+        Self::validate_state(&initial_state)?;
+        let mut ukf = Self::try_new(config)?;
         ukf.x = initial_state;
-        ukf
+        ukf.refresh_covariance_cache();
+        Ok(ukf)
+    }
+
+    /// Create with common State2D type
+    pub fn with_initial_state_2d(
+        initial_state: State2D,
+        config: UKFConfig,
+    ) -> RoboticsResult<Self> {
+        Self::try_with_initial_state(initial_state.to_vector(), config)
     }
 
     /// Get current state estimate
     pub fn estimate(&self) -> UKFState {
         self.x
+    }
+
+    /// Get current estimate as State2D
+    pub fn state_2d(&self) -> State2D {
+        State2D::new(self.x[0], self.x[1], self.x[2], self.x[3])
     }
 
     /// Get state covariance
@@ -311,6 +433,14 @@ impl UKFLocalizer {
 
     /// Prediction step with control input
     pub fn predict_with_control(&mut self, control: &UKFControl) {
+        self.try_predict_with_control(control)
+            .expect("invalid UKF prediction input")
+    }
+
+    /// Prediction step with validation
+    pub fn try_predict_with_control(&mut self, control: &UKFControl) -> RoboticsResult<()> {
+        Self::validate_control(control)?;
+
         // Generate sigma points
         let sigma = self.generate_sigma_points(&self.x, &self.p);
 
@@ -328,10 +458,20 @@ impl UKFLocalizer {
         self.x = Vector4::new(x_pred[0], x_pred[1], x_pred[2], x_pred[3]);
         self.p = Matrix4::from_fn(|i, j| p_pred[(i, j)]);
         self.last_control = *control;
+        self.refresh_covariance_cache();
+        Ok(())
     }
 
     /// Update step with measurement
     pub fn update_with_measurement(&mut self, z: &UKFMeasurement) {
+        self.try_update_with_measurement(z)
+            .expect("invalid UKF update input")
+    }
+
+    /// Update step with validation
+    pub fn try_update_with_measurement(&mut self, z: &UKFMeasurement) -> RoboticsResult<()> {
+        Self::validate_measurement(z)?;
+
         // Generate sigma points from current state
         let sigma = self.generate_sigma_points(&self.x, &self.p);
 
@@ -353,10 +493,9 @@ impl UKFLocalizer {
         let pxz = self.calc_cross_covariance(&sigma_dyn, &x_mean, &z_sigma, &z_pred);
 
         // Kalman gain
-        let s_inv = s
-            .clone()
-            .try_inverse()
-            .unwrap_or_else(|| DMatrix::identity(2, 2));
+        let s_inv = s.clone().try_inverse().ok_or_else(|| {
+            RoboticsError::NumericalError("Failed to invert UKF innovation covariance".to_string())
+        })?;
         let k = &pxz * &s_inv;
 
         // Innovation
@@ -370,13 +509,35 @@ impl UKFLocalizer {
         let p_dyn = DMatrix::from_fn(4, 4, |i, j| self.p[(i, j)]);
         let p_update = &p_dyn - &k * &s * k.transpose();
         self.p = Matrix4::from_fn(|i, j| p_update[(i, j)]);
+        self.refresh_covariance_cache();
+        Ok(())
     }
 
     /// Full estimation step (predict + update)
     pub fn step(&mut self, control: &UKFControl, measurement: &UKFMeasurement) -> UKFState {
-        self.predict_with_control(control);
-        self.update_with_measurement(measurement);
-        self.x
+        self.try_step(control, measurement)
+            .expect("invalid UKF step input or numerical failure")
+    }
+
+    /// Full validated estimation step (predict + update)
+    pub fn try_step(
+        &mut self,
+        control: &UKFControl,
+        measurement: &UKFMeasurement,
+    ) -> RoboticsResult<UKFState> {
+        self.try_predict_with_control(control)?;
+        self.try_update_with_measurement(measurement)?;
+        Ok(self.x)
+    }
+
+    /// Full estimation step using common crate types
+    pub fn estimate_state(
+        &mut self,
+        control: ControlInput,
+        measurement: Point2D,
+    ) -> RoboticsResult<State2D> {
+        self.try_step(&control.to_vector(), &measurement.to_vector())?;
+        Ok(self.state_2d())
     }
 
     /// Calculate position uncertainty (2-sigma ellipse parameters)
@@ -395,6 +556,40 @@ impl UKFLocalizer {
         let angle = eigen.eigenvectors[(1, big_idx)].atan2(eigen.eigenvectors[(0, big_idx)]);
 
         (a, b, angle)
+    }
+
+    fn refresh_covariance_cache(&mut self) {
+        self.covariance_dyn = DMatrix::from_fn(4, 4, |i, j| self.p[(i, j)]);
+    }
+
+    fn validate_state(state: &UKFState) -> RoboticsResult<()> {
+        if state.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF state must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_control(control: &UKFControl) -> RoboticsResult<()> {
+        if control.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF control input must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_measurement(measurement: &UKFMeasurement) -> RoboticsResult<()> {
+        if measurement.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "UKF measurement must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -416,7 +611,7 @@ impl StateEstimator for UKFLocalizer {
     }
 
     fn get_covariance(&self) -> Option<&nalgebra::DMatrix<f64>> {
-        None // Use covariance() method for fixed-size covariance
+        Some(&self.covariance_dyn)
     }
 }
 
@@ -697,6 +892,55 @@ mod tests {
 
         let state = ukf.get_state();
         assert!(state[0].is_finite());
+    }
+
+    #[test]
+    fn test_ukf_try_new_rejects_invalid_config() {
+        let config = UKFConfig {
+            dt: 0.0,
+            ..Default::default()
+        };
+
+        let err = match UKFLocalizer::try_new(config) {
+            Ok(_) => panic!("expected invalid config to be rejected"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_ukf_with_initial_state_2d() {
+        let ukf = UKFLocalizer::with_initial_state_2d(
+            State2D::new(1.0, 2.0, 0.3, 0.4),
+            UKFConfig::default(),
+        )
+        .unwrap();
+
+        let state = ukf.state_2d();
+        assert_eq!(state.x, 1.0);
+        assert_eq!(state.y, 2.0);
+        assert_eq!(state.yaw, 0.3);
+        assert_eq!(state.v, 0.4);
+    }
+
+    #[test]
+    fn test_ukf_estimate_state_with_common_types() {
+        let mut ukf = UKFLocalizer::with_defaults();
+        let state = ukf
+            .estimate_state(ControlInput::new(1.0, 0.1), Point2D::new(0.1, 0.01))
+            .unwrap();
+
+        assert!(state.x.is_finite());
+        assert!(state.y.is_finite());
+    }
+
+    #[test]
+    fn test_ukf_get_covariance_trait_access() {
+        let ukf = UKFLocalizer::with_defaults();
+        let covariance = ukf.get_covariance().unwrap();
+
+        assert_eq!(covariance.nrows(), 4);
+        assert_eq!(covariance.ncols(), 4);
     }
 
     #[test]

--- a/src/mapping/mod.rs
+++ b/src/mapping/mod.rs
@@ -1,6 +1,7 @@
 // Mapping algorithms module
 
 pub mod gaussian_grid_map;
+#[cfg(feature = "viz")]
 pub mod ndt;
 pub mod ray_casting_grid_map;
 

--- a/src/path_planning/a_star.rs
+++ b/src/path_planning/a_star.rs
@@ -6,7 +6,7 @@
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 
-use crate::common::{Path2D, PathPlanner, Point2D, RoboticsError};
+use crate::common::{Obstacles, Path2D, PathPlanner, Point2D, RoboticsError, RoboticsResult};
 use crate::utils::{GridMap, Node};
 
 /// Configuration for A* planner
@@ -27,6 +27,31 @@ impl Default for AStarConfig {
             robot_radius: 0.5,
             heuristic_weight: 1.0,
         }
+    }
+}
+
+impl AStarConfig {
+    pub fn validate(&self) -> RoboticsResult<()> {
+        if !self.resolution.is_finite() || self.resolution <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "resolution must be positive and finite, got {}",
+                self.resolution
+            )));
+        }
+        if !self.robot_radius.is_finite() || self.robot_radius < 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "robot_radius must be non-negative and finite, got {}",
+                self.robot_radius
+            )));
+        }
+        if !self.heuristic_weight.is_finite() || self.heuristic_weight <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "heuristic_weight must be positive and finite, got {}",
+                self.heuristic_weight
+            )));
+        }
+
+        Ok(())
     }
 }
 
@@ -74,14 +99,22 @@ pub struct AStarPlanner {
 impl AStarPlanner {
     /// Create a new A* planner with obstacle positions
     pub fn new(ox: &[f64], oy: &[f64], config: AStarConfig) -> Self {
-        let grid_map = GridMap::new(ox, oy, config.resolution, config.robot_radius);
+        Self::try_new(ox, oy, config).expect(
+            "invalid A* planner input: obstacle list must be non-empty and valid, and config values must be positive/finite",
+        )
+    }
+
+    /// Create a validated A* planner with obstacle positions
+    pub fn try_new(ox: &[f64], oy: &[f64], config: AStarConfig) -> RoboticsResult<Self> {
+        config.validate()?;
+        let grid_map = GridMap::try_new(ox, oy, config.resolution, config.robot_radius)?;
         let motion = Self::get_motion_model();
 
-        AStarPlanner {
+        Ok(AStarPlanner {
             grid_map,
             config,
             motion,
-        }
+        })
     }
 
     /// Create from obstacle x/y vectors with default config
@@ -94,15 +127,38 @@ impl AStarPlanner {
         Self::new(ox, oy, config)
     }
 
+    /// Create a validated A* planner from typed obstacle points
+    pub fn from_obstacle_points(
+        obstacles: &Obstacles,
+        config: AStarConfig,
+    ) -> RoboticsResult<Self> {
+        config.validate()?;
+        let grid_map = GridMap::from_obstacles(obstacles, config.resolution, config.robot_radius)?;
+        let motion = Self::get_motion_model();
+
+        Ok(AStarPlanner {
+            grid_map,
+            config,
+            motion,
+        })
+    }
+
     /// Plan a path returning (rx, ry) vectors (legacy interface)
     pub fn planning(&self, sx: f64, sy: f64, gx: f64, gy: f64) -> Option<(Vec<f64>, Vec<f64>)> {
-        let start = Point2D::new(sx, sy);
-        let goal = Point2D::new(gx, gy);
-
-        match self.plan(start, goal) {
+        match self.plan_xy(sx, sy, gx, gy) {
             Ok(path) => Some((path.x_coords(), path.y_coords())),
             Err(_) => None,
         }
+    }
+
+    /// Plan a path without requiring the PathPlanner trait in scope
+    pub fn plan(&self, start: Point2D, goal: Point2D) -> RoboticsResult<Path2D> {
+        self.plan_impl(start, goal)
+    }
+
+    /// Plan a path from raw coordinates without requiring the PathPlanner trait in scope
+    pub fn plan_xy(&self, sx: f64, sy: f64, gx: f64, gy: f64) -> RoboticsResult<Path2D> {
+        self.plan_impl(Point2D::new(sx, sy), Point2D::new(gx, gy))
     }
 
     /// Get reference to the grid map
@@ -135,8 +191,8 @@ impl AStarPlanner {
         while let Some(index) = current_index {
             let node = &node_storage[index];
             points.push(Point2D::new(
-                self.grid_map.calc_grid_position(node.x),
-                self.grid_map.calc_grid_position(node.y),
+                self.grid_map.calc_x_position(node.x),
+                self.grid_map.calc_y_position(node.y),
             ));
             current_index = node.parent_index;
         }
@@ -144,14 +200,26 @@ impl AStarPlanner {
         points.reverse();
         Path2D::from_points(points)
     }
-}
 
-impl PathPlanner for AStarPlanner {
-    fn plan(&self, start: Point2D, goal: Point2D) -> Result<Path2D, RoboticsError> {
-        let start_x = self.grid_map.calc_xy_index(start.x);
-        let start_y = self.grid_map.calc_xy_index(start.y);
-        let goal_x = self.grid_map.calc_xy_index(goal.x);
-        let goal_y = self.grid_map.calc_xy_index(goal.y);
+    fn ensure_query_is_valid(&self, x: i32, y: i32, label: &str) -> RoboticsResult<()> {
+        if self.grid_map.is_valid(x, y) {
+            return Ok(());
+        }
+
+        Err(RoboticsError::PlanningError(format!(
+            "{} position is invalid",
+            label
+        )))
+    }
+
+    fn plan_impl(&self, start: Point2D, goal: Point2D) -> RoboticsResult<Path2D> {
+        let start_x = self.grid_map.calc_x_index(start.x);
+        let start_y = self.grid_map.calc_y_index(start.y);
+        let goal_x = self.grid_map.calc_x_index(goal.x);
+        let goal_y = self.grid_map.calc_y_index(goal.y);
+
+        self.ensure_query_is_valid(start_x, start_y, "Start")?;
+        self.ensure_query_is_valid(goal_x, goal_y, "Goal")?;
 
         let mut open_set = BinaryHeap::new();
         let mut closed_set = HashMap::new();
@@ -219,9 +287,17 @@ impl PathPlanner for AStarPlanner {
     }
 }
 
+impl PathPlanner for AStarPlanner {
+    fn plan(&self, start: Point2D, goal: Point2D) -> Result<Path2D, RoboticsError> {
+        self.plan_impl(start, goal)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::common::Obstacles;
 
     fn create_simple_obstacles() -> (Vec<f64>, Vec<f64>) {
         let mut ox = Vec::new();
@@ -274,5 +350,56 @@ mod tests {
         let (rx, ry) = result.unwrap();
         assert!(!rx.is_empty());
         assert_eq!(rx.len(), ry.len());
+    }
+
+    #[test]
+    fn test_a_star_from_obstacle_points() {
+        let (ox, oy) = create_simple_obstacles();
+        let obstacles = Obstacles::try_from_xy(&ox, &oy).unwrap();
+        let planner =
+            AStarPlanner::from_obstacle_points(&obstacles, AStarConfig::default()).unwrap();
+
+        let path = planner.plan_xy(2.0, 2.0, 8.0, 8.0).unwrap();
+        assert!(!path.is_empty());
+    }
+
+    #[test]
+    fn test_a_star_try_new_rejects_invalid_config() {
+        let (ox, oy) = create_simple_obstacles();
+        let config = AStarConfig {
+            heuristic_weight: 0.0,
+            ..Default::default()
+        };
+
+        let err = match AStarPlanner::try_new(&ox, &oy, config) {
+            Ok(_) => panic!("expected invalid config to be rejected"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_a_star_preserves_asymmetric_world_coordinates() {
+        let mut obstacles = Obstacles::new();
+
+        for x in 10..=20 {
+            obstacles.push(Point2D::new(x as f64, -4.0));
+            obstacles.push(Point2D::new(x as f64, 6.0));
+        }
+        for y in -4..=6 {
+            obstacles.push(Point2D::new(10.0, y as f64));
+            obstacles.push(Point2D::new(20.0, y as f64));
+        }
+
+        let planner =
+            AStarPlanner::from_obstacle_points(&obstacles, AStarConfig::default()).unwrap();
+        let path = planner.plan_xy(12.0, -2.0, 18.0, 4.0).unwrap();
+
+        let first = path.points.first().unwrap();
+        let last = path.points.last().unwrap();
+        assert!((first.x - 12.0).abs() < 1e-6);
+        assert!((first.y + 2.0).abs() < 1e-6);
+        assert!((last.x - 18.0).abs() < 1e-6);
+        assert!((last.y - 4.0).abs() < 1e-6);
     }
 }

--- a/src/path_planning/dwa.rs
+++ b/src/path_planning/dwa.rs
@@ -6,7 +6,9 @@
 
 use nalgebra::{Vector2, Vector4, Vector5};
 
-use crate::common::{ControlInput, Path2D, Point2D, State2D};
+use crate::common::{
+    ControlInput, Obstacles, Path2D, Point2D, RoboticsError, RoboticsResult, State2D,
+};
 
 /// Robot state for DWA: [x, y, yaw, v, omega]
 pub type DWAState = Vector5<f64>;
@@ -65,6 +67,81 @@ impl Default for DWAConfig {
             robot_radius: 1.0,
             goal_threshold: 1.0,
         }
+    }
+}
+
+impl DWAConfig {
+    pub fn validate(&self) -> RoboticsResult<()> {
+        if !self.max_speed.is_finite()
+            || !self.min_speed.is_finite()
+            || self.min_speed > self.max_speed
+        {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA speed range must be finite and min_speed must be <= max_speed".to_string(),
+            ));
+        }
+        if !self.max_yaw_rate.is_finite() || self.max_yaw_rate <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA max_yaw_rate must be positive and finite".to_string(),
+            ));
+        }
+        if !self.max_accel.is_finite() || self.max_accel <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA max_accel must be positive and finite".to_string(),
+            ));
+        }
+        if !self.max_delta_yaw_rate.is_finite() || self.max_delta_yaw_rate <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA max_delta_yaw_rate must be positive and finite".to_string(),
+            ));
+        }
+        if !self.v_resolution.is_finite() || self.v_resolution <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA v_resolution must be positive and finite".to_string(),
+            ));
+        }
+        if !self.yaw_rate_resolution.is_finite() || self.yaw_rate_resolution <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA yaw_rate_resolution must be positive and finite".to_string(),
+            ));
+        }
+        if !self.dt.is_finite() || self.dt <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA dt must be positive and finite".to_string(),
+            ));
+        }
+        if !self.predict_time.is_finite() || self.predict_time <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA predict_time must be positive and finite".to_string(),
+            ));
+        }
+        if !self.to_goal_cost_gain.is_finite() || self.to_goal_cost_gain < 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA to_goal_cost_gain must be non-negative and finite".to_string(),
+            ));
+        }
+        if !self.speed_cost_gain.is_finite() || self.speed_cost_gain < 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA speed_cost_gain must be non-negative and finite".to_string(),
+            ));
+        }
+        if !self.obstacle_cost_gain.is_finite() || self.obstacle_cost_gain < 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA obstacle_cost_gain must be non-negative and finite".to_string(),
+            ));
+        }
+        if !self.robot_radius.is_finite() || self.robot_radius < 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA robot_radius must be non-negative and finite".to_string(),
+            ));
+        }
+        if !self.goal_threshold.is_finite() || self.goal_threshold < 0.0 {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA goal_threshold must be non-negative and finite".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -131,13 +208,21 @@ pub struct DWAPlanner {
 impl DWAPlanner {
     /// Create a new DWA planner
     pub fn new(config: DWAConfig) -> Self {
-        Self {
+        Self::try_new(config).expect(
+            "invalid DWA configuration: planner parameters must be finite and within supported ranges",
+        )
+    }
+
+    /// Create a validated DWA planner
+    pub fn try_new(config: DWAConfig) -> RoboticsResult<Self> {
+        config.validate()?;
+        Ok(Self {
             config,
             state: DWAState::zeros(),
             goal: Point2D::origin(),
             obstacles: Vec::new(),
             best_trajectory: Trajectory::new(),
-        }
+        })
     }
 
     /// Create with default configuration
@@ -147,12 +232,26 @@ impl DWAPlanner {
 
     /// Set current state
     pub fn set_state(&mut self, state: DWAState) {
+        self.try_set_state(state)
+            .expect("DWA state must contain only finite values")
+    }
+
+    /// Set current state with validation
+    pub fn try_set_state(&mut self, state: DWAState) -> RoboticsResult<()> {
+        Self::validate_state(&state)?;
         self.state = state;
+        Ok(())
     }
 
     /// Set state from State2D
     pub fn set_state_from_2d(&mut self, state: &State2D, omega: f64) {
-        self.state = DWAState::new(state.x, state.y, state.yaw, state.v, omega);
+        self.try_set_state_from_2d(state, omega)
+            .expect("DWA state must contain only finite values")
+    }
+
+    /// Set state from State2D with validation
+    pub fn try_set_state_from_2d(&mut self, state: &State2D, omega: f64) -> RoboticsResult<()> {
+        self.try_set_state(DWAState::new(state.x, state.y, state.yaw, state.v, omega))
     }
 
     /// Get current state
@@ -160,27 +259,61 @@ impl DWAPlanner {
         &self.state
     }
 
+    /// Get current state as State2D
+    pub fn state_2d(&self) -> State2D {
+        State2D::new(self.state[0], self.state[1], self.state[2], self.state[3])
+    }
+
     /// Set goal position
     pub fn set_goal(&mut self, goal: Point2D) {
+        self.try_set_goal(goal)
+            .expect("DWA goal must contain only finite values")
+    }
+
+    /// Set goal position with validation
+    pub fn try_set_goal(&mut self, goal: Point2D) -> RoboticsResult<()> {
+        Self::validate_goal(&goal)?;
         self.goal = goal;
+        Ok(())
     }
 
     /// Set obstacles
     pub fn set_obstacles(&mut self, obstacles: Vec<Point2D>) {
+        self.try_set_obstacles(obstacles)
+            .expect("DWA obstacles must contain only finite values")
+    }
+
+    /// Set obstacles with validation
+    pub fn try_set_obstacles(&mut self, obstacles: Vec<Point2D>) -> RoboticsResult<()> {
+        Self::validate_obstacles(&obstacles)?;
         self.obstacles = obstacles;
+        Ok(())
     }
 
     /// Set obstacles from tuples
     pub fn set_obstacles_from_tuples(&mut self, obstacles: &[(f64, f64)]) {
-        self.obstacles = obstacles
-            .iter()
-            .map(|(x, y)| Point2D::new(*x, *y))
-            .collect();
+        self.try_set_obstacles(
+            obstacles
+                .iter()
+                .map(|(x, y)| Point2D::new(*x, *y))
+                .collect(),
+        )
+        .expect("DWA obstacles must contain only finite values")
+    }
+
+    /// Set obstacles from typed obstacle container
+    pub fn set_obstacles_from_obstacles(&mut self, obstacles: &Obstacles) -> RoboticsResult<()> {
+        self.try_set_obstacles(obstacles.points.clone())
     }
 
     /// Get best trajectory from last planning
     pub fn get_best_trajectory(&self) -> &Trajectory {
         &self.best_trajectory
+    }
+
+    /// Get best trajectory as a path
+    pub fn best_path(&self) -> Path2D {
+        self.best_trajectory.to_path()
     }
 
     /// Get configuration
@@ -310,6 +443,18 @@ impl DWAPlanner {
 
     /// Plan one step: find best control
     pub fn plan_step(&mut self) -> DWAControl {
+        self.try_plan_step().expect(
+            "invalid DWA planning state: configuration, state, goal, and obstacles must be valid",
+        )
+    }
+
+    /// Plan one step with validation
+    pub fn try_plan_step(&mut self) -> RoboticsResult<DWAControl> {
+        self.config.validate()?;
+        Self::validate_state(&self.state)?;
+        Self::validate_goal(&self.goal)?;
+        Self::validate_obstacles(&self.obstacles)?;
+
         let config = &self.config;
         let dw = self.calc_dynamic_window();
 
@@ -345,15 +490,27 @@ impl DWAPlanner {
             v += config.v_resolution;
         }
 
+        if best_trajectory.states.is_empty() {
+            return Err(RoboticsError::PlanningError(
+                "DWA failed to find an admissible trajectory".to_string(),
+            ));
+        }
+
         self.best_trajectory = best_trajectory;
-        self.best_trajectory.control
+        Ok(self.best_trajectory.control)
     }
 
     /// Execute one control step and update state
     pub fn step(&mut self) -> DWAControl {
-        let control = self.plan_step();
+        self.try_step()
+            .expect("invalid DWA step: planning prerequisites must be satisfied")
+    }
+
+    /// Execute one validated control step and update state
+    pub fn try_step(&mut self) -> RoboticsResult<DWAControl> {
+        let control = self.try_plan_step()?;
         self.state = self.motion(&self.state, &control);
-        control
+        Ok(control)
     }
 
     /// Check if goal is reached
@@ -372,22 +529,67 @@ impl DWAPlanner {
 
     /// Run full navigation to goal
     pub fn navigate_to_goal(&mut self, max_steps: usize) -> Vec<DWAState> {
+        self.try_navigate_to_goal(max_steps)
+            .expect("invalid DWA navigation: planning prerequisites must be satisfied")
+    }
+
+    /// Run full validated navigation to goal
+    pub fn try_navigate_to_goal(&mut self, max_steps: usize) -> RoboticsResult<Vec<DWAState>> {
         let mut path = vec![self.state];
 
         for _ in 0..max_steps {
             if self.is_goal_reached() {
                 break;
             }
-            self.step();
+            self.try_step()?;
             path.push(self.state);
         }
 
-        path
+        Ok(path)
+    }
+
+    /// Plan one step and convert directly to common ControlInput
+    pub fn try_plan_input(&mut self) -> RoboticsResult<ControlInput> {
+        let control = self.try_plan_step()?;
+        Ok(Self::control_to_input(&control))
     }
 
     /// Convert control to ControlInput
     pub fn control_to_input(control: &DWAControl) -> ControlInput {
         ControlInput::new(control[0], control[1])
+    }
+
+    fn validate_state(state: &DWAState) -> RoboticsResult<()> {
+        if state.iter().any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA state must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_goal(goal: &Point2D) -> RoboticsResult<()> {
+        if !goal.x.is_finite() || !goal.y.is_finite() {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA goal must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_obstacles(obstacles: &[Point2D]) -> RoboticsResult<()> {
+        if obstacles
+            .iter()
+            .any(|obstacle| !obstacle.x.is_finite() || !obstacle.y.is_finite())
+        {
+            return Err(RoboticsError::InvalidParameter(
+                "DWA obstacles must contain only finite values".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -697,5 +899,62 @@ mod tests {
         let next = motion(x, u, 0.1);
 
         assert!(next[0] > 0.0);
+    }
+
+    #[test]
+    fn test_dwa_try_new_rejects_invalid_config() {
+        let config = DWAConfig {
+            dt: 0.0,
+            ..Default::default()
+        };
+
+        let err = match DWAPlanner::try_new(config) {
+            Ok(_) => panic!("expected invalid config to be rejected"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_dwa_state_2d_matches_internal_state() {
+        let mut dwa = DWAPlanner::with_defaults();
+        dwa.set_state(DWAState::new(1.0, 2.0, 0.3, 0.4, 0.1));
+
+        let state = dwa.state_2d();
+        assert_eq!(state.x, 1.0);
+        assert_eq!(state.y, 2.0);
+        assert_eq!(state.yaw, 0.3);
+        assert_eq!(state.v, 0.4);
+    }
+
+    #[test]
+    fn test_dwa_set_obstacles_from_obstacles() {
+        let mut dwa = DWAPlanner::with_defaults();
+        let obstacles =
+            Obstacles::from_points(vec![Point2D::new(1.0, 1.0), Point2D::new(2.0, 2.0)]);
+
+        dwa.set_obstacles_from_obstacles(&obstacles).unwrap();
+        assert_eq!(dwa.obstacles.len(), 2);
+    }
+
+    #[test]
+    fn test_dwa_try_plan_input_returns_common_control() {
+        let mut dwa = DWAPlanner::with_defaults();
+        dwa.set_state(DWAState::new(0.0, 0.0, 0.0, 0.0, 0.0));
+        dwa.set_goal(Point2D::new(10.0, 0.0));
+
+        let control = dwa.try_plan_input().unwrap();
+        assert!(control.v > 0.0);
+    }
+
+    #[test]
+    fn test_dwa_best_path_after_planning() {
+        let mut dwa = DWAPlanner::with_defaults();
+        dwa.set_state(DWAState::new(0.0, 0.0, 0.0, 0.0, 0.0));
+        dwa.set_goal(Point2D::new(3.0, 0.0));
+
+        dwa.try_plan_step().unwrap();
+        let best_path = dwa.best_path();
+        assert!(!best_path.is_empty());
     }
 }

--- a/src/path_planning/jps.rs
+++ b/src/path_planning/jps.rs
@@ -12,7 +12,7 @@
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 
-use crate::common::{Path2D, PathPlanner, Point2D, RoboticsError};
+use crate::common::{Obstacles, Path2D, PathPlanner, Point2D, RoboticsError, RoboticsResult};
 use crate::utils::{GridMap, Node};
 
 /// Configuration for JPS planner
@@ -33,6 +33,31 @@ impl Default for JPSConfig {
             robot_radius: 0.5,
             heuristic_weight: 1.0,
         }
+    }
+}
+
+impl JPSConfig {
+    pub fn validate(&self) -> RoboticsResult<()> {
+        if !self.resolution.is_finite() || self.resolution <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "resolution must be positive and finite, got {}",
+                self.resolution
+            )));
+        }
+        if !self.robot_radius.is_finite() || self.robot_radius < 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "robot_radius must be non-negative and finite, got {}",
+                self.robot_radius
+            )));
+        }
+        if !self.heuristic_weight.is_finite() || self.heuristic_weight <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "heuristic_weight must be positive and finite, got {}",
+                self.heuristic_weight
+            )));
+        }
+
+        Ok(())
     }
 }
 
@@ -100,8 +125,16 @@ pub struct JPSPlanner {
 impl JPSPlanner {
     /// Create a new JPS planner with obstacle positions
     pub fn new(ox: &[f64], oy: &[f64], config: JPSConfig) -> Self {
-        let grid_map = GridMap::new(ox, oy, config.resolution, config.robot_radius);
-        JPSPlanner { grid_map, config }
+        Self::try_new(ox, oy, config).expect(
+            "invalid JPS planner input: obstacle list must be non-empty and valid, and config values must be positive/finite",
+        )
+    }
+
+    /// Create a validated JPS planner with obstacle positions
+    pub fn try_new(ox: &[f64], oy: &[f64], config: JPSConfig) -> RoboticsResult<Self> {
+        config.validate()?;
+        let grid_map = GridMap::try_new(ox, oy, config.resolution, config.robot_radius)?;
+        Ok(JPSPlanner { grid_map, config })
     }
 
     /// Create from obstacle x/y vectors with default config
@@ -114,15 +147,29 @@ impl JPSPlanner {
         Self::new(ox, oy, config)
     }
 
+    /// Create a validated JPS planner from typed obstacle points
+    pub fn from_obstacle_points(obstacles: &Obstacles, config: JPSConfig) -> RoboticsResult<Self> {
+        config.validate()?;
+        let grid_map = GridMap::from_obstacles(obstacles, config.resolution, config.robot_radius)?;
+        Ok(JPSPlanner { grid_map, config })
+    }
+
     /// Plan a path returning (rx, ry) vectors (legacy interface)
     pub fn planning(&self, sx: f64, sy: f64, gx: f64, gy: f64) -> Option<(Vec<f64>, Vec<f64>)> {
-        let start = Point2D::new(sx, sy);
-        let goal = Point2D::new(gx, gy);
-
-        match self.plan(start, goal) {
+        match self.plan_xy(sx, sy, gx, gy) {
             Ok(path) => Some((path.x_coords(), path.y_coords())),
             Err(_) => None,
         }
+    }
+
+    /// Plan a path without requiring the PathPlanner trait in scope
+    pub fn plan(&self, start: Point2D, goal: Point2D) -> RoboticsResult<Path2D> {
+        self.plan_impl(start, goal)
+    }
+
+    /// Plan a path from raw coordinates without requiring the PathPlanner trait in scope
+    pub fn plan_xy(&self, sx: f64, sy: f64, gx: f64, gy: f64) -> RoboticsResult<Path2D> {
+        self.plan_impl(Point2D::new(sx, sy), Point2D::new(gx, gy))
     }
 
     /// Get reference to the grid map
@@ -388,8 +435,8 @@ impl JPSPlanner {
             if i == 0 {
                 // Add start point
                 points.push(Point2D::new(
-                    self.grid_map.calc_grid_position(x),
-                    self.grid_map.calc_grid_position(y),
+                    self.grid_map.calc_x_position(x),
+                    self.grid_map.calc_y_position(y),
                 ));
             } else {
                 // Interpolate from previous jump point to current
@@ -416,8 +463,8 @@ impl JPSPlanner {
                     }
 
                     points.push(Point2D::new(
-                        self.grid_map.calc_grid_position(cx),
-                        self.grid_map.calc_grid_position(cy),
+                        self.grid_map.calc_x_position(cx),
+                        self.grid_map.calc_y_position(cy),
                     ));
                 }
             }
@@ -425,26 +472,26 @@ impl JPSPlanner {
 
         Path2D::from_points(points)
     }
-}
 
-impl PathPlanner for JPSPlanner {
-    fn plan(&self, start: Point2D, goal: Point2D) -> Result<Path2D, RoboticsError> {
-        let start_x = self.grid_map.calc_xy_index(start.x);
-        let start_y = self.grid_map.calc_xy_index(start.y);
-        let goal_x = self.grid_map.calc_xy_index(goal.x);
-        let goal_y = self.grid_map.calc_xy_index(goal.y);
+    fn ensure_query_is_valid(&self, x: i32, y: i32, label: &str) -> RoboticsResult<()> {
+        if self.grid_map.is_valid(x, y) {
+            return Ok(());
+        }
 
-        // Validate start and goal
-        if !self.grid_map.is_valid(start_x, start_y) {
-            return Err(RoboticsError::PlanningError(
-                "Start position is invalid".to_string(),
-            ));
-        }
-        if !self.grid_map.is_valid(goal_x, goal_y) {
-            return Err(RoboticsError::PlanningError(
-                "Goal position is invalid".to_string(),
-            ));
-        }
+        Err(RoboticsError::PlanningError(format!(
+            "{} position is invalid",
+            label
+        )))
+    }
+
+    fn plan_impl(&self, start: Point2D, goal: Point2D) -> RoboticsResult<Path2D> {
+        let start_x = self.grid_map.calc_x_index(start.x);
+        let start_y = self.grid_map.calc_y_index(start.y);
+        let goal_x = self.grid_map.calc_x_index(goal.x);
+        let goal_y = self.grid_map.calc_y_index(goal.y);
+
+        self.ensure_query_is_valid(start_x, start_y, "Start")?;
+        self.ensure_query_is_valid(goal_x, goal_y, "Goal")?;
 
         let mut open_set = BinaryHeap::new();
         let mut closed_set: HashMap<i32, usize> = HashMap::new();
@@ -517,9 +564,17 @@ impl PathPlanner for JPSPlanner {
     }
 }
 
+impl PathPlanner for JPSPlanner {
+    fn plan(&self, start: Point2D, goal: Point2D) -> Result<Path2D, RoboticsError> {
+        self.plan_impl(start, goal)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::common::Obstacles;
 
     fn create_simple_obstacles() -> (Vec<f64>, Vec<f64>) {
         let mut ox = Vec::new();
@@ -691,5 +746,54 @@ mod tests {
             "Path should be efficient, got length {}",
             total_len
         );
+    }
+
+    #[test]
+    fn test_jps_from_obstacle_points() {
+        let (ox, oy) = create_small_obstacles();
+        let obstacles = Obstacles::try_from_xy(&ox, &oy).unwrap();
+        let planner = JPSPlanner::from_obstacle_points(&obstacles, JPSConfig::default()).unwrap();
+
+        let path = planner.plan_xy(2.0, 2.0, 8.0, 8.0).unwrap();
+        assert!(!path.is_empty());
+    }
+
+    #[test]
+    fn test_jps_try_new_rejects_invalid_config() {
+        let (ox, oy) = create_small_obstacles();
+        let config = JPSConfig {
+            heuristic_weight: 0.0,
+            ..Default::default()
+        };
+
+        let err = match JPSPlanner::try_new(&ox, &oy, config) {
+            Ok(_) => panic!("expected invalid config to be rejected"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_jps_preserves_asymmetric_world_coordinates() {
+        let mut obstacles = Obstacles::new();
+
+        for x in 10..=20 {
+            obstacles.push(Point2D::new(x as f64, -4.0));
+            obstacles.push(Point2D::new(x as f64, 6.0));
+        }
+        for y in -4..=6 {
+            obstacles.push(Point2D::new(10.0, y as f64));
+            obstacles.push(Point2D::new(20.0, y as f64));
+        }
+
+        let planner = JPSPlanner::from_obstacle_points(&obstacles, JPSConfig::default()).unwrap();
+        let path = planner.plan_xy(12.0, -2.0, 18.0, 4.0).unwrap();
+
+        let first = path.points.first().unwrap();
+        let last = path.points.last().unwrap();
+        assert!((first.x - 12.0).abs() < 1e-6);
+        assert!((first.y + 2.0).abs() < 1e-6);
+        assert!((last.x - 18.0).abs() < 1e-6);
+        assert!((last.y - 4.0).abs() < 1e-6);
     }
 }

--- a/src/path_planning/mod.rs
+++ b/src/path_planning/mod.rs
@@ -9,32 +9,45 @@
 
 // Grid-based planners
 pub mod a_star;
+#[cfg(feature = "viz")]
 pub mod d_star_lite;
+#[cfg(feature = "viz")]
 pub mod dijkstra;
 pub mod jps;
 pub mod theta_star;
 
 // Sampling-based planners
+#[cfg(feature = "viz")]
 pub mod informed_rrt_star;
+#[cfg(feature = "viz")]
 pub mod prm;
 pub mod rrt;
 pub mod rrt_star;
+#[cfg(feature = "viz")]
 pub mod voronoi_road_map;
 
 // Other planners
 pub mod dwa;
+#[cfg(feature = "viz")]
 pub mod frenet_optimal_trajectory;
+#[cfg(feature = "viz")]
 pub mod potential_field;
 
 // State Lattice Planner
 pub mod state_lattice;
 
 // Curve generation
+#[cfg(feature = "viz")]
 pub mod bezier_path;
+#[cfg(feature = "viz")]
 pub mod bezier_path_planning;
+#[cfg(feature = "viz")]
 pub mod csp;
+#[cfg(feature = "viz")]
 pub mod cubic_spline_planner;
+#[cfg(feature = "viz")]
 pub mod quintic_polynomials;
+#[cfg(feature = "viz")]
 pub mod reeds_shepp_path;
 
 // Re-exports for convenience

--- a/src/path_planning/theta_star.rs
+++ b/src/path_planning/theta_star.rs
@@ -15,7 +15,7 @@
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 
-use crate::common::{Path2D, PathPlanner, Point2D, RoboticsError};
+use crate::common::{Obstacles, Path2D, PathPlanner, Point2D, RoboticsError, RoboticsResult};
 use crate::utils::{GridMap, Node};
 
 /// Configuration for Theta* planner
@@ -36,6 +36,31 @@ impl Default for ThetaStarConfig {
             robot_radius: 0.5,
             heuristic_weight: 1.0,
         }
+    }
+}
+
+impl ThetaStarConfig {
+    pub fn validate(&self) -> RoboticsResult<()> {
+        if !self.resolution.is_finite() || self.resolution <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "resolution must be positive and finite, got {}",
+                self.resolution
+            )));
+        }
+        if !self.robot_radius.is_finite() || self.robot_radius < 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "robot_radius must be non-negative and finite, got {}",
+                self.robot_radius
+            )));
+        }
+        if !self.heuristic_weight.is_finite() || self.heuristic_weight <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "heuristic_weight must be positive and finite, got {}",
+                self.heuristic_weight
+            )));
+        }
+
+        Ok(())
     }
 }
 
@@ -87,14 +112,22 @@ pub struct ThetaStarPlanner {
 impl ThetaStarPlanner {
     /// Create a new Theta* planner with obstacle positions
     pub fn new(ox: &[f64], oy: &[f64], config: ThetaStarConfig) -> Self {
-        let grid_map = GridMap::new(ox, oy, config.resolution, config.robot_radius);
+        Self::try_new(ox, oy, config).expect(
+            "invalid Theta* planner input: obstacle list must be non-empty and valid, and config values must be positive/finite",
+        )
+    }
+
+    /// Create a validated Theta* planner with obstacle positions
+    pub fn try_new(ox: &[f64], oy: &[f64], config: ThetaStarConfig) -> RoboticsResult<Self> {
+        config.validate()?;
+        let grid_map = GridMap::try_new(ox, oy, config.resolution, config.robot_radius)?;
         let motion = Self::get_motion_model();
 
-        ThetaStarPlanner {
+        Ok(ThetaStarPlanner {
             grid_map,
             config,
             motion,
-        }
+        })
     }
 
     /// Create from obstacle x/y vectors with default config
@@ -107,15 +140,38 @@ impl ThetaStarPlanner {
         Self::new(ox, oy, config)
     }
 
+    /// Create a validated Theta* planner from typed obstacle points
+    pub fn from_obstacle_points(
+        obstacles: &Obstacles,
+        config: ThetaStarConfig,
+    ) -> RoboticsResult<Self> {
+        config.validate()?;
+        let grid_map = GridMap::from_obstacles(obstacles, config.resolution, config.robot_radius)?;
+        let motion = Self::get_motion_model();
+
+        Ok(ThetaStarPlanner {
+            grid_map,
+            config,
+            motion,
+        })
+    }
+
     /// Plan a path returning (rx, ry) vectors (legacy interface)
     pub fn planning(&self, sx: f64, sy: f64, gx: f64, gy: f64) -> Option<(Vec<f64>, Vec<f64>)> {
-        let start = Point2D::new(sx, sy);
-        let goal = Point2D::new(gx, gy);
-
-        match self.plan(start, goal) {
+        match self.plan_xy(sx, sy, gx, gy) {
             Ok(path) => Some((path.x_coords(), path.y_coords())),
             Err(_) => None,
         }
+    }
+
+    /// Plan a path without requiring the PathPlanner trait in scope
+    pub fn plan(&self, start: Point2D, goal: Point2D) -> RoboticsResult<Path2D> {
+        self.plan_impl(start, goal)
+    }
+
+    /// Plan a path from raw coordinates without requiring the PathPlanner trait in scope
+    pub fn plan_xy(&self, sx: f64, sy: f64, gx: f64, gy: f64) -> RoboticsResult<Path2D> {
+        self.plan_impl(Point2D::new(sx, sy), Point2D::new(gx, gy))
     }
 
     /// Get reference to the grid map
@@ -200,14 +256,26 @@ impl ThetaStarPlanner {
         points.reverse();
         Path2D::from_points(points)
     }
-}
 
-impl PathPlanner for ThetaStarPlanner {
-    fn plan(&self, start: Point2D, goal: Point2D) -> Result<Path2D, RoboticsError> {
+    fn ensure_query_is_valid(&self, x: i32, y: i32, label: &str) -> RoboticsResult<()> {
+        if self.grid_map.is_valid(x, y) {
+            return Ok(());
+        }
+
+        Err(RoboticsError::PlanningError(format!(
+            "{} position is invalid",
+            label
+        )))
+    }
+
+    fn plan_impl(&self, start: Point2D, goal: Point2D) -> RoboticsResult<Path2D> {
         let start_x = self.grid_map.calc_x_index(start.x);
         let start_y = self.grid_map.calc_y_index(start.y);
         let goal_x = self.grid_map.calc_x_index(goal.x);
         let goal_y = self.grid_map.calc_y_index(goal.y);
+
+        self.ensure_query_is_valid(start_x, start_y, "Start")?;
+        self.ensure_query_is_valid(goal_x, goal_y, "Goal")?;
 
         let mut open_set = BinaryHeap::new();
         let mut closed_set = HashMap::new();
@@ -318,9 +386,17 @@ impl PathPlanner for ThetaStarPlanner {
     }
 }
 
+impl PathPlanner for ThetaStarPlanner {
+    fn plan(&self, start: Point2D, goal: Point2D) -> Result<Path2D, RoboticsError> {
+        self.plan_impl(start, goal)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::common::Obstacles;
 
     fn create_simple_obstacles() -> (Vec<f64>, Vec<f64>) {
         let mut ox = Vec::new();
@@ -414,5 +490,31 @@ mod tests {
 
         // Blocked by obstacle (wall at x=10)
         assert!(!planner.line_of_sight(5, 10, 15, 10));
+    }
+
+    #[test]
+    fn test_theta_star_from_obstacle_points() {
+        let (ox, oy) = create_simple_obstacles();
+        let obstacles = Obstacles::try_from_xy(&ox, &oy).unwrap();
+        let planner =
+            ThetaStarPlanner::from_obstacle_points(&obstacles, ThetaStarConfig::default()).unwrap();
+
+        let path = planner.plan_xy(2.0, 10.0, 18.0, 10.0).unwrap();
+        assert!(!path.is_empty());
+    }
+
+    #[test]
+    fn test_theta_star_try_new_rejects_invalid_config() {
+        let (ox, oy) = create_simple_obstacles();
+        let config = ThetaStarConfig {
+            heuristic_weight: 0.0,
+            ..Default::default()
+        };
+
+        let err = match ThetaStarPlanner::try_new(&ox, &oy, config) {
+            Ok(_) => panic!("expected invalid config to be rejected"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
     }
 }

--- a/src/path_tracking/mod.rs
+++ b/src/path_tracking/mod.rs
@@ -2,7 +2,9 @@
 
 pub mod cgmres_nmpc;
 pub mod lqr_steer_control;
+#[cfg(feature = "viz")]
 pub mod model_predictive_trajectory_generator;
+#[cfg(feature = "viz")]
 pub mod move_to_pose;
 pub mod mpc;
 pub mod pure_pursuit;
@@ -11,6 +13,7 @@ pub mod stanley_controller;
 
 // Re-export main controllers with explicit types to avoid name conflicts
 pub use lqr_steer_control::{LQRSteerConfig, LQRSteerController, LQRVehicleState};
+#[cfg(feature = "viz")]
 pub use move_to_pose::{MoveToPoseConfig, MoveToPoseController, MoveToPoseResult};
 pub use pure_pursuit::VehicleState as PurePursuitVehicleState;
 pub use pure_pursuit::{PurePursuitConfig, PurePursuitController};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,7 +3,11 @@
 pub use crate::common::{
     ControlInput, Obstacles, Path2D, Point2D, Pose2D, RoboticsError, RoboticsResult, State2D,
 };
-pub use crate::localization::{EKFConfig, EKFControl, EKFLocalizer, EKFMeasurement, EKFState};
+pub use crate::localization::{
+    EKFConfig, EKFControl, EKFLocalizer, EKFMeasurement, EKFState, PFControl, PFMeasurement,
+    PFState, Particle, ParticleFilterConfig, ParticleFilterLocalizer, UKFConfig, UKFControl,
+    UKFLocalizer, UKFMeasurement, UKFParams, UKFState, UKFWeights,
+};
 pub use crate::path_planning::{
     AStarConfig, AStarPlanner, DWAConfig, DWAControl, DWAPlanner, DWAState, DWATrajectory,
     JPSConfig, JPSPlanner, ThetaStarConfig, ThetaStarPlanner,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,10 @@
+//! Stable, headless-first imports for practical library usage.
+
+pub use crate::common::{
+    ControlInput, Obstacles, Path2D, Point2D, Pose2D, RoboticsError, RoboticsResult, State2D,
+};
+pub use crate::localization::{EKFConfig, EKFControl, EKFLocalizer, EKFMeasurement, EKFState};
+pub use crate::path_planning::{
+    AStarConfig, AStarPlanner, DWAConfig, DWAControl, DWAPlanner, DWAState, DWATrajectory,
+    JPSConfig, JPSPlanner, ThetaStarConfig, ThetaStarPlanner,
+};

--- a/src/slam/mod.rs
+++ b/src/slam/mod.rs
@@ -1,6 +1,10 @@
 // SLAM algorithms module
 
+#[cfg(feature = "viz")]
 pub mod ekf_slam;
+#[cfg(feature = "viz")]
 pub mod fastslam1;
+#[cfg(feature = "viz")]
 pub mod graph_based_slam;
+#[cfg(feature = "viz")]
 pub mod icp_matching;

--- a/src/utils/grid_map_planner.rs
+++ b/src/utils/grid_map_planner.rs
@@ -3,6 +3,8 @@
 // Provides occupancy grid representation and utility functions
 // for grid-based path planning algorithms like A*, Dijkstra, D* Lite.
 
+use crate::common::{Obstacles, RoboticsError, RoboticsResult};
+
 /// Node for grid-based path search
 #[derive(Debug, Clone)]
 pub struct Node {
@@ -59,6 +61,20 @@ pub struct GridMap {
 impl GridMap {
     /// Create a new grid map from obstacle points
     pub fn new(ox: &[f64], oy: &[f64], resolution: f64, robot_radius: f64) -> Self {
+        Self::try_new(ox, oy, resolution, robot_radius).expect(
+            "invalid grid map input: obstacle list must be non-empty, finite, and match lengths; resolution must be > 0; robot_radius must be >= 0",
+        )
+    }
+
+    /// Create a validated grid map from obstacle points
+    pub fn try_new(
+        ox: &[f64],
+        oy: &[f64],
+        resolution: f64,
+        robot_radius: f64,
+    ) -> RoboticsResult<Self> {
+        Self::validate_inputs(ox, oy, resolution, robot_radius)?;
+
         let min_x = ox.iter().fold(f64::INFINITY, |a, &b| a.min(b)).round();
         let min_y = oy.iter().fold(f64::INFINITY, |a, &b| a.min(b)).round();
         let max_x = ox.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)).round();
@@ -66,6 +82,12 @@ impl GridMap {
 
         let x_width = ((max_x - min_x) / resolution).round() as i32;
         let y_width = ((max_y - min_y) / resolution).round() as i32;
+
+        if x_width <= 0 || y_width <= 0 {
+            return Err(RoboticsError::InvalidParameter(
+                "obstacles must span a non-zero 2D area at the requested resolution".to_string(),
+            ));
+        }
 
         // Initialize obstacle map
         let mut obstacle_map = vec![vec![false; y_width as usize]; x_width as usize];
@@ -86,7 +108,7 @@ impl GridMap {
             }
         }
 
-        GridMap {
+        Ok(GridMap {
             resolution,
             robot_radius,
             min_x,
@@ -96,7 +118,18 @@ impl GridMap {
             x_width,
             y_width,
             obstacle_map,
-        }
+        })
+    }
+
+    /// Create a validated grid map from obstacle points
+    pub fn from_obstacles(
+        obstacles: &Obstacles,
+        resolution: f64,
+        robot_radius: f64,
+    ) -> RoboticsResult<Self> {
+        let ox = obstacles.x_coords();
+        let oy = obstacles.y_coords();
+        Self::try_new(&ox, &oy, resolution, robot_radius)
     }
 
     /// Convert world position to grid index (uses min_x as reference)
@@ -165,7 +198,88 @@ impl GridMap {
         // Collision check
         !self.obstacle_map[x as usize][y as usize]
     }
+
+    fn validate_inputs(
+        ox: &[f64],
+        oy: &[f64],
+        resolution: f64,
+        robot_radius: f64,
+    ) -> RoboticsResult<()> {
+        if ox.len() != oy.len() {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "obstacle x/y coordinates must have matching lengths, got {} and {}",
+                ox.len(),
+                oy.len()
+            )));
+        }
+        if ox.is_empty() {
+            return Err(RoboticsError::InvalidParameter(
+                "grid planners require at least one obstacle point".to_string(),
+            ));
+        }
+        if !resolution.is_finite() || resolution <= 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "resolution must be positive and finite, got {}",
+                resolution
+            )));
+        }
+        if !robot_radius.is_finite() || robot_radius < 0.0 {
+            return Err(RoboticsError::InvalidParameter(format!(
+                "robot_radius must be non-negative and finite, got {}",
+                robot_radius
+            )));
+        }
+        if ox.iter().chain(oy.iter()).any(|value| !value.is_finite()) {
+            return Err(RoboticsError::InvalidParameter(
+                "obstacle coordinates must be finite".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 // Alias for backward compatibility
 pub type SearchNode = Node;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::Point2D;
+
+    fn create_obstacles() -> Obstacles {
+        Obstacles::from_points(vec![
+            Point2D::new(0.0, 0.0),
+            Point2D::new(10.0, 0.0),
+            Point2D::new(0.0, 10.0),
+            Point2D::new(10.0, 10.0),
+        ])
+    }
+
+    #[test]
+    fn test_try_new_rejects_empty_obstacles() {
+        let err = GridMap::try_new(&[], &[], 1.0, 0.5).unwrap_err();
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_try_new_rejects_invalid_resolution() {
+        let obstacles = create_obstacles();
+        let ox = obstacles.x_coords();
+        let oy = obstacles.y_coords();
+
+        let err = GridMap::try_new(&ox, &oy, 0.0, 0.5).unwrap_err();
+        assert!(matches!(err, RoboticsError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn test_from_obstacles_builds_valid_map() {
+        let obstacles = create_obstacles();
+        let grid_map = GridMap::from_obstacles(&obstacles, 1.0, 0.5).unwrap();
+
+        assert_eq!(grid_map.min_x, 0.0);
+        assert_eq!(grid_map.min_y, 0.0);
+        assert_eq!(grid_map.x_width, 10);
+        assert_eq!(grid_map.y_width, 10);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,8 +2,10 @@
 
 pub mod grid_map;
 pub mod grid_map_planner;
+#[cfg(feature = "viz")]
 pub mod visualization;
 
 pub use grid_map::*;
 pub use grid_map_planner::*;
+#[cfg(feature = "viz")]
 pub use visualization::{colors, PathStyle, PointStyle, Visualizer};


### PR DESCRIPTION
## Summary
- introduce `showcase` and `viz` cargo features so the crate supports a real headless library mode without breaking the current demo-first default
- make plotting dependencies optional, gate visualization-coupled modules behind `viz`, and keep `--no-default-features` covered in CI
- add validated constructors and typed obstacle APIs for the stable grid planners (`A*`, `JPS`, `Theta*`), plus headless examples and regression tests
- add validated, core-type-friendly APIs for `EKF`, `UKF`, `DWA`, and `ParticleFilter`, including `try_*` constructors, checked planning/state-estimation entry points, and common-type conversions
- replace the particle filter's unusable trait implementation with cache-backed state/covariance access so `StateEstimator` is actually usable
- add a `prelude` module plus headless integration/localization examples so consumers can build planning and localization loops without visualization dependencies

## Why
The crate was still shaped around sample execution even after adding headless features. This PR turns a meaningful subset of the repo into a practical library surface: callers can build planners and localizers safely, work with shared crate types, and run path planning / local planning / localization without demo-specific setup or plotting dependencies.

## Testing
- cargo fmt --all
- cargo test --all-targets
- cargo test --all-targets --no-default-features
- cargo run --example headless_grid_planners --no-default-features
- cargo run --example headless_navigation_loop --no-default-features
- cargo run --example headless_localizers --no-default-features