### PR TITLE
[codex] Add EKF-backed mission odometry stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,12 @@ export TURTLEBOT3_MODEL=burger
 ./ros2_nodes/launch/run_gazebo_demo.sh
 
 # Multi-goal mission demo
+WAYPOINT_NAV_FRAME=relative_start \
 WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5" \
   ./ros2_nodes/launch/run_gazebo_mission_demo.sh
 ```
+
+`run_gazebo_mission_demo.sh` defaults to `WAYPOINT_NAV_FRAME=relative_start`, so the mission waypoints above are interpreted as offsets from the first odom pose observed by `waypoint_navigator_node`.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ export TURTLEBOT3_MODEL=burger
 
 # Multi-goal mission demo
 WAYPOINT_NAV_FRAME=relative_start \
-WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5" \
+WAYPOINT_NAV_WAYPOINTS="0.4,0.0;0.1,0.4" \
   ./ros2_nodes/launch/run_gazebo_mission_demo.sh
 ```
 
-`run_gazebo_mission_demo.sh` defaults to `WAYPOINT_NAV_FRAME=relative_start`, so the mission waypoints above are interpreted as offsets from the first odom pose observed by `waypoint_navigator_node`.
+`run_gazebo_mission_demo.sh` defaults to `WAYPOINT_NAV_FRAME=relative_start`, so the mission waypoints above are interpreted as offsets from the first odom pose observed by `waypoint_navigator_node`. The wrapper's default mission is a conservative two-waypoint route that was verified in TurtleBot3 world: `(0.4, 0.0) -> (0.1, 0.4)`.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The workspace includes ready-to-use ROS2 navigation nodes built with safe_drive 
 - Path Planner (A*)
 - DWA Local Planner
 - SLAM Node
+- Waypoint Navigator
 
 ```text
                  TurtleBot3 Gazebo
@@ -100,7 +101,11 @@ The workspace includes ready-to-use ROS2 navigation nodes built with safe_drive 
              ^           ^                  v
              |           |           +--------------+
            /odom     /goal_pose ---> | dwa_planner |
-                                     +--------------+
+             ^                       +--------------+
+             |
+   +-------------------------+
+   | waypoint_navigator_node |
+   +-------------------------+
 ```
 
 Demo video: [docs/gazebo_demo.mp4](./docs/gazebo_demo.mp4)
@@ -114,9 +119,14 @@ export ROS_DOMAIN_ID=42  # optional but recommended if other ROS graphs are alre
 cargo build --release --manifest-path ros2_nodes/path_planner_node/Cargo.toml
 cargo build --release --manifest-path ros2_nodes/dwa_planner_node/Cargo.toml
 cargo build --release --manifest-path ros2_nodes/slam_node/Cargo.toml
+cargo build --release --manifest-path ros2_nodes/waypoint_navigator_node/Cargo.toml
 
 export TURTLEBOT3_MODEL=burger
 ./ros2_nodes/launch/run_gazebo_demo.sh
+
+# Multi-goal mission demo
+WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5" \
+  ./ros2_nodes/launch/run_gazebo_mission_demo.sh
 ```
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -83,29 +83,35 @@ The workspace includes ready-to-use ROS2 navigation nodes built with safe_drive 
 - Path Planner (A*)
 - DWA Local Planner
 - SLAM Node
+- EKF Localizer
 - Waypoint Navigator
 
 ```text
-                 TurtleBot3 Gazebo
-              /scan  /odom  /cmd_vel
-                 |      |       ^
-                 v      |       |
-            +-----------+       |
-            | slam_node | ----- +
-            +-----------+    /map
-                   |
-                   v
-          +-------------------+
-          | path_planner_node | ---> /planned_path
-          +-------------------+             |
-             ^           ^                  v
-             |           |           +--------------+
-           /odom     /goal_pose ---> | dwa_planner |
-             ^                       +--------------+
-             |
-   +-------------------------+
-   | waypoint_navigator_node |
-   +-------------------------+
+                    TurtleBot3 Gazebo
+                 /scan  /odom  /cmd_vel
+                    |      |       ^
+                    v      |       |
+               +-----------+       |
+               | slam_node | ----- +
+               +-----------+    /map
+                      |
+                      v
+             +-------------------+
+             | path_planner_node | ---> /planned_path
+             +-------------------+             |
+                ^           ^                  v
+                |           |           +--------------+
+         /ekf_odom     /goal_pose ---> | dwa_planner |
+                ^                      +--------------+
+                |
+      +----------------------+
+      | ekf_localizer_node   |
+      +----------------------+
+                ^
+                |
+      +-------------------------+
+      | waypoint_navigator_node |
+      +-------------------------+
 ```
 
 Demo video: [docs/gazebo_demo.mp4](./docs/gazebo_demo.mp4)
@@ -119,6 +125,7 @@ export ROS_DOMAIN_ID=42  # optional but recommended if other ROS graphs are alre
 cargo build --release --manifest-path ros2_nodes/path_planner_node/Cargo.toml
 cargo build --release --manifest-path ros2_nodes/dwa_planner_node/Cargo.toml
 cargo build --release --manifest-path ros2_nodes/slam_node/Cargo.toml
+cargo build --release --manifest-path ros2_nodes/ekf_localizer_node/Cargo.toml
 cargo build --release --manifest-path ros2_nodes/waypoint_navigator_node/Cargo.toml
 
 export TURTLEBOT3_MODEL=burger

--- a/crates/rust_robotics_localization/src/ekf.rs
+++ b/crates/rust_robotics_localization/src/ekf.rs
@@ -3,7 +3,7 @@
 //! Implements state estimation using the Extended Kalman Filter algorithm
 //! for robot localization with nonlinear motion and observation models.
 
-use nalgebra::{Matrix2, Matrix2x4, Matrix4, Matrix4x2, Vector2, Vector4};
+use nalgebra::{Matrix2, Matrix2x4, Matrix4, Vector2, Vector4};
 use rust_robotics_core::{
     ControlInput, Point2D, RoboticsError, RoboticsResult, State2D, StateEstimator,
 };
@@ -30,8 +30,8 @@ impl Default for EKFConfig {
     fn default() -> Self {
         let mut q = Matrix4::<f64>::identity();
         q[(0, 0)] = 0.1_f64.powi(2);
-        q[(1, 1)] = (1.0_f64.to_radians()).powi(2);
-        q[(2, 2)] = 0.1_f64.powi(2);
+        q[(1, 1)] = 0.1_f64.powi(2);
+        q[(2, 2)] = (1.0_f64.to_radians()).powi(2);
         q[(3, 3)] = 0.1_f64.powi(2);
 
         let r = Matrix2::<f64>::identity();
@@ -195,11 +195,12 @@ impl EKFLocalizer {
     /// Motion model: predict state based on control input
     fn motion_model(x: &EKFState, u: &EKFControl, dt: f64) -> EKFState {
         let yaw = x[2];
-        let f = Matrix4::new(
-            1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.,
-        );
-        let b = Matrix4x2::new(dt * yaw.cos(), 0., dt * yaw.sin(), 0., 0., dt, 1., 0.);
-        f * x + b * u
+        EKFState::new(
+            x[0] + dt * u[0] * yaw.cos(),
+            x[1] + dt * u[0] * yaw.sin(),
+            x[2] + dt * u[1],
+            u[0],
+        )
     }
 
     /// Jacobian of motion model with respect to state
@@ -210,19 +211,19 @@ impl EKFLocalizer {
             1.,
             0.,
             -dt * v * yaw.sin(),
-            dt * yaw.cos(),
+            0.,
             0.,
             1.,
             dt * v * yaw.cos(),
-            dt * yaw.sin(),
-            0.,
-            0.,
-            1.,
-            0.,
             0.,
             0.,
             0.,
             1.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
         )
     }
 
@@ -477,6 +478,23 @@ mod tests {
             .unwrap();
 
         assert!(state.x > 0.0);
+    }
+
+    #[test]
+    fn test_ekf_velocity_tracks_control_without_accumulating() {
+        let mut ekf = EKFLocalizer::with_defaults();
+
+        for step in 1..=20 {
+            let state = ekf
+                .estimate_state(
+                    Point2D::new(step as f64 * 0.05, 0.0),
+                    ControlInput::new(0.5, 0.0),
+                    0.1,
+                )
+                .unwrap();
+
+            assert!((state.v - 0.5).abs() < 1e-9);
+        }
     }
 
     #[test]

--- a/docs/ros2_integration.md
+++ b/docs/ros2_integration.md
@@ -50,6 +50,8 @@ cargo test --workspace --lib --tests
   - `/planned_path` (`nav_msgs/Path`)
 - **Configuration**:
   - `RUST_NAV_ODOM_TOPIC`
+  - `DWA_GOAL_THRESHOLD`
+  - `DWA_ROBOT_RADIUS`
 - **Notes**:
   - Rebuilds its A* planner whenever `/map` updates
   - Converts occupied grid cells into A* obstacles
@@ -171,17 +173,18 @@ export ROS_DOMAIN_ID=42
 export TURTLEBOT3_MODEL=burger
 export NAV_ODOM_TOPIC=/ekf_odom
 export WAYPOINT_NAV_FRAME=relative_start
-export WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5"
+export WAYPOINT_NAV_WAYPOINTS="0.4,0.0;0.1,0.4"
 
 ./ros2_nodes/launch/run_gazebo_mission_demo.sh
 ```
 
-The mission wrapper uses `WAYPOINT_NAV_FRAME=relative_start` by default, so the demo waypoints above are interpreted as offsets from the first odom pose observed by `waypoint_navigator_node`. `navigation_demo.launch.py` still exposes `spawn_x` / `spawn_y` and forwards the upstream TurtleBot3 world defaults (`x=-2.0`, `y=-0.5`) for reproducibility.
+The mission wrapper uses `WAYPOINT_NAV_FRAME=relative_start` by default, so the demo waypoints above are interpreted as offsets from the first odom pose observed by `waypoint_navigator_node`. Its default mission is a verified two-waypoint route, `(0.4, 0.0) -> (0.1, 0.4)`. `navigation_demo.launch.py` still exposes `spawn_x` / `spawn_y` and forwards the upstream TurtleBot3 world defaults (`x=-2.0`, `y=-0.5`) for reproducibility.
 
 The mission wrapper reuses [navigation_demo.launch.py](../ros2_nodes/launch/navigation_demo.launch.py) and enables `waypoint_navigator_node` with:
 
 - `enable_ekf_localizer:=true`
 - `nav_odom_topic:=/ekf_odom`
+- `dwa_goal_threshold:=0.3`
 - `waypoint_frame:=relative_start`
 - `WAYPOINT_NAV_WAYPOINTS`: semicolon-delimited 2D mission
 - `WAYPOINT_NAV_LOOP`: `true` or `false`
@@ -191,7 +194,7 @@ Example looping square:
 
 ```bash
 export WAYPOINT_NAV_FRAME=relative_start
-export WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5;0.0,0.0"
+export WAYPOINT_NAV_WAYPOINTS="0.4,0.0;0.0,0.4;0.4,0.0"
 export WAYPOINT_NAV_LOOP=true
 ./ros2_nodes/launch/run_gazebo_mission_demo.sh
 ```
@@ -234,8 +237,8 @@ ros2 topic echo /cmd_vel geometry_msgs/msg/Twist --once
 
 ### `dwa_planner_node`
 
-- `goal_threshold` (default `0.3`): terminal tolerance \[m\]
-- `robot_radius` (default `0.35`): collision radius \[m\]
+- `DWA_GOAL_THRESHOLD` (default `0.3`): terminal tolerance \[m\]
+- `DWA_ROBOT_RADIUS` (default `0.35`): collision radius \[m\]
 - `look_ahead_points` (default `10`): target index offset on global path
 - `predict_time`, `dt`, `max_speed`, `max_yaw_rate`: standard DWA tuning terms
 

--- a/docs/ros2_integration.md
+++ b/docs/ros2_integration.md
@@ -103,11 +103,13 @@ cargo test --workspace --lib --tests
 - **Configuration**:
   - `RUST_NAV_ODOM_TOPIC`
   - `WAYPOINT_NAV_WAYPOINTS`: semicolon-delimited `x,y` mission string
+  - `WAYPOINT_NAV_FRAME`: `map` or `relative_start`
   - `WAYPOINT_NAV_GOAL_TOLERANCE`: waypoint reach tolerance \[m\]
   - `WAYPOINT_NAV_LOOP`: whether to restart after the last waypoint
 - **Notes**:
   - Waits for the selected odometry topic before sending the first goal
-  - Publishes the next `/goal_pose` only when the current waypoint is reached
+  - Republishes the active `/goal_pose` every 2 seconds until the planner reacts
+  - `relative_start` resolves waypoints as offsets from the robot pose seen on the first odom sample
 
 ## Navigation Stack Architecture
 
@@ -154,6 +156,7 @@ export TURTLEBOT3_MODEL=burger
 The wrapper script starts [navigation_demo.launch.py](../ros2_nodes/launch/navigation_demo.launch.py), which:
 
 - launches `turtlebot3_gazebo/turtlebot3_world.launch.py`
+- forwards the upstream TurtleBot3 world spawn defaults (`x=-2.0`, `y=-0.5`) as launch arguments
 - adds an extra `ros_gz_bridge` subscription so `/cmd_vel` accepts `geometry_msgs/Twist`
 - waits 5 seconds for Gazebo topics to appear
 - starts `slam_node`, `path_planner_node`, and `dwa_planner_node` from `target/release`
@@ -167,15 +170,19 @@ source /opt/ros/jazzy/setup.bash
 export ROS_DOMAIN_ID=42
 export TURTLEBOT3_MODEL=burger
 export NAV_ODOM_TOPIC=/ekf_odom
+export WAYPOINT_NAV_FRAME=relative_start
 export WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5"
 
 ./ros2_nodes/launch/run_gazebo_mission_demo.sh
 ```
 
+The mission wrapper uses `WAYPOINT_NAV_FRAME=relative_start` by default, so the demo waypoints above are interpreted as offsets from the first odom pose observed by `waypoint_navigator_node`. `navigation_demo.launch.py` still exposes `spawn_x` / `spawn_y` and forwards the upstream TurtleBot3 world defaults (`x=-2.0`, `y=-0.5`) for reproducibility.
+
 The mission wrapper reuses [navigation_demo.launch.py](../ros2_nodes/launch/navigation_demo.launch.py) and enables `waypoint_navigator_node` with:
 
 - `enable_ekf_localizer:=true`
 - `nav_odom_topic:=/ekf_odom`
+- `waypoint_frame:=relative_start`
 - `WAYPOINT_NAV_WAYPOINTS`: semicolon-delimited 2D mission
 - `WAYPOINT_NAV_LOOP`: `true` or `false`
 - `WAYPOINT_NAV_GOAL_TOLERANCE`: waypoint completion radius
@@ -183,6 +190,7 @@ The mission wrapper reuses [navigation_demo.launch.py](../ros2_nodes/launch/navi
 Example looping square:
 
 ```bash
+export WAYPOINT_NAV_FRAME=relative_start
 export WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5;0.0,0.0"
 export WAYPOINT_NAV_LOOP=true
 ./ros2_nodes/launch/run_gazebo_mission_demo.sh
@@ -248,7 +256,8 @@ ros2 topic echo /cmd_vel geometry_msgs/msg/Twist --once
 ### `waypoint_navigator_node`
 
 - `RUST_NAV_ODOM_TOPIC` (default `"/odom"` unless launch overrides it): mission odom input topic
-- `WAYPOINT_NAV_WAYPOINTS` (default `"0.5,0.0;0.5,0.5;0.0,0.5"`): mission waypoints in the `map` frame
+- `WAYPOINT_NAV_WAYPOINTS` (default `"0.5,0.0;0.5,0.5;0.0,0.5"`): mission waypoints interpreted in the frame selected by `WAYPOINT_NAV_FRAME`
+- `WAYPOINT_NAV_FRAME` (default `"map"`): `map` for absolute goals, `relative_start` for offsets from the initial odom pose
 - `WAYPOINT_NAV_GOAL_TOLERANCE` (default `0.35`): distance threshold for waypoint completion \[m\]
 - `WAYPOINT_NAV_LOOP` (default `false`): restart the mission after the last waypoint
 

--- a/docs/ros2_integration.md
+++ b/docs/ros2_integration.md
@@ -26,6 +26,7 @@ source /opt/ros/jazzy/setup.bash
 cargo build --release --manifest-path ros2_nodes/path_planner_node/Cargo.toml
 cargo build --release --manifest-path ros2_nodes/dwa_planner_node/Cargo.toml
 cargo build --release --manifest-path ros2_nodes/slam_node/Cargo.toml
+cargo build --release --manifest-path ros2_nodes/waypoint_navigator_node/Cargo.toml
 ```
 
 ### Core library workspace
@@ -70,6 +71,21 @@ cargo test --workspace --lib --tests
 - **Publications**:
   - `/map` (`nav_msgs/OccupancyGrid`)
 
+### `waypoint_navigator_node`
+
+- **Role**: Mission-level sequencing of multiple 2D goals
+- **Subscriptions**:
+  - `/odom` (`nav_msgs/Odometry`)
+- **Publications**:
+  - `/goal_pose` (`geometry_msgs/PoseStamped`)
+- **Configuration**:
+  - `WAYPOINT_NAV_WAYPOINTS`: semicolon-delimited `x,y` mission string
+  - `WAYPOINT_NAV_GOAL_TOLERANCE`: waypoint reach tolerance \[m\]
+  - `WAYPOINT_NAV_LOOP`: whether to restart after the last waypoint
+- **Notes**:
+  - Waits for `/odom` before sending the first goal
+  - Publishes the next `/goal_pose` only when the current waypoint is reached
+
 ## Navigation Stack Architecture
 
 ```text
@@ -88,10 +104,11 @@ cargo test --workspace --lib --tests
              ^           ^                  v
              |           |           +--------------+
            /odom     /goal_pose ---> | dwa_planner |
-                                     +--------------+
-                                            |
-                                            v
-                                         /cmd_vel
+             ^                       +--------------+
+             |                              |
+   +-------------------------+              v
+   | waypoint_navigator_node |           /cmd_vel
+   +-------------------------+
 ```
 
 ## Gazebo Demo
@@ -115,6 +132,31 @@ The wrapper script starts [navigation_demo.launch.py](../ros2_nodes/launch/navig
 
 Demo video: [gazebo_demo.mp4](./gazebo_demo.mp4)
 
+### Launch the mission demo
+
+```bash
+source /opt/ros/jazzy/setup.bash
+export ROS_DOMAIN_ID=42
+export TURTLEBOT3_MODEL=burger
+export WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5"
+
+./ros2_nodes/launch/run_gazebo_mission_demo.sh
+```
+
+The mission wrapper reuses [navigation_demo.launch.py](../ros2_nodes/launch/navigation_demo.launch.py) and enables `waypoint_navigator_node` with:
+
+- `WAYPOINT_NAV_WAYPOINTS`: semicolon-delimited 2D mission
+- `WAYPOINT_NAV_LOOP`: `true` or `false`
+- `WAYPOINT_NAV_GOAL_TOLERANCE`: waypoint completion radius
+
+Example looping square:
+
+```bash
+export WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5;0.0,0.0"
+export WAYPOINT_NAV_LOOP=true
+./ros2_nodes/launch/run_gazebo_mission_demo.sh
+```
+
 ### Send a goal
 
 ```bash
@@ -125,9 +167,10 @@ ros2 topic pub --once /goal_pose geometry_msgs/msg/PoseStamped \
 ### Expected data flow
 
 1. `slam_node` receives `/scan` and `/odom`, then publishes `/map`.
-2. `path_planner_node` rebuilds A* from `/map` and publishes `/planned_path`.
-3. `dwa_planner_node` follows `/planned_path` while avoiding live laser obstacles and publishes `/cmd_vel`.
-4. TurtleBot3 moves toward the requested goal in Gazebo.
+2. `waypoint_navigator_node` publishes the current mission waypoint on `/goal_pose`.
+3. `path_planner_node` rebuilds A* from `/map` and publishes `/planned_path`.
+4. `dwa_planner_node` follows `/planned_path` while avoiding live laser obstacles and publishes `/cmd_vel`.
+5. TurtleBot3 moves toward the requested goal in Gazebo.
 
 ### Verify topic wiring
 
@@ -163,6 +206,12 @@ ros2 topic echo /cmd_vel geometry_msgs/msg/Twist --once
 - `occupied_log_odds` / `free_log_odds`: Bayesian update weights
 - `icp_max_iterations` (from algorithm defaults): ICP optimization limit
 
+### `waypoint_navigator_node`
+
+- `WAYPOINT_NAV_WAYPOINTS` (default `"0.5,0.0;0.5,0.5;0.0,0.5"`): mission waypoints in the `map` frame
+- `WAYPOINT_NAV_GOAL_TOLERANCE` (default `0.35`): distance threshold for waypoint completion \[m\]
+- `WAYPOINT_NAV_LOOP` (default `false`): restart the mission after the last waypoint
+
 ## Troubleshooting
 
 - `run_gazebo_demo.sh` reports missing binaries:
@@ -177,3 +226,5 @@ ros2 topic echo /cmd_vel geometry_msgs/msg/Twist --once
   - The goal may be outside the current map bounds or inside an occupied cell.
 - No robot motion despite `/planned_path`:
   - Check `/cmd_vel` output from `dwa_planner_node` and verify TurtleBot3 Gazebo is subscribed to `/cmd_vel`.
+- Mission demo does not advance to the next waypoint:
+  - Check `/odom` and confirm the robot is entering `WAYPOINT_NAV_GOAL_TOLERANCE` around the active waypoint.

--- a/docs/ros2_integration.md
+++ b/docs/ros2_integration.md
@@ -26,6 +26,7 @@ source /opt/ros/jazzy/setup.bash
 cargo build --release --manifest-path ros2_nodes/path_planner_node/Cargo.toml
 cargo build --release --manifest-path ros2_nodes/dwa_planner_node/Cargo.toml
 cargo build --release --manifest-path ros2_nodes/slam_node/Cargo.toml
+cargo build --release --manifest-path ros2_nodes/ekf_localizer_node/Cargo.toml
 cargo build --release --manifest-path ros2_nodes/waypoint_navigator_node/Cargo.toml
 ```
 
@@ -43,24 +44,28 @@ cargo test --workspace --lib --tests
 - **Role**: Global path planning with A*
 - **Subscriptions**:
   - `/goal_pose` (`geometry_msgs/PoseStamped`)
-  - `/odom` (`nav_msgs/Odometry`)
+  - `RUST_NAV_ODOM_TOPIC` (`nav_msgs/Odometry`, default `/odom`)
   - `/map` (`nav_msgs/OccupancyGrid`)
 - **Publications**:
   - `/planned_path` (`nav_msgs/Path`)
+- **Configuration**:
+  - `RUST_NAV_ODOM_TOPIC`
 - **Notes**:
   - Rebuilds its A* planner whenever `/map` updates
   - Converts occupied grid cells into A* obstacles
-  - Uses `/odom.pose.pose.position` as the robot start pose
+  - Uses the selected odometry topic pose as the robot start pose
 
 ### `dwa_planner_node`
 
 - **Role**: Local trajectory planning and velocity command generation
 - **Subscriptions**:
   - `/scan` (`sensor_msgs/LaserScan`)
-  - `/odom` (`nav_msgs/Odometry`)
+  - `RUST_NAV_ODOM_TOPIC` (`nav_msgs/Odometry`, default `/odom`)
   - `/planned_path` (`nav_msgs/Path`)
 - **Publications**:
   - `/cmd_vel` (`geometry_msgs/Twist`)
+- **Configuration**:
+  - `RUST_NAV_ODOM_TOPIC`
 
 ### `slam_node`
 
@@ -71,44 +76,67 @@ cargo test --workspace --lib --tests
 - **Publications**:
   - `/map` (`nav_msgs/OccupancyGrid`)
 
+### `ekf_localizer_node`
+
+- **Role**: Filter wheel odometry into a smoother navigation odom stream
+- **Subscriptions**:
+  - `/odom` (`nav_msgs/Odometry`) by default
+- **Publications**:
+  - `/ekf_pose` (`geometry_msgs/PoseStamped`)
+  - `/ekf_odom` (`nav_msgs/Odometry`)
+- **Configuration**:
+  - `EKF_INPUT_ODOM_TOPIC`
+  - `EKF_OUTPUT_ODOM_TOPIC`
+  - `EKF_OUTPUT_POSE_TOPIC`
+- **Notes**:
+  - Wraps `rust_robotics_localization::EKFLocalizer`
+  - Uses raw odometry pose as measurement and raw twist as control input
+  - Provides a filtered odom source for the planner / mission nodes
+
 ### `waypoint_navigator_node`
 
 - **Role**: Mission-level sequencing of multiple 2D goals
 - **Subscriptions**:
-  - `/odom` (`nav_msgs/Odometry`)
+  - `RUST_NAV_ODOM_TOPIC` (`nav_msgs/Odometry`, default `/odom`)
 - **Publications**:
   - `/goal_pose` (`geometry_msgs/PoseStamped`)
 - **Configuration**:
+  - `RUST_NAV_ODOM_TOPIC`
   - `WAYPOINT_NAV_WAYPOINTS`: semicolon-delimited `x,y` mission string
   - `WAYPOINT_NAV_GOAL_TOLERANCE`: waypoint reach tolerance \[m\]
   - `WAYPOINT_NAV_LOOP`: whether to restart after the last waypoint
 - **Notes**:
-  - Waits for `/odom` before sending the first goal
+  - Waits for the selected odometry topic before sending the first goal
   - Publishes the next `/goal_pose` only when the current waypoint is reached
 
 ## Navigation Stack Architecture
 
 ```text
-                 TurtleBot3 Gazebo
-              /scan  /odom  /cmd_vel
-                 |      |       ^
-                 v      |       |
-            +-----------+       |
-            | slam_node | ----- +
-            +-----------+    /map
-                   |
-                   v
-          +-------------------+
-          | path_planner_node | ---> /planned_path
-          +-------------------+             |
-             ^           ^                  v
-             |           |           +--------------+
-           /odom     /goal_pose ---> | dwa_planner |
-             ^                       +--------------+
-             |                              |
-   +-------------------------+              v
-   | waypoint_navigator_node |           /cmd_vel
-   +-------------------------+
+                    TurtleBot3 Gazebo
+                 /scan  /odom  /cmd_vel
+                    |      |       ^
+                    v      |       |
+               +-----------+       |
+               | slam_node | ----- +
+               +-----------+    /map
+                      |
+                      v
+             +-------------------+
+             | path_planner_node | ---> /planned_path
+             +-------------------+             |
+                ^           ^                  v
+                |           |           +--------------+
+         /ekf_odom     /goal_pose ---> | dwa_planner |
+                ^                      +--------------+
+                |                             |
+      +----------------------+                v
+      | ekf_localizer_node   |             /cmd_vel
+      +----------------------+
+                ^
+                |
+      +-------------------------+
+      | waypoint_navigator_node |
+      +-------------------------+
 ```
 
 ## Gazebo Demo
@@ -138,6 +166,7 @@ Demo video: [gazebo_demo.mp4](./gazebo_demo.mp4)
 source /opt/ros/jazzy/setup.bash
 export ROS_DOMAIN_ID=42
 export TURTLEBOT3_MODEL=burger
+export NAV_ODOM_TOPIC=/ekf_odom
 export WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5"
 
 ./ros2_nodes/launch/run_gazebo_mission_demo.sh
@@ -145,6 +174,8 @@ export WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5"
 
 The mission wrapper reuses [navigation_demo.launch.py](../ros2_nodes/launch/navigation_demo.launch.py) and enables `waypoint_navigator_node` with:
 
+- `enable_ekf_localizer:=true`
+- `nav_odom_topic:=/ekf_odom`
 - `WAYPOINT_NAV_WAYPOINTS`: semicolon-delimited 2D mission
 - `WAYPOINT_NAV_LOOP`: `true` or `false`
 - `WAYPOINT_NAV_GOAL_TOLERANCE`: waypoint completion radius
@@ -167,10 +198,11 @@ ros2 topic pub --once /goal_pose geometry_msgs/msg/PoseStamped \
 ### Expected data flow
 
 1. `slam_node` receives `/scan` and `/odom`, then publishes `/map`.
-2. `waypoint_navigator_node` publishes the current mission waypoint on `/goal_pose`.
-3. `path_planner_node` rebuilds A* from `/map` and publishes `/planned_path`.
-4. `dwa_planner_node` follows `/planned_path` while avoiding live laser obstacles and publishes `/cmd_vel`.
-5. TurtleBot3 moves toward the requested goal in Gazebo.
+2. `ekf_localizer_node` converts `/odom` into `/ekf_odom` and `/ekf_pose`.
+3. `waypoint_navigator_node` publishes the current mission waypoint on `/goal_pose`.
+4. `path_planner_node` rebuilds A* from `/map` and publishes `/planned_path`.
+5. `dwa_planner_node` follows `/planned_path` while using `/ekf_odom` for state and publishes `/cmd_vel`.
+6. TurtleBot3 moves toward the requested goal in Gazebo.
 
 ### Verify topic wiring
 
@@ -178,6 +210,7 @@ ros2 topic pub --once /goal_pose geometry_msgs/msg/PoseStamped \
 ros2 topic list
 ros2 topic echo /scan --once
 ros2 topic echo /odom --once
+ros2 topic echo /ekf_odom --once
 ros2 topic echo /map --once
 ros2 topic echo /planned_path --qos-durability transient_local --once
 ros2 topic echo /cmd_vel geometry_msgs/msg/Twist --once
@@ -206,8 +239,15 @@ ros2 topic echo /cmd_vel geometry_msgs/msg/Twist --once
 - `occupied_log_odds` / `free_log_odds`: Bayesian update weights
 - `icp_max_iterations` (from algorithm defaults): ICP optimization limit
 
+### `ekf_localizer_node`
+
+- `EKF_INPUT_ODOM_TOPIC` (default `"/odom"`): raw odom input topic
+- `EKF_OUTPUT_ODOM_TOPIC` (default `"/ekf_odom"`): filtered odom output topic
+- `EKF_OUTPUT_POSE_TOPIC` (default `"/ekf_pose"`): filtered pose output topic
+
 ### `waypoint_navigator_node`
 
+- `RUST_NAV_ODOM_TOPIC` (default `"/odom"` unless launch overrides it): mission odom input topic
 - `WAYPOINT_NAV_WAYPOINTS` (default `"0.5,0.0;0.5,0.5;0.0,0.5"`): mission waypoints in the `map` frame
 - `WAYPOINT_NAV_GOAL_TOLERANCE` (default `0.35`): distance threshold for waypoint completion \[m\]
 - `WAYPOINT_NAV_LOOP` (default `false`): restart the mission after the last waypoint
@@ -221,10 +261,12 @@ ros2 topic echo /cmd_vel geometry_msgs/msg/Twist --once
 - `path_planner_node` logs `planner is not ready yet; waiting for /map`:
   - Confirm `slam_node` is running and `/map` is being published.
 - `path_planner_node` logs `robot pose from /odom is not available yet`:
-  - Confirm TurtleBot3 Gazebo is publishing `/odom`.
+  - Confirm the selected odom topic is publishing (`/odom` or `/ekf_odom` depending on launch mode).
 - `A* failed for start=... goal=...`:
   - The goal may be outside the current map bounds or inside an occupied cell.
 - No robot motion despite `/planned_path`:
   - Check `/cmd_vel` output from `dwa_planner_node` and verify TurtleBot3 Gazebo is subscribed to `/cmd_vel`.
+- `ekf_localizer_node` is running but `/ekf_odom` stays silent:
+  - Confirm raw `/odom` exists and that `EKF_INPUT_ODOM_TOPIC` matches it.
 - Mission demo does not advance to the next waypoint:
-  - Check `/odom` and confirm the robot is entering `WAYPOINT_NAV_GOAL_TOLERANCE` around the active waypoint.
+  - Check the selected mission odom topic and confirm the robot is entering `WAYPOINT_NAV_GOAL_TOLERANCE` around the active waypoint.

--- a/ros2_nodes/dwa_planner_node/src/main.rs
+++ b/ros2_nodes/dwa_planner_node/src/main.rs
@@ -12,6 +12,8 @@ use safe_drive::{
 use std::{env, sync::{Arc, Mutex}};
 
 const DEFAULT_ODOM_TOPIC: &str = "/odom";
+const DEFAULT_GOAL_THRESHOLD: f64 = 0.3;
+const DEFAULT_ROBOT_RADIUS: f64 = 0.35;
 
 #[derive(Clone, Copy)]
 struct OdomState {
@@ -46,6 +48,25 @@ fn nearest_goal(path: &[Point2D], x: f64, y: f64) -> Option<Point2D> {
     path.get(look_ahead).copied()
 }
 
+fn load_f64_env(name: &str, default: f64) -> Result<f64, String> {
+    match env::var(name) {
+        Ok(raw) if !raw.trim().is_empty() => {
+            let value = raw
+                .trim()
+                .parse::<f64>()
+                .map_err(|_| format!("invalid {} '{}'", name, raw))?;
+            if !value.is_finite() || value <= 0.0 {
+                return Err(format!(
+                    "{} must be positive and finite, got {}",
+                    name, value
+                ));
+            }
+            Ok(value)
+        }
+        _ => Ok(default),
+    }
+}
+
 fn build_obstacles_from_scan(scan: &sensor_msgs::msg::LaserScan, odom: OdomState) -> Vec<Point2D> {
     let mut obstacles = Vec::new();
     let mut angle = scan.angle_min as f64;
@@ -71,6 +92,10 @@ fn main() -> Result<(), DynError> {
         .ok()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_ODOM_TOPIC.to_string());
+    let goal_threshold = load_f64_env("DWA_GOAL_THRESHOLD", DEFAULT_GOAL_THRESHOLD)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+    let robot_radius = load_f64_env("DWA_ROBOT_RADIUS", DEFAULT_ROBOT_RADIUS)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
 
     let mut path_qos = Profile::default();
     path_qos.durability = DurabilityPolicy::TransientLocal;
@@ -81,13 +106,19 @@ fn main() -> Result<(), DynError> {
     let cmd_pub = node.create_publisher::<geometry_msgs::msg::Twist>("/cmd_vel", None)?;
 
     let mut config = DWAConfig::default();
-    config.goal_threshold = 0.3;
-    config.robot_radius = 0.35;
+    config.goal_threshold = goal_threshold;
+    config.robot_radius = robot_radius;
 
     let planner = Arc::new(Mutex::new(DWAPlanner::new(config)));
     let state = Arc::new(Mutex::new(PlannerState::default()));
     let logger = Logger::new("dwa_planner_node");
-    pr_info!(logger, "dwa planner started (odom topic: {})", odom_topic);
+    pr_info!(
+        logger,
+        "dwa planner started (odom topic: {}, goal_threshold={:.2}, robot_radius={:.2})",
+        odom_topic,
+        goal_threshold,
+        robot_radius
+    );
 
     let mut selector = ctx.create_selector()?;
 

--- a/ros2_nodes/dwa_planner_node/src/main.rs
+++ b/ros2_nodes/dwa_planner_node/src/main.rs
@@ -9,7 +9,9 @@ use safe_drive::{
     qos::{policy::DurabilityPolicy, Profile},
     pr_info, pr_warn,
 };
-use std::sync::{Arc, Mutex};
+use std::{env, sync::{Arc, Mutex}};
+
+const DEFAULT_ODOM_TOPIC: &str = "/odom";
 
 #[derive(Clone, Copy)]
 struct OdomState {
@@ -65,12 +67,16 @@ fn build_obstacles_from_scan(scan: &sensor_msgs::msg::LaserScan, odom: OdomState
 fn main() -> Result<(), DynError> {
     let ctx = Context::new()?;
     let node = ctx.create_node("dwa_planner_node", None, Default::default())?;
+    let odom_topic = env::var("RUST_NAV_ODOM_TOPIC")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_ODOM_TOPIC.to_string());
 
     let mut path_qos = Profile::default();
     path_qos.durability = DurabilityPolicy::TransientLocal;
 
     let scan_sub = node.create_subscriber::<sensor_msgs::msg::LaserScan>("/scan", None)?;
-    let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>("/odom", None)?;
+    let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>(&odom_topic, None)?;
     let path_sub = node.create_subscriber::<nav_msgs::msg::Path>("/planned_path", Some(path_qos))?;
     let cmd_pub = node.create_publisher::<geometry_msgs::msg::Twist>("/cmd_vel", None)?;
 
@@ -81,7 +87,7 @@ fn main() -> Result<(), DynError> {
     let planner = Arc::new(Mutex::new(DWAPlanner::new(config)));
     let state = Arc::new(Mutex::new(PlannerState::default()));
     let logger = Logger::new("dwa_planner_node");
-    pr_info!(logger, "dwa planner started");
+    pr_info!(logger, "dwa planner started (odom topic: {})", odom_topic);
 
     let mut selector = ctx.create_selector()?;
 

--- a/ros2_nodes/dwa_planner_node/src/main.rs
+++ b/ros2_nodes/dwa_planner_node/src/main.rs
@@ -6,10 +6,13 @@ use safe_drive::{
     error::DynError,
     logger::Logger,
     msg::common_interfaces::{geometry_msgs, nav_msgs, sensor_msgs},
-    qos::{policy::DurabilityPolicy, Profile},
     pr_info, pr_warn,
+    qos::{policy::DurabilityPolicy, Profile},
 };
-use std::{env, sync::{Arc, Mutex}};
+use std::{
+    env,
+    sync::{Arc, Mutex},
+};
 
 const DEFAULT_ODOM_TOPIC: &str = "/odom";
 const DEFAULT_GOAL_THRESHOLD: f64 = 0.3;
@@ -46,6 +49,26 @@ fn nearest_goal(path: &[Point2D], x: f64, y: f64) -> Option<Point2D> {
     })?;
     let look_ahead = (nearest_idx + 10).min(path.len().saturating_sub(1));
     path.get(look_ahead).copied()
+}
+
+fn publish_stop_command(
+    publisher: &safe_drive::topic::publisher::Publisher<geometry_msgs::msg::Twist>,
+    logger: &Logger,
+) {
+    let mut cmd = match geometry_msgs::msg::Twist::new() {
+        Some(msg) => msg,
+        None => {
+            pr_warn!(logger, "failed to allocate Twist message for stop command");
+            return;
+        }
+    };
+    cmd.linear.x = 0.0;
+    cmd.angular.z = 0.0;
+    if let Err(err) = publisher.send(&cmd) {
+        pr_warn!(logger, "failed to publish stop command: {}", err);
+    } else {
+        pr_info!(logger, "published stop command after path clear");
+    }
 }
 
 fn load_f64_env(name: &str, default: f64) -> Result<f64, String> {
@@ -102,8 +125,9 @@ fn main() -> Result<(), DynError> {
 
     let scan_sub = node.create_subscriber::<sensor_msgs::msg::LaserScan>("/scan", None)?;
     let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>(&odom_topic, None)?;
-    let path_sub = node.create_subscriber::<nav_msgs::msg::Path>("/planned_path", Some(path_qos))?;
-    let cmd_pub = node.create_publisher::<geometry_msgs::msg::Twist>("/cmd_vel", None)?;
+    let path_sub =
+        node.create_subscriber::<nav_msgs::msg::Path>("/planned_path", Some(path_qos))?;
+    let cmd_pub = Arc::new(node.create_publisher::<geometry_msgs::msg::Twist>("/cmd_vel", None)?);
 
     let mut config = DWAConfig::default();
     config.goal_threshold = goal_threshold;
@@ -123,6 +147,7 @@ fn main() -> Result<(), DynError> {
     let mut selector = ctx.create_selector()?;
 
     let state_path = state.clone();
+    let cmd_path = cmd_pub.clone();
     let log_path = Logger::new("dwa_planner_node");
     selector.add_subscriber(
         path_sub,
@@ -138,6 +163,7 @@ fn main() -> Result<(), DynError> {
                     if had_path {
                         st.warned_missing_path = true;
                         pr_warn!(log_path, "planned path cleared");
+                        publish_stop_command(cmd_path.as_ref(), &log_path);
                     }
                 } else {
                     st.warned_missing_path = false;
@@ -207,7 +233,10 @@ fn main() -> Result<(), DynError> {
                 Some(goal) => goal,
                 None => {
                     if should_warn_missing_path {
-                        pr_warn!(log_odom, "planned path is empty; waiting for planner output");
+                        pr_warn!(
+                            log_odom,
+                            "planned path is empty; waiting for planner output"
+                        );
                     }
                     return;
                 }
@@ -248,7 +277,7 @@ fn main() -> Result<(), DynError> {
             };
             cmd.linear.x = control[0];
             cmd.angular.z = control[1];
-            let _ = pub_odom.send(&cmd);
+            let _ = pub_odom.as_ref().send(&cmd);
         }),
     );
 

--- a/ros2_nodes/ekf_localizer_node/Cargo.toml
+++ b/ros2_nodes/ekf_localizer_node/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ekf_localizer_node"
+version = "0.1.0"
+edition = "2021"
+description = "ROS2 EKF localizer node using rust_robotics_localization and safe_drive"
+
+[dependencies]
+safe_drive = { path = "../../../safe_drive", features = ["jazzy"] }
+rust_robotics_core = { path = "../../crates/rust_robotics_core" }
+rust_robotics_localization = { path = "../../crates/rust_robotics_localization" }
+
+[workspace]

--- a/ros2_nodes/ekf_localizer_node/src/main.rs
+++ b/ros2_nodes/ekf_localizer_node/src/main.rs
@@ -4,19 +4,22 @@ use safe_drive::{
     context::Context,
     error::DynError,
     logger::Logger,
-    msg::common_interfaces::{geometry_msgs, nav_msgs},
+    msg::{
+        builtin_interfaces,
+        common_interfaces::{geometry_msgs, nav_msgs},
+    },
     pr_info, pr_warn,
 };
 use std::{
     env, io,
     sync::{Arc, Mutex},
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, Instant},
 };
 
 const DEFAULT_INPUT_ODOM_TOPIC: &str = "/odom";
 const DEFAULT_OUTPUT_ODOM_TOPIC: &str = "/ekf_odom";
 const DEFAULT_OUTPUT_POSE_TOPIC: &str = "/ekf_pose";
-const POSE_FRAME_ID: &str = "map";
+const DEFAULT_FRAME_ID: &str = "odom";
 const LOG_INTERVAL: Duration = Duration::from_secs(5);
 const FALLBACK_DT: f64 = 0.1;
 const MIN_DT: f64 = 1e-3;
@@ -70,13 +73,32 @@ fn initial_state_from_odom(msg: &nav_msgs::msg::Odometry) -> State2D {
     )
 }
 
+fn copy_stamp(
+    target: &mut builtin_interfaces::UnsafeTime,
+    source: &builtin_interfaces::UnsafeTime,
+) {
+    target.sec = source.sec;
+    target.nanosec = source.nanosec;
+}
+
+fn output_frame_id(source: &nav_msgs::msg::Odometry) -> String {
+    let source_frame_id = source.header.frame_id.get_string();
+    if source_frame_id.is_empty() {
+        DEFAULT_FRAME_ID.to_string()
+    } else {
+        source_frame_id
+    }
+}
+
 fn publish_pose(
     publisher: &safe_drive::topic::publisher::Publisher<geometry_msgs::msg::PoseStamped>,
     state: State2D,
+    source: &nav_msgs::msg::Odometry,
 ) -> Result<(), DynError> {
     let mut msg = geometry_msgs::msg::PoseStamped::new().ok_or("failed to allocate PoseStamped")?;
-    msg.header.stamp = SystemTime::now().into();
-    let _ = msg.header.frame_id.assign(POSE_FRAME_ID);
+    copy_stamp(&mut msg.header.stamp, &source.header.stamp);
+    let frame_id = output_frame_id(source);
+    let _ = msg.header.frame_id.assign(&frame_id);
     msg.pose.position.x = state.x;
     msg.pose.position.y = state.y;
     msg.pose.position.z = 0.0;
@@ -91,13 +113,9 @@ fn publish_odom(
     source: &nav_msgs::msg::Odometry,
 ) -> Result<(), DynError> {
     let mut msg = nav_msgs::msg::Odometry::new().ok_or("failed to allocate Odometry")?;
-    msg.header.stamp = SystemTime::now().into();
-    let source_frame_id = source.header.frame_id.get_string();
-    if source_frame_id.is_empty() {
-        let _ = msg.header.frame_id.assign(POSE_FRAME_ID);
-    } else {
-        let _ = msg.header.frame_id.assign(&source_frame_id);
-    }
+    copy_stamp(&mut msg.header.stamp, &source.header.stamp);
+    let frame_id = output_frame_id(source);
+    let _ = msg.header.frame_id.assign(&frame_id);
     let child_frame_id = source.child_frame_id.get_string();
     if !child_frame_id.is_empty() {
         let _ = msg.child_frame_id.assign(&child_frame_id);
@@ -136,8 +154,9 @@ fn main() -> Result<(), DynError> {
     let output_odom_topic = topic_from_env("EKF_OUTPUT_ODOM_TOPIC", DEFAULT_OUTPUT_ODOM_TOPIC);
     let output_pose_topic = topic_from_env("EKF_OUTPUT_POSE_TOPIC", DEFAULT_OUTPUT_POSE_TOPIC);
 
-    let initial_localizer = EKFLocalizer::with_initial_state_2d(State2D::origin(), EKFConfig::default())
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err.to_string()))?;
+    let initial_localizer =
+        EKFLocalizer::with_initial_state_2d(State2D::origin(), EKFConfig::default())
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err.to_string()))?;
     let shared_state = Arc::new(Mutex::new(EkfState {
         localizer: initial_localizer,
         initialized: false,
@@ -148,7 +167,8 @@ fn main() -> Result<(), DynError> {
     let ctx = Context::new()?;
     let node = ctx.create_node("ekf_localizer_node", None, Default::default())?;
     let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>(&input_odom_topic, None)?;
-    let pose_pub = node.create_publisher::<geometry_msgs::msg::PoseStamped>(&output_pose_topic, None)?;
+    let pose_pub =
+        node.create_publisher::<geometry_msgs::msg::PoseStamped>(&output_pose_topic, None)?;
     let odom_pub = node.create_publisher::<nav_msgs::msg::Odometry>(&output_odom_topic, None)?;
 
     let logger = Logger::new("ekf_localizer_node");
@@ -175,23 +195,51 @@ fn main() -> Result<(), DynError> {
                 }
             };
 
-            let dt = sanitize_dt(state.last_update_at, now);
-            state.last_update_at = Some(now);
-
             if !state.initialized {
                 let initialized = initial_state_from_odom(&msg);
-                state.localizer = match EKFLocalizer::with_initial_state_2d(
-                    initialized,
-                    EKFConfig::default(),
-                ) {
-                    Ok(localizer) => localizer,
-                    Err(err) => {
-                        pr_warn!(logger_cb, "failed to initialize EKF state: {}", err);
-                        return;
-                    }
-                };
+                state.localizer =
+                    match EKFLocalizer::with_initial_state_2d(initialized, EKFConfig::default()) {
+                        Ok(localizer) => localizer,
+                        Err(err) => {
+                            pr_warn!(logger_cb, "failed to initialize EKF state: {}", err);
+                            return;
+                        }
+                    };
                 state.initialized = true;
+                state.last_update_at = Some(now);
+
+                if let Err(err) = publish_pose(&pose_pub, initialized, &msg) {
+                    pr_warn!(
+                        logger_cb,
+                        "failed to publish initial filtered pose: {}",
+                        err
+                    );
+                    return;
+                }
+                if let Err(err) = publish_odom(&odom_pub, initialized, &msg) {
+                    pr_warn!(
+                        logger_cb,
+                        "failed to publish initial filtered odom: {}",
+                        err
+                    );
+                    return;
+                }
+
+                if should_log(&mut state.last_log_at, now) {
+                    pr_info!(
+                        logger_cb,
+                        "initialized filtered pose x={:.2} y={:.2} yaw={:.2} v={:.2}",
+                        initialized.x,
+                        initialized.y,
+                        initialized.yaw,
+                        initialized.v
+                    );
+                }
+                return;
             }
+
+            let dt = sanitize_dt(state.last_update_at, now);
+            state.last_update_at = Some(now);
 
             let measurement = Point2D::new(msg.pose.pose.position.x, msg.pose.pose.position.y);
             let control = ControlInput::new(msg.twist.twist.linear.x, msg.twist.twist.angular.z);
@@ -204,7 +252,7 @@ fn main() -> Result<(), DynError> {
                 }
             };
 
-            if let Err(err) = publish_pose(&pose_pub, estimate) {
+            if let Err(err) = publish_pose(&pose_pub, estimate, &msg) {
                 pr_warn!(logger_cb, "failed to publish filtered pose: {}", err);
                 return;
             }
@@ -233,7 +281,11 @@ fn main() -> Result<(), DynError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{sanitize_dt, yaw_from_quaternion, FALLBACK_DT, MAX_DT, MIN_DT};
+    use super::{
+        copy_stamp, output_frame_id, sanitize_dt, yaw_from_quaternion, DEFAULT_FRAME_ID,
+        FALLBACK_DT, MAX_DT, MIN_DT,
+    };
+    use safe_drive::msg::common_interfaces::nav_msgs;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -256,5 +308,24 @@ mod tests {
         let half = std::f64::consts::FRAC_PI_4;
         let yaw = yaw_from_quaternion(0.0, 0.0, half.sin(), half.cos());
         assert!((yaw - std::f64::consts::FRAC_PI_2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn output_frame_id_falls_back_when_source_is_empty() {
+        let msg = nav_msgs::msg::Odometry::new().unwrap();
+        assert_eq!(output_frame_id(&msg), DEFAULT_FRAME_ID);
+    }
+
+    #[test]
+    fn copy_stamp_preserves_source_timestamp() {
+        let mut source = nav_msgs::msg::Odometry::new().unwrap();
+        let mut target = nav_msgs::msg::Odometry::new().unwrap();
+        source.header.stamp.sec = 12;
+        source.header.stamp.nanosec = 34;
+
+        copy_stamp(&mut target.header.stamp, &source.header.stamp);
+
+        assert_eq!(target.header.stamp.sec, 12);
+        assert_eq!(target.header.stamp.nanosec, 34);
     }
 }

--- a/ros2_nodes/ekf_localizer_node/src/main.rs
+++ b/ros2_nodes/ekf_localizer_node/src/main.rs
@@ -1,0 +1,260 @@
+use rust_robotics_core::{ControlInput, Point2D, State2D};
+use rust_robotics_localization::{EKFConfig, EKFLocalizer};
+use safe_drive::{
+    context::Context,
+    error::DynError,
+    logger::Logger,
+    msg::common_interfaces::{geometry_msgs, nav_msgs},
+    pr_info, pr_warn,
+};
+use std::{
+    env, io,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant, SystemTime},
+};
+
+const DEFAULT_INPUT_ODOM_TOPIC: &str = "/odom";
+const DEFAULT_OUTPUT_ODOM_TOPIC: &str = "/ekf_odom";
+const DEFAULT_OUTPUT_POSE_TOPIC: &str = "/ekf_pose";
+const POSE_FRAME_ID: &str = "map";
+const LOG_INTERVAL: Duration = Duration::from_secs(5);
+const FALLBACK_DT: f64 = 0.1;
+const MIN_DT: f64 = 1e-3;
+const MAX_DT: f64 = 0.5;
+
+struct EkfState {
+    localizer: EKFLocalizer,
+    initialized: bool,
+    last_update_at: Option<Instant>,
+    last_log_at: Option<Instant>,
+}
+
+fn topic_from_env(key: &str, default: &str) -> String {
+    env::var(key)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn yaw_from_quaternion(x: f64, y: f64, z: f64, w: f64) -> f64 {
+    let siny_cosp = 2.0 * (w * z + x * y);
+    let cosy_cosp = 1.0 - 2.0 * (y * y + z * z);
+    siny_cosp.atan2(cosy_cosp)
+}
+
+fn apply_yaw_to_pose(pose: &mut geometry_msgs::msg::Pose, yaw: f64) {
+    let half_yaw = 0.5 * yaw;
+    pose.orientation.x = 0.0;
+    pose.orientation.y = 0.0;
+    pose.orientation.z = half_yaw.sin();
+    pose.orientation.w = half_yaw.cos();
+}
+
+fn sanitize_dt(last_update_at: Option<Instant>, now: Instant) -> f64 {
+    match last_update_at {
+        Some(previous) => now
+            .saturating_duration_since(previous)
+            .as_secs_f64()
+            .clamp(MIN_DT, MAX_DT),
+        None => FALLBACK_DT,
+    }
+}
+
+fn initial_state_from_odom(msg: &nav_msgs::msg::Odometry) -> State2D {
+    let orientation = &msg.pose.pose.orientation;
+    State2D::new(
+        msg.pose.pose.position.x,
+        msg.pose.pose.position.y,
+        yaw_from_quaternion(orientation.x, orientation.y, orientation.z, orientation.w),
+        msg.twist.twist.linear.x,
+    )
+}
+
+fn publish_pose(
+    publisher: &safe_drive::topic::publisher::Publisher<geometry_msgs::msg::PoseStamped>,
+    state: State2D,
+) -> Result<(), DynError> {
+    let mut msg = geometry_msgs::msg::PoseStamped::new().ok_or("failed to allocate PoseStamped")?;
+    msg.header.stamp = SystemTime::now().into();
+    let _ = msg.header.frame_id.assign(POSE_FRAME_ID);
+    msg.pose.position.x = state.x;
+    msg.pose.position.y = state.y;
+    msg.pose.position.z = 0.0;
+    apply_yaw_to_pose(&mut msg.pose, state.yaw);
+    publisher.send(&msg)?;
+    Ok(())
+}
+
+fn publish_odom(
+    publisher: &safe_drive::topic::publisher::Publisher<nav_msgs::msg::Odometry>,
+    state: State2D,
+    source: &nav_msgs::msg::Odometry,
+) -> Result<(), DynError> {
+    let mut msg = nav_msgs::msg::Odometry::new().ok_or("failed to allocate Odometry")?;
+    msg.header.stamp = SystemTime::now().into();
+    let source_frame_id = source.header.frame_id.get_string();
+    if source_frame_id.is_empty() {
+        let _ = msg.header.frame_id.assign(POSE_FRAME_ID);
+    } else {
+        let _ = msg.header.frame_id.assign(&source_frame_id);
+    }
+    let child_frame_id = source.child_frame_id.get_string();
+    if !child_frame_id.is_empty() {
+        let _ = msg.child_frame_id.assign(&child_frame_id);
+    }
+
+    msg.pose.pose.position.x = state.x;
+    msg.pose.pose.position.y = state.y;
+    msg.pose.pose.position.z = 0.0;
+    apply_yaw_to_pose(&mut msg.pose.pose, state.yaw);
+    msg.pose.covariance = source.pose.covariance;
+
+    msg.twist.twist.linear.x = source.twist.twist.linear.x;
+    msg.twist.twist.linear.y = source.twist.twist.linear.y;
+    msg.twist.twist.linear.z = source.twist.twist.linear.z;
+    msg.twist.twist.angular.x = source.twist.twist.angular.x;
+    msg.twist.twist.angular.y = source.twist.twist.angular.y;
+    msg.twist.twist.angular.z = source.twist.twist.angular.z;
+    msg.twist.covariance = source.twist.covariance;
+
+    publisher.send(&msg)?;
+    Ok(())
+}
+
+fn should_log(last_log_at: &mut Option<Instant>, now: Instant) -> bool {
+    let do_log = last_log_at
+        .map(|previous| now.duration_since(previous) >= LOG_INTERVAL)
+        .unwrap_or(true);
+    if do_log {
+        *last_log_at = Some(now);
+    }
+    do_log
+}
+
+fn main() -> Result<(), DynError> {
+    let input_odom_topic = topic_from_env("EKF_INPUT_ODOM_TOPIC", DEFAULT_INPUT_ODOM_TOPIC);
+    let output_odom_topic = topic_from_env("EKF_OUTPUT_ODOM_TOPIC", DEFAULT_OUTPUT_ODOM_TOPIC);
+    let output_pose_topic = topic_from_env("EKF_OUTPUT_POSE_TOPIC", DEFAULT_OUTPUT_POSE_TOPIC);
+
+    let initial_localizer = EKFLocalizer::with_initial_state_2d(State2D::origin(), EKFConfig::default())
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err.to_string()))?;
+    let shared_state = Arc::new(Mutex::new(EkfState {
+        localizer: initial_localizer,
+        initialized: false,
+        last_update_at: None,
+        last_log_at: None,
+    }));
+
+    let ctx = Context::new()?;
+    let node = ctx.create_node("ekf_localizer_node", None, Default::default())?;
+    let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>(&input_odom_topic, None)?;
+    let pose_pub = node.create_publisher::<geometry_msgs::msg::PoseStamped>(&output_pose_topic, None)?;
+    let odom_pub = node.create_publisher::<nav_msgs::msg::Odometry>(&output_odom_topic, None)?;
+
+    let logger = Logger::new("ekf_localizer_node");
+    pr_info!(
+        logger,
+        "ekf localizer started (input: {}, pose: {}, odom: {})",
+        input_odom_topic,
+        output_pose_topic,
+        output_odom_topic
+    );
+
+    let mut selector = ctx.create_selector()?;
+    let state_cb = shared_state.clone();
+    let logger_cb = Logger::new("ekf_localizer_node");
+    selector.add_subscriber(
+        odom_sub,
+        Box::new(move |msg| {
+            let now = Instant::now();
+            let mut state = match state_cb.lock() {
+                Ok(guard) => guard,
+                Err(_) => {
+                    pr_warn!(logger_cb, "failed to lock EKF state on odom callback");
+                    return;
+                }
+            };
+
+            let dt = sanitize_dt(state.last_update_at, now);
+            state.last_update_at = Some(now);
+
+            if !state.initialized {
+                let initialized = initial_state_from_odom(&msg);
+                state.localizer = match EKFLocalizer::with_initial_state_2d(
+                    initialized,
+                    EKFConfig::default(),
+                ) {
+                    Ok(localizer) => localizer,
+                    Err(err) => {
+                        pr_warn!(logger_cb, "failed to initialize EKF state: {}", err);
+                        return;
+                    }
+                };
+                state.initialized = true;
+            }
+
+            let measurement = Point2D::new(msg.pose.pose.position.x, msg.pose.pose.position.y);
+            let control = ControlInput::new(msg.twist.twist.linear.x, msg.twist.twist.angular.z);
+
+            let estimate = match state.localizer.estimate_state(measurement, control, dt) {
+                Ok(estimate) => estimate,
+                Err(err) => {
+                    pr_warn!(logger_cb, "EKF update failed: {}", err);
+                    return;
+                }
+            };
+
+            if let Err(err) = publish_pose(&pose_pub, estimate) {
+                pr_warn!(logger_cb, "failed to publish filtered pose: {}", err);
+                return;
+            }
+            if let Err(err) = publish_odom(&odom_pub, estimate, &msg) {
+                pr_warn!(logger_cb, "failed to publish filtered odom: {}", err);
+                return;
+            }
+
+            if should_log(&mut state.last_log_at, now) {
+                pr_info!(
+                    logger_cb,
+                    "filtered pose x={:.2} y={:.2} yaw={:.2} v={:.2}",
+                    estimate.x,
+                    estimate.y,
+                    estimate.yaw,
+                    estimate.v
+                );
+            }
+        }),
+    );
+
+    loop {
+        selector.wait()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sanitize_dt, yaw_from_quaternion, FALLBACK_DT, MAX_DT, MIN_DT};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn sanitize_dt_uses_default_without_history() {
+        let now = Instant::now();
+        assert!((sanitize_dt(None, now) - FALLBACK_DT).abs() < 1e-9);
+    }
+
+    #[test]
+    fn sanitize_dt_clamps_bounds() {
+        let now = Instant::now();
+        let short = now - Duration::from_micros(100);
+        let long = now - Duration::from_secs(2);
+        assert!((sanitize_dt(Some(short), now) - MIN_DT).abs() < 1e-9);
+        assert!((sanitize_dt(Some(long), now) - MAX_DT).abs() < 1e-9);
+    }
+
+    #[test]
+    fn yaw_from_quaternion_handles_planar_rotation() {
+        let half = std::f64::consts::FRAC_PI_4;
+        let yaw = yaw_from_quaternion(0.0, 0.0, half.sin(), half.cos());
+        assert!((yaw - std::f64::consts::FRAC_PI_2).abs() < 1e-9);
+    }
+}

--- a/ros2_nodes/ekf_localizer_node/src/main.rs
+++ b/ros2_nodes/ekf_localizer_node/src/main.rs
@@ -28,8 +28,14 @@ const MAX_DT: f64 = 0.5;
 struct EkfState {
     localizer: EKFLocalizer,
     initialized: bool,
-    last_update_at: Option<Instant>,
+    last_update_at: Option<MessageStamp>,
     last_log_at: Option<Instant>,
+}
+
+#[derive(Clone, Copy)]
+struct MessageStamp {
+    sec: i32,
+    nanosec: u32,
 }
 
 fn topic_from_env(key: &str, default: &str) -> String {
@@ -53,12 +59,16 @@ fn apply_yaw_to_pose(pose: &mut geometry_msgs::msg::Pose, yaw: f64) {
     pose.orientation.w = half_yaw.cos();
 }
 
-fn sanitize_dt(last_update_at: Option<Instant>, now: Instant) -> f64 {
+fn sanitize_dt(last_update_at: Option<MessageStamp>, now: MessageStamp) -> f64 {
     match last_update_at {
-        Some(previous) => now
-            .saturating_duration_since(previous)
-            .as_secs_f64()
-            .clamp(MIN_DT, MAX_DT),
+        Some(previous) => {
+            let delta_nanos = stamp_to_nanos(now) - stamp_to_nanos(previous);
+            if delta_nanos <= 0 {
+                MIN_DT
+            } else {
+                (delta_nanos as f64 / 1_000_000_000.0).clamp(MIN_DT, MAX_DT)
+            }
+        }
         None => FALLBACK_DT,
     }
 }
@@ -79,6 +89,17 @@ fn copy_stamp(
 ) {
     target.sec = source.sec;
     target.nanosec = source.nanosec;
+}
+
+fn stamp_from_odom(msg: &nav_msgs::msg::Odometry) -> MessageStamp {
+    MessageStamp {
+        sec: msg.header.stamp.sec,
+        nanosec: msg.header.stamp.nanosec,
+    }
+}
+
+fn stamp_to_nanos(stamp: MessageStamp) -> i128 {
+    i128::from(stamp.sec) * 1_000_000_000 + i128::from(stamp.nanosec)
 }
 
 fn output_frame_id(source: &nav_msgs::msg::Odometry) -> String {
@@ -187,6 +208,7 @@ fn main() -> Result<(), DynError> {
         odom_sub,
         Box::new(move |msg| {
             let now = Instant::now();
+            let msg_stamp = stamp_from_odom(&msg);
             let mut state = match state_cb.lock() {
                 Ok(guard) => guard,
                 Err(_) => {
@@ -206,7 +228,7 @@ fn main() -> Result<(), DynError> {
                         }
                     };
                 state.initialized = true;
-                state.last_update_at = Some(now);
+                state.last_update_at = Some(msg_stamp);
 
                 if let Err(err) = publish_pose(&pose_pub, initialized, &msg) {
                     pr_warn!(
@@ -238,8 +260,8 @@ fn main() -> Result<(), DynError> {
                 return;
             }
 
-            let dt = sanitize_dt(state.last_update_at, now);
-            state.last_update_at = Some(now);
+            let dt = sanitize_dt(state.last_update_at, msg_stamp);
+            state.last_update_at = Some(msg_stamp);
 
             let measurement = Point2D::new(msg.pose.pose.position.x, msg.pose.pose.position.y);
             let control = ControlInput::new(msg.twist.twist.linear.x, msg.twist.twist.angular.z);
@@ -282,25 +304,46 @@ fn main() -> Result<(), DynError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        copy_stamp, output_frame_id, sanitize_dt, yaw_from_quaternion, DEFAULT_FRAME_ID,
-        FALLBACK_DT, MAX_DT, MIN_DT,
+        copy_stamp, output_frame_id, sanitize_dt, stamp_to_nanos, yaw_from_quaternion,
+        MessageStamp, DEFAULT_FRAME_ID, FALLBACK_DT, MAX_DT, MIN_DT,
     };
     use safe_drive::msg::common_interfaces::nav_msgs;
-    use std::time::{Duration, Instant};
 
     #[test]
     fn sanitize_dt_uses_default_without_history() {
-        let now = Instant::now();
+        let now = MessageStamp {
+            sec: 10,
+            nanosec: 0,
+        };
         assert!((sanitize_dt(None, now) - FALLBACK_DT).abs() < 1e-9);
     }
 
     #[test]
     fn sanitize_dt_clamps_bounds() {
-        let now = Instant::now();
-        let short = now - Duration::from_micros(100);
-        let long = now - Duration::from_secs(2);
+        let now = MessageStamp {
+            sec: 10,
+            nanosec: 0,
+        };
+        let short = MessageStamp {
+            sec: 9,
+            nanosec: 999_900_000,
+        };
+        let long = MessageStamp { sec: 8, nanosec: 0 };
         assert!((sanitize_dt(Some(short), now) - MIN_DT).abs() < 1e-9);
         assert!((sanitize_dt(Some(long), now) - MAX_DT).abs() < 1e-9);
+    }
+
+    #[test]
+    fn sanitize_dt_uses_min_dt_for_non_monotonic_stamp() {
+        let previous = MessageStamp {
+            sec: 10,
+            nanosec: 500_000_000,
+        };
+        let current = MessageStamp {
+            sec: 10,
+            nanosec: 400_000_000,
+        };
+        assert!((sanitize_dt(Some(previous), current) - MIN_DT).abs() < 1e-9);
     }
 
     #[test]
@@ -327,5 +370,14 @@ mod tests {
 
         assert_eq!(target.header.stamp.sec, 12);
         assert_eq!(target.header.stamp.nanosec, 34);
+    }
+
+    #[test]
+    fn stamp_to_nanos_combines_sec_and_nanosec() {
+        let stamp = MessageStamp {
+            sec: 3,
+            nanosec: 25,
+        };
+        assert_eq!(stamp_to_nanos(stamp), 3_000_000_025);
     }
 }

--- a/ros2_nodes/launch/navigation_demo.launch.py
+++ b/ros2_nodes/launch/navigation_demo.launch.py
@@ -46,6 +46,8 @@ def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
         [
             DeclareLaunchArgument("turtlebot3_model", default_value="burger"),
+            DeclareLaunchArgument("enable_ekf_localizer", default_value="false"),
+            DeclareLaunchArgument("nav_odom_topic", default_value="/odom"),
             DeclareLaunchArgument("enable_waypoint_navigator", default_value="false"),
             DeclareLaunchArgument(
                 "waypoint_mission", default_value="0.5,0.0;0.5,0.5;0.0,0.5"
@@ -69,8 +71,32 @@ def generate_launch_description() -> LaunchDescription:
                 period=5.0,
                 actions=[
                     rust_node_process(ros2_nodes_dir, "slam_node"),
-                    rust_node_process(ros2_nodes_dir, "path_planner_node"),
-                    rust_node_process(ros2_nodes_dir, "dwa_planner_node"),
+                    rust_node_process(
+                        ros2_nodes_dir,
+                        "ekf_localizer_node",
+                        condition=IfCondition(
+                            LaunchConfiguration("enable_ekf_localizer")
+                        ),
+                        additional_env={
+                            "EKF_INPUT_ODOM_TOPIC": "/odom",
+                            "EKF_OUTPUT_ODOM_TOPIC": LaunchConfiguration("nav_odom_topic"),
+                            "EKF_OUTPUT_POSE_TOPIC": "/ekf_pose",
+                        },
+                    ),
+                    rust_node_process(
+                        ros2_nodes_dir,
+                        "path_planner_node",
+                        additional_env={
+                            "RUST_NAV_ODOM_TOPIC": LaunchConfiguration("nav_odom_topic")
+                        },
+                    ),
+                    rust_node_process(
+                        ros2_nodes_dir,
+                        "dwa_planner_node",
+                        additional_env={
+                            "RUST_NAV_ODOM_TOPIC": LaunchConfiguration("nav_odom_topic")
+                        },
+                    ),
                     rust_node_process(
                         ros2_nodes_dir,
                         "waypoint_navigator_node",
@@ -78,6 +104,7 @@ def generate_launch_description() -> LaunchDescription:
                             LaunchConfiguration("enable_waypoint_navigator")
                         ),
                         additional_env={
+                            "RUST_NAV_ODOM_TOPIC": LaunchConfiguration("nav_odom_topic"),
                             "WAYPOINT_NAV_WAYPOINTS": LaunchConfiguration(
                                 "waypoint_mission"
                             ),

--- a/ros2_nodes/launch/navigation_demo.launch.py
+++ b/ros2_nodes/launch/navigation_demo.launch.py
@@ -46,12 +46,15 @@ def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
         [
             DeclareLaunchArgument("turtlebot3_model", default_value="burger"),
+            DeclareLaunchArgument("spawn_x", default_value="-2.0"),
+            DeclareLaunchArgument("spawn_y", default_value="-0.5"),
             DeclareLaunchArgument("enable_ekf_localizer", default_value="false"),
             DeclareLaunchArgument("nav_odom_topic", default_value="/odom"),
             DeclareLaunchArgument("enable_waypoint_navigator", default_value="false"),
             DeclareLaunchArgument(
                 "waypoint_mission", default_value="0.5,0.0;0.5,0.5;0.0,0.5"
             ),
+            DeclareLaunchArgument("waypoint_frame", default_value="map"),
             DeclareLaunchArgument("waypoint_loop", default_value="false"),
             DeclareLaunchArgument("waypoint_goal_tolerance", default_value="0.35"),
             SetEnvironmentVariable(
@@ -59,6 +62,10 @@ def generate_launch_description() -> LaunchDescription:
             ),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(turtlebot3_launch),
+                launch_arguments={
+                    "x_pose": LaunchConfiguration("spawn_x"),
+                    "y_pose": LaunchConfiguration("spawn_y"),
+                }.items(),
             ),
             Node(
                 package="ros_gz_bridge",
@@ -108,6 +115,7 @@ def generate_launch_description() -> LaunchDescription:
                             "WAYPOINT_NAV_WAYPOINTS": LaunchConfiguration(
                                 "waypoint_mission"
                             ),
+                            "WAYPOINT_NAV_FRAME": LaunchConfiguration("waypoint_frame"),
                             "WAYPOINT_NAV_LOOP": LaunchConfiguration("waypoint_loop"),
                             "WAYPOINT_NAV_GOAL_TOLERANCE": LaunchConfiguration(
                                 "waypoint_goal_tolerance"

--- a/ros2_nodes/launch/navigation_demo.launch.py
+++ b/ros2_nodes/launch/navigation_demo.launch.py
@@ -50,9 +50,10 @@ def generate_launch_description() -> LaunchDescription:
             DeclareLaunchArgument("spawn_y", default_value="-0.5"),
             DeclareLaunchArgument("enable_ekf_localizer", default_value="false"),
             DeclareLaunchArgument("nav_odom_topic", default_value="/odom"),
+            DeclareLaunchArgument("dwa_goal_threshold", default_value="0.3"),
             DeclareLaunchArgument("enable_waypoint_navigator", default_value="false"),
             DeclareLaunchArgument(
-                "waypoint_mission", default_value="0.5,0.0;0.5,0.5;0.0,0.5"
+                "waypoint_mission", default_value="0.4,0.0;0.1,0.4"
             ),
             DeclareLaunchArgument("waypoint_frame", default_value="map"),
             DeclareLaunchArgument("waypoint_loop", default_value="false"),
@@ -101,7 +102,8 @@ def generate_launch_description() -> LaunchDescription:
                         ros2_nodes_dir,
                         "dwa_planner_node",
                         additional_env={
-                            "RUST_NAV_ODOM_TOPIC": LaunchConfiguration("nav_odom_topic")
+                            "RUST_NAV_ODOM_TOPIC": LaunchConfiguration("nav_odom_topic"),
+                            "DWA_GOAL_THRESHOLD": LaunchConfiguration("dwa_goal_threshold"),
                         },
                     ),
                     rust_node_process(

--- a/ros2_nodes/launch/navigation_demo.launch.py
+++ b/ros2_nodes/launch/navigation_demo.launch.py
@@ -12,14 +12,27 @@ from launch.actions import (
     SetEnvironmentVariable,
     TimerAction,
 )
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
-def rust_node_process(pkg_dir: str, node_name: str) -> ExecuteProcess:
+def rust_node_process(
+    pkg_dir: str,
+    node_name: str,
+    *,
+    condition=None,
+    additional_env=None,
+) -> ExecuteProcess:
     binary_path = os.path.join(pkg_dir, node_name, "target", "release", node_name)
-    return ExecuteProcess(cmd=[binary_path], name=node_name, output="screen")
+    return ExecuteProcess(
+        cmd=[binary_path],
+        name=node_name,
+        output="screen",
+        condition=condition,
+        additional_env=additional_env,
+    )
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -33,6 +46,12 @@ def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
         [
             DeclareLaunchArgument("turtlebot3_model", default_value="burger"),
+            DeclareLaunchArgument("enable_waypoint_navigator", default_value="false"),
+            DeclareLaunchArgument(
+                "waypoint_mission", default_value="0.5,0.0;0.5,0.5;0.0,0.5"
+            ),
+            DeclareLaunchArgument("waypoint_loop", default_value="false"),
+            DeclareLaunchArgument("waypoint_goal_tolerance", default_value="0.35"),
             SetEnvironmentVariable(
                 "TURTLEBOT3_MODEL", LaunchConfiguration("turtlebot3_model")
             ),
@@ -52,6 +71,22 @@ def generate_launch_description() -> LaunchDescription:
                     rust_node_process(ros2_nodes_dir, "slam_node"),
                     rust_node_process(ros2_nodes_dir, "path_planner_node"),
                     rust_node_process(ros2_nodes_dir, "dwa_planner_node"),
+                    rust_node_process(
+                        ros2_nodes_dir,
+                        "waypoint_navigator_node",
+                        condition=IfCondition(
+                            LaunchConfiguration("enable_waypoint_navigator")
+                        ),
+                        additional_env={
+                            "WAYPOINT_NAV_WAYPOINTS": LaunchConfiguration(
+                                "waypoint_mission"
+                            ),
+                            "WAYPOINT_NAV_LOOP": LaunchConfiguration("waypoint_loop"),
+                            "WAYPOINT_NAV_GOAL_TOLERANCE": LaunchConfiguration(
+                                "waypoint_goal_tolerance"
+                            ),
+                        },
+                    ),
                 ],
             ),
         ]

--- a/ros2_nodes/launch/run_gazebo_demo.sh
+++ b/ros2_nodes/launch/run_gazebo_demo.sh
@@ -36,4 +36,4 @@ EOF
   exit 1
 fi
 
-exec python3 "$LAUNCH_FILE" "turtlebot3_model:=${TURTLEBOT3_MODEL}"
+exec ros2 launch "$LAUNCH_FILE" "turtlebot3_model:=${TURTLEBOT3_MODEL}"

--- a/ros2_nodes/launch/run_gazebo_mission_demo.sh
+++ b/ros2_nodes/launch/run_gazebo_mission_demo.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Launch TurtleBot3 Gazebo, the Rust navigation stack, and the waypoint mission node.
+# Usage:
+#   WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5" ./ros2_nodes/launch/run_gazebo_mission_demo.sh
+
+set -eo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+LAUNCH_FILE="$ROOT_DIR/ros2_nodes/launch/navigation_demo.launch.py"
+
+set +u
+source /opt/ros/jazzy/setup.bash
+set -u
+export TURTLEBOT3_MODEL="${TURTLEBOT3_MODEL:-burger}"
+export WAYPOINT_NAV_WAYPOINTS="${WAYPOINT_NAV_WAYPOINTS:-0.5,0.0;0.5,0.5;0.0,0.5}"
+export WAYPOINT_NAV_LOOP="${WAYPOINT_NAV_LOOP:-false}"
+export WAYPOINT_NAV_GOAL_TOLERANCE="${WAYPOINT_NAV_GOAL_TOLERANCE:-0.35}"
+
+required_bins=(
+  "$ROOT_DIR/ros2_nodes/path_planner_node/target/release/path_planner_node"
+  "$ROOT_DIR/ros2_nodes/dwa_planner_node/target/release/dwa_planner_node"
+  "$ROOT_DIR/ros2_nodes/slam_node/target/release/slam_node"
+  "$ROOT_DIR/ros2_nodes/waypoint_navigator_node/target/release/waypoint_navigator_node"
+)
+
+missing=0
+for bin in "${required_bins[@]}"; do
+  if [[ ! -x "$bin" ]]; then
+    echo "Missing release binary: $bin" >&2
+    missing=1
+  fi
+done
+
+if [[ "$missing" -ne 0 ]]; then
+  cat >&2 <<'EOF'
+Build the ROS2 nodes in release mode first:
+  cargo build --release --manifest-path ros2_nodes/path_planner_node/Cargo.toml
+  cargo build --release --manifest-path ros2_nodes/dwa_planner_node/Cargo.toml
+  cargo build --release --manifest-path ros2_nodes/slam_node/Cargo.toml
+  cargo build --release --manifest-path ros2_nodes/waypoint_navigator_node/Cargo.toml
+EOF
+  exit 1
+fi
+
+exec python3 "$LAUNCH_FILE" \
+  "turtlebot3_model:=${TURTLEBOT3_MODEL}" \
+  "enable_waypoint_navigator:=true" \
+  "waypoint_mission:=${WAYPOINT_NAV_WAYPOINTS}" \
+  "waypoint_loop:=${WAYPOINT_NAV_LOOP}" \
+  "waypoint_goal_tolerance:=${WAYPOINT_NAV_GOAL_TOLERANCE}"

--- a/ros2_nodes/launch/run_gazebo_mission_demo.sh
+++ b/ros2_nodes/launch/run_gazebo_mission_demo.sh
@@ -2,6 +2,7 @@
 # Launch TurtleBot3 Gazebo, the Rust navigation stack, and the waypoint mission node.
 # Usage:
 #   WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5" ./ros2_nodes/launch/run_gazebo_mission_demo.sh
+# Waypoints default to offsets from the first odom pose seen by waypoint_navigator_node.
 
 set -eo pipefail
 
@@ -14,6 +15,7 @@ set -u
 export TURTLEBOT3_MODEL="${TURTLEBOT3_MODEL:-burger}"
 export NAV_ODOM_TOPIC="${NAV_ODOM_TOPIC:-/ekf_odom}"
 export WAYPOINT_NAV_WAYPOINTS="${WAYPOINT_NAV_WAYPOINTS:-0.5,0.0;0.5,0.5;0.0,0.5}"
+export WAYPOINT_NAV_FRAME="${WAYPOINT_NAV_FRAME:-relative_start}"
 export WAYPOINT_NAV_LOOP="${WAYPOINT_NAV_LOOP:-false}"
 export WAYPOINT_NAV_GOAL_TOLERANCE="${WAYPOINT_NAV_GOAL_TOLERANCE:-0.35}"
 
@@ -51,5 +53,6 @@ exec ros2 launch "$LAUNCH_FILE" \
   "nav_odom_topic:=${NAV_ODOM_TOPIC}" \
   "enable_waypoint_navigator:=true" \
   "waypoint_mission:=${WAYPOINT_NAV_WAYPOINTS}" \
+  "waypoint_frame:=${WAYPOINT_NAV_FRAME}" \
   "waypoint_loop:=${WAYPOINT_NAV_LOOP}" \
   "waypoint_goal_tolerance:=${WAYPOINT_NAV_GOAL_TOLERANCE}"

--- a/ros2_nodes/launch/run_gazebo_mission_demo.sh
+++ b/ros2_nodes/launch/run_gazebo_mission_demo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Launch TurtleBot3 Gazebo, the Rust navigation stack, and the waypoint mission node.
 # Usage:
-#   WAYPOINT_NAV_WAYPOINTS="0.5,0.0;0.5,0.5;0.0,0.5" ./ros2_nodes/launch/run_gazebo_mission_demo.sh
+#   WAYPOINT_NAV_WAYPOINTS="0.4,0.0;0.1,0.4" ./ros2_nodes/launch/run_gazebo_mission_demo.sh
 # Waypoints default to offsets from the first odom pose seen by waypoint_navigator_node.
 
 set -eo pipefail
@@ -14,10 +14,11 @@ source /opt/ros/jazzy/setup.bash
 set -u
 export TURTLEBOT3_MODEL="${TURTLEBOT3_MODEL:-burger}"
 export NAV_ODOM_TOPIC="${NAV_ODOM_TOPIC:-/ekf_odom}"
-export WAYPOINT_NAV_WAYPOINTS="${WAYPOINT_NAV_WAYPOINTS:-0.5,0.0;0.5,0.5;0.0,0.5}"
+export WAYPOINT_NAV_WAYPOINTS="${WAYPOINT_NAV_WAYPOINTS:-0.4,0.0;0.1,0.4}"
 export WAYPOINT_NAV_FRAME="${WAYPOINT_NAV_FRAME:-relative_start}"
 export WAYPOINT_NAV_LOOP="${WAYPOINT_NAV_LOOP:-false}"
 export WAYPOINT_NAV_GOAL_TOLERANCE="${WAYPOINT_NAV_GOAL_TOLERANCE:-0.35}"
+export DWA_GOAL_THRESHOLD="${DWA_GOAL_THRESHOLD:-0.3}"
 
 required_bins=(
   "$ROOT_DIR/ros2_nodes/path_planner_node/target/release/path_planner_node"
@@ -51,6 +52,7 @@ exec ros2 launch "$LAUNCH_FILE" \
   "turtlebot3_model:=${TURTLEBOT3_MODEL}" \
   "enable_ekf_localizer:=true" \
   "nav_odom_topic:=${NAV_ODOM_TOPIC}" \
+  "dwa_goal_threshold:=${DWA_GOAL_THRESHOLD}" \
   "enable_waypoint_navigator:=true" \
   "waypoint_mission:=${WAYPOINT_NAV_WAYPOINTS}" \
   "waypoint_frame:=${WAYPOINT_NAV_FRAME}" \

--- a/ros2_nodes/launch/run_gazebo_mission_demo.sh
+++ b/ros2_nodes/launch/run_gazebo_mission_demo.sh
@@ -12,6 +12,7 @@ set +u
 source /opt/ros/jazzy/setup.bash
 set -u
 export TURTLEBOT3_MODEL="${TURTLEBOT3_MODEL:-burger}"
+export NAV_ODOM_TOPIC="${NAV_ODOM_TOPIC:-/ekf_odom}"
 export WAYPOINT_NAV_WAYPOINTS="${WAYPOINT_NAV_WAYPOINTS:-0.5,0.0;0.5,0.5;0.0,0.5}"
 export WAYPOINT_NAV_LOOP="${WAYPOINT_NAV_LOOP:-false}"
 export WAYPOINT_NAV_GOAL_TOLERANCE="${WAYPOINT_NAV_GOAL_TOLERANCE:-0.35}"
@@ -20,6 +21,7 @@ required_bins=(
   "$ROOT_DIR/ros2_nodes/path_planner_node/target/release/path_planner_node"
   "$ROOT_DIR/ros2_nodes/dwa_planner_node/target/release/dwa_planner_node"
   "$ROOT_DIR/ros2_nodes/slam_node/target/release/slam_node"
+  "$ROOT_DIR/ros2_nodes/ekf_localizer_node/target/release/ekf_localizer_node"
   "$ROOT_DIR/ros2_nodes/waypoint_navigator_node/target/release/waypoint_navigator_node"
 )
 
@@ -37,13 +39,16 @@ Build the ROS2 nodes in release mode first:
   cargo build --release --manifest-path ros2_nodes/path_planner_node/Cargo.toml
   cargo build --release --manifest-path ros2_nodes/dwa_planner_node/Cargo.toml
   cargo build --release --manifest-path ros2_nodes/slam_node/Cargo.toml
+  cargo build --release --manifest-path ros2_nodes/ekf_localizer_node/Cargo.toml
   cargo build --release --manifest-path ros2_nodes/waypoint_navigator_node/Cargo.toml
 EOF
   exit 1
 fi
 
-exec python3 "$LAUNCH_FILE" \
+exec ros2 launch "$LAUNCH_FILE" \
   "turtlebot3_model:=${TURTLEBOT3_MODEL}" \
+  "enable_ekf_localizer:=true" \
+  "nav_odom_topic:=${NAV_ODOM_TOPIC}" \
   "enable_waypoint_navigator:=true" \
   "waypoint_mission:=${WAYPOINT_NAV_WAYPOINTS}" \
   "waypoint_loop:=${WAYPOINT_NAV_LOOP}" \

--- a/ros2_nodes/path_planner_node/src/main.rs
+++ b/ros2_nodes/path_planner_node/src/main.rs
@@ -4,9 +4,9 @@ use safe_drive::{
     context::Context,
     error::DynError,
     logger::Logger,
-    msg::common_interfaces::{geometry_msgs, nav_msgs},
-    qos::{policy::DurabilityPolicy, Profile},
+    msg::common_interfaces::{geometry_msgs, nav_msgs, std_msgs},
     pr_info, pr_warn,
+    qos::{policy::DurabilityPolicy, Profile},
 };
 use std::env;
 use std::sync::{Arc, Mutex};
@@ -17,6 +17,7 @@ const ROBOT_RADIUS: f64 = 0.4;
 const MAP_OCCUPANCY_THRESHOLD: i8 = 60;
 const MAP_REBUILD_LOG_INTERVAL: Duration = Duration::from_secs(5);
 const QUERY_SNAP_MAX_DISTANCE: f64 = 0.35;
+const NAVIGATION_CANCEL_TOPIC: &str = "/navigation_cancel";
 
 #[derive(Default)]
 struct PlannerState {
@@ -254,7 +255,8 @@ fn find_nearest_valid_query_point(
                 continue;
             }
 
-            let candidate = Point2D::new(grid.calc_x_position(cell_x), grid.calc_y_position(cell_y));
+            let candidate =
+                Point2D::new(grid.calc_x_position(cell_x), grid.calc_y_position(cell_y));
             let distance_sq = (candidate.x - point.x).powi(2) + (candidate.y - point.y).powi(2);
             if distance_sq > max_distance_sq {
                 continue;
@@ -283,12 +285,12 @@ fn main() -> Result<(), DynError> {
     let goal_sub = node.create_subscriber::<geometry_msgs::msg::PoseStamped>("/goal_pose", None)?;
     let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>(&odom_topic, None)?;
     let map_sub = node.create_subscriber::<nav_msgs::msg::OccupancyGrid>("/map", None)?;
+    let cancel_sub =
+        node.create_subscriber::<std_msgs::msg::Empty>(NAVIGATION_CANCEL_TOPIC, None)?;
     let mut path_qos = Profile::default();
     path_qos.durability = DurabilityPolicy::TransientLocal;
-    let path_pub = Arc::new(node.create_publisher::<nav_msgs::msg::Path>(
-        "/planned_path",
-        Some(path_qos),
-    )?);
+    let path_pub =
+        Arc::new(node.create_publisher::<nav_msgs::msg::Path>("/planned_path", Some(path_qos))?);
 
     let state = Arc::new(Mutex::new(PlannerState::default()));
     let logger = Logger::new("path_planner_node");
@@ -369,7 +371,7 @@ fn main() -> Result<(), DynError> {
     );
 
     let state_goal = state.clone();
-    let pub_goal = path_pub;
+    let pub_goal = path_pub.clone();
     let log_goal = Logger::new("path_planner_node");
     let odom_topic_goal = odom_topic.clone();
     selector.add_subscriber(
@@ -415,6 +417,34 @@ fn main() -> Result<(), DynError> {
                 &log_goal,
                 true,
             );
+        }),
+    );
+
+    let state_cancel = state.clone();
+    let pub_cancel = path_pub.clone();
+    let log_cancel = Logger::new("path_planner_node");
+    selector.add_subscriber(
+        cancel_sub,
+        Box::new(move |_msg| {
+            let had_goal = {
+                let mut st = match state_cancel.lock() {
+                    Ok(guard) => guard,
+                    Err(_) => {
+                        pr_warn!(log_cancel, "failed to lock planner state on cancel");
+                        return;
+                    }
+                };
+                st.goal_pose.take().is_some()
+            };
+
+            if let Err(err) = publish_path(pub_cancel.as_ref(), &[]) {
+                pr_warn!(log_cancel, "failed to clear published path: {}", err);
+                return;
+            }
+
+            if had_goal {
+                pr_info!(log_cancel, "cleared active navigation goal");
+            }
         }),
     );
 

--- a/ros2_nodes/path_planner_node/src/main.rs
+++ b/ros2_nodes/path_planner_node/src/main.rs
@@ -16,6 +16,7 @@ const DEFAULT_ODOM_TOPIC: &str = "/odom";
 const ROBOT_RADIUS: f64 = 0.4;
 const MAP_OCCUPANCY_THRESHOLD: i8 = 60;
 const MAP_REBUILD_LOG_INTERVAL: Duration = Duration::from_secs(5);
+const QUERY_SNAP_MAX_DISTANCE: f64 = 0.35;
 
 #[derive(Default)]
 struct PlannerState {
@@ -156,6 +157,9 @@ fn attempt_plan(
     logger: &Logger,
     log_success: bool,
 ) {
+    let start = snap_query_point(&planner, start, "start", QUERY_SNAP_MAX_DISTANCE, logger);
+    let goal = snap_query_point(&planner, goal, "goal", QUERY_SNAP_MAX_DISTANCE, logger);
+
     match planner.plan(start, goal) {
         Ok(path) => {
             if let Err(err) = publish_path(publisher, &path.points) {
@@ -186,6 +190,86 @@ fn attempt_plan(
             );
         }
     }
+}
+
+fn snap_query_point(
+    planner: &AStarPlanner,
+    point: Point2D,
+    label: &str,
+    max_distance: f64,
+    logger: &Logger,
+) -> Point2D {
+    if !max_distance.is_finite() || max_distance <= 0.0 {
+        return point;
+    }
+
+    let grid = planner.grid_map();
+    let query_x = grid.calc_x_index(point.x);
+    let query_y = grid.calc_y_index(point.y);
+    if grid.is_valid(query_x, query_y) {
+        return point;
+    }
+
+    let Some(snapped) = find_nearest_valid_query_point(planner, point, max_distance) else {
+        return point;
+    };
+
+    pr_warn!(
+        logger,
+        "{} query snapped from ({:.2},{:.2}) to ({:.2},{:.2})",
+        label,
+        point.x,
+        point.y,
+        snapped.x,
+        snapped.y
+    );
+    snapped
+}
+
+fn find_nearest_valid_query_point(
+    planner: &AStarPlanner,
+    point: Point2D,
+    max_distance: f64,
+) -> Option<Point2D> {
+    if !max_distance.is_finite() || max_distance < 0.0 {
+        return None;
+    }
+
+    let grid = planner.grid_map();
+    let query_x = grid.calc_x_index(point.x);
+    let query_y = grid.calc_y_index(point.y);
+    if grid.is_valid(query_x, query_y) {
+        return Some(point);
+    }
+
+    let search_radius = (max_distance / grid.resolution).ceil() as i32;
+    let max_distance_sq = max_distance * max_distance;
+    let mut best: Option<(Point2D, f64)> = None;
+
+    for dx in -search_radius..=search_radius {
+        for dy in -search_radius..=search_radius {
+            let cell_x = query_x + dx;
+            let cell_y = query_y + dy;
+            if !grid.is_valid(cell_x, cell_y) {
+                continue;
+            }
+
+            let candidate = Point2D::new(grid.calc_x_position(cell_x), grid.calc_y_position(cell_y));
+            let distance_sq = (candidate.x - point.x).powi(2) + (candidate.y - point.y).powi(2);
+            if distance_sq > max_distance_sq {
+                continue;
+            }
+
+            let replace = best
+                .as_ref()
+                .is_none_or(|(_, best_distance_sq)| distance_sq < *best_distance_sq);
+            if replace {
+                best = Some((candidate, distance_sq));
+            }
+        }
+    }
+
+    best.map(|(candidate, _)| candidate)
 }
 
 fn main() -> Result<(), DynError> {
@@ -336,5 +420,69 @@ fn main() -> Result<(), DynError> {
 
     loop {
         selector.wait()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_nearest_valid_query_point;
+    use rust_robotics_core::Point2D;
+    use rust_robotics_planning::{AStarConfig, AStarPlanner};
+
+    fn make_test_planner() -> AStarPlanner {
+        let mut ox = Vec::new();
+        let mut oy = Vec::new();
+
+        for i in 0..=4 {
+            let v = i as f64;
+            ox.push(v);
+            oy.push(0.0);
+            ox.push(v);
+            oy.push(4.0);
+            ox.push(0.0);
+            oy.push(v);
+            ox.push(4.0);
+            oy.push(v);
+        }
+        ox.push(2.0);
+        oy.push(2.0);
+
+        AStarPlanner::new(
+            &ox,
+            &oy,
+            AStarConfig {
+                resolution: 1.0,
+                robot_radius: 0.0,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[test]
+    fn find_nearest_valid_query_point_returns_original_for_valid_query() {
+        let planner = make_test_planner();
+        let query = Point2D::new(1.0, 1.0);
+        let snapped = find_nearest_valid_query_point(&planner, query, 1.0).unwrap();
+        assert!((snapped.x - query.x).abs() < 1e-9);
+        assert!((snapped.y - query.y).abs() < 1e-9);
+    }
+
+    #[test]
+    fn find_nearest_valid_query_point_snaps_invalid_goal_to_neighbor() {
+        let planner = make_test_planner();
+        let query = Point2D::new(2.0, 2.0);
+        let snapped = find_nearest_valid_query_point(&planner, query, 1.1).unwrap();
+
+        assert!((snapped.x - query.x).abs() > 1e-9 || (snapped.y - query.y).abs() > 1e-9);
+        let grid = planner.grid_map();
+        assert!(grid.is_valid(grid.calc_x_index(snapped.x), grid.calc_y_index(snapped.y)));
+        assert!((snapped.x - query.x).powi(2) + (snapped.y - query.y).powi(2) <= 1.1f64.powi(2));
+    }
+
+    #[test]
+    fn find_nearest_valid_query_point_respects_distance_cap() {
+        let planner = make_test_planner();
+        let query = Point2D::new(2.0, 2.0);
+        assert!(find_nearest_valid_query_point(&planner, query, 0.5).is_none());
     }
 }

--- a/ros2_nodes/path_planner_node/src/main.rs
+++ b/ros2_nodes/path_planner_node/src/main.rs
@@ -8,9 +8,11 @@ use safe_drive::{
     qos::{policy::DurabilityPolicy, Profile},
     pr_info, pr_warn,
 };
+use std::env;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+const DEFAULT_ODOM_TOPIC: &str = "/odom";
 const ROBOT_RADIUS: f64 = 0.4;
 const MAP_OCCUPANCY_THRESHOLD: i8 = 60;
 const MAP_REBUILD_LOG_INTERVAL: Duration = Duration::from_secs(5);
@@ -189,9 +191,13 @@ fn attempt_plan(
 fn main() -> Result<(), DynError> {
     let ctx = Context::new()?;
     let node = ctx.create_node("path_planner_node", None, Default::default())?;
+    let odom_topic = env::var("RUST_NAV_ODOM_TOPIC")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_ODOM_TOPIC.to_string());
 
     let goal_sub = node.create_subscriber::<geometry_msgs::msg::PoseStamped>("/goal_pose", None)?;
-    let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>("/odom", None)?;
+    let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>(&odom_topic, None)?;
     let map_sub = node.create_subscriber::<nav_msgs::msg::OccupancyGrid>("/map", None)?;
     let mut path_qos = Profile::default();
     path_qos.durability = DurabilityPolicy::TransientLocal;
@@ -203,7 +209,7 @@ fn main() -> Result<(), DynError> {
     let state = Arc::new(Mutex::new(PlannerState::default()));
     let logger = Logger::new("path_planner_node");
 
-    pr_info!(logger, "path planner started");
+    pr_info!(logger, "path planner started (odom topic: {})", odom_topic);
 
     let mut selector = ctx.create_selector()?;
 
@@ -281,6 +287,7 @@ fn main() -> Result<(), DynError> {
     let state_goal = state.clone();
     let pub_goal = path_pub;
     let log_goal = Logger::new("path_planner_node");
+    let odom_topic_goal = odom_topic.clone();
     selector.add_subscriber(
         goal_sub,
         Box::new(move |msg| {
@@ -298,7 +305,11 @@ fn main() -> Result<(), DynError> {
                 let start = match st.robot_pose {
                     Some(pose) => pose,
                     None => {
-                        pr_warn!(log_goal, "robot pose from /odom is not available yet");
+                        pr_warn!(
+                            log_goal,
+                            "robot pose from {} is not available yet",
+                            odom_topic_goal
+                        );
                         return;
                     }
                 };

--- a/ros2_nodes/waypoint_navigator_node/Cargo.toml
+++ b/ros2_nodes/waypoint_navigator_node/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "waypoint_navigator_node"
+version = "0.1.0"
+edition = "2021"
+description = "ROS2 waypoint mission node using safe_drive"
+
+[dependencies]
+safe_drive = { path = "../../../safe_drive", features = ["jazzy"] }
+rust_robotics_core = { path = "../../crates/rust_robotics_core" }
+
+[workspace]

--- a/ros2_nodes/waypoint_navigator_node/src/main.rs
+++ b/ros2_nodes/waypoint_navigator_node/src/main.rs
@@ -11,6 +11,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+const DEFAULT_ODOM_TOPIC: &str = "/odom";
 const DEFAULT_WAYPOINTS: &str = "0.5,0.0;0.5,0.5;0.0,0.5";
 const DEFAULT_GOAL_TOLERANCE: f64 = 0.35;
 const GOAL_FRAME_ID: &str = "map";
@@ -156,11 +157,15 @@ fn publish_goal(
 fn main() -> Result<(), DynError> {
     let mission =
         load_mission_config().map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    let odom_topic = env::var("RUST_NAV_ODOM_TOPIC")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_ODOM_TOPIC.to_string());
 
     let ctx = Context::new()?;
     let node = ctx.create_node("waypoint_navigator_node", None, Default::default())?;
 
-    let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>("/odom", None)?;
+    let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>(&odom_topic, None)?;
     let goal_pub = node.create_publisher::<geometry_msgs::msg::PoseStamped>("/goal_pose", None)?;
 
     let state = Arc::new(Mutex::new(NavigatorState::default()));
@@ -172,6 +177,7 @@ fn main() -> Result<(), DynError> {
         mission.goal_tolerance,
         mission.loop_mission
     );
+    pr_info!(logger, "waypoint odom topic: {}", odom_topic);
     pr_info!(logger, "mission: {}", format_waypoints(&mission.waypoints));
 
     let mut selector = ctx.create_selector()?;

--- a/ros2_nodes/waypoint_navigator_node/src/main.rs
+++ b/ros2_nodes/waypoint_navigator_node/src/main.rs
@@ -18,6 +18,7 @@ const DEFAULT_GOAL_TOLERANCE: f64 = 0.35;
 const DEFAULT_WAYPOINT_FRAME: &str = "map";
 const GOAL_FRAME_ID: &str = "map";
 const GOAL_REPUBLISH_INTERVAL: Duration = Duration::from_secs(2);
+const GOAL_PROGRESS_ARM_DISTANCE: f64 = 0.05;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MissionFrame {
@@ -48,10 +49,21 @@ struct NavigatorState {
     mission_completed: bool,
     last_goal_publish_at: Option<Instant>,
     anchor_pose: Option<Point2D>,
+    active_goal: Option<ActiveGoalState>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ActiveGoalState {
+    published_goal: Point2D,
+    published_robot_pose: Point2D,
+    completion_armed: bool,
 }
 
 enum MissionEvent {
-    Start { next_idx: usize, goal: Point2D },
+    Start {
+        next_idx: usize,
+        goal: Point2D,
+    },
     Advance {
         reached_idx: usize,
         reached_goal: Point2D,
@@ -64,8 +76,14 @@ enum MissionEvent {
         next_idx: usize,
         next_goal: Point2D,
     },
-    Complete { reached_idx: usize, reached_goal: Point2D },
-    Republish { current_idx: usize, goal: Point2D },
+    Complete {
+        reached_idx: usize,
+        reached_goal: Point2D,
+    },
+    Republish {
+        current_idx: usize,
+        goal: Point2D,
+    },
 }
 
 fn parse_waypoints(raw: &str) -> Result<Vec<Point2D>, String> {
@@ -159,9 +177,8 @@ fn load_mission_config() -> Result<MissionConfig, String> {
     };
 
     let frame = match env::var("WAYPOINT_NAV_FRAME") {
-        Ok(raw) if !raw.trim().is_empty() => {
-            parse_mission_frame(&raw).ok_or_else(|| format!("invalid WAYPOINT_NAV_FRAME '{}'", raw))?
-        }
+        Ok(raw) if !raw.trim().is_empty() => parse_mission_frame(&raw)
+            .ok_or_else(|| format!("invalid WAYPOINT_NAV_FRAME '{}'", raw))?,
         _ => parse_mission_frame(DEFAULT_WAYPOINT_FRAME)
             .expect("DEFAULT_WAYPOINT_FRAME must be valid"),
     };
@@ -205,6 +222,30 @@ fn resolve_waypoint(
             let anchor = anchor_pose.unwrap_or(Point2D::origin());
             Point2D::new(anchor.x + waypoint.x, anchor.y + waypoint.y)
         }
+    }
+}
+
+fn new_active_goal(goal: Point2D, robot_pose: Point2D, goal_tolerance: f64) -> ActiveGoalState {
+    ActiveGoalState {
+        published_goal: goal,
+        published_robot_pose: robot_pose,
+        completion_armed: distance(robot_pose, goal) > goal_tolerance,
+    }
+}
+
+fn arm_goal_completion_if_progressed(
+    active_goal: &mut ActiveGoalState,
+    robot_pose: Point2D,
+    goal_tolerance: f64,
+) {
+    if active_goal.completion_armed {
+        return;
+    }
+
+    let moved_since_publish = distance(robot_pose, active_goal.published_robot_pose);
+    let remaining_distance = distance(robot_pose, active_goal.published_goal);
+    if moved_since_publish >= GOAL_PROGRESS_ARM_DISTANCE || remaining_distance > goal_tolerance {
+        active_goal.completion_armed = true;
     }
 }
 
@@ -287,6 +328,11 @@ fn main() -> Result<(), DynError> {
                             );
                             st.current_waypoint_idx = Some(0);
                             st.last_goal_publish_at = Some(now);
+                            st.active_goal = Some(new_active_goal(
+                                goal,
+                                robot_pose,
+                                mission_cb.goal_tolerance,
+                            ));
                             Some(MissionEvent::Start { next_idx: 0, goal })
                         }
                         Some(current_idx) => {
@@ -295,7 +341,20 @@ fn main() -> Result<(), DynError> {
                                 mission_cb.frame,
                                 st.anchor_pose,
                             );
-                            if distance(robot_pose, current_goal) > mission_cb.goal_tolerance {
+                            let current_distance = distance(robot_pose, current_goal);
+                            if let Some(active_goal) = st.active_goal.as_mut() {
+                                arm_goal_completion_if_progressed(
+                                    active_goal,
+                                    robot_pose,
+                                    mission_cb.goal_tolerance,
+                                );
+                            }
+                            let completion_armed = st
+                                .active_goal
+                                .map(|active_goal| active_goal.completion_armed)
+                                .unwrap_or(current_distance > mission_cb.goal_tolerance);
+
+                            if current_distance > mission_cb.goal_tolerance || !completion_armed {
                                 if should_republish_goal(st.last_goal_publish_at, now) {
                                     st.last_goal_publish_at = Some(now);
                                     Some(MissionEvent::Republish {
@@ -314,6 +373,11 @@ fn main() -> Result<(), DynError> {
                                 );
                                 st.current_waypoint_idx = Some(next_idx);
                                 st.last_goal_publish_at = Some(now);
+                                st.active_goal = Some(new_active_goal(
+                                    next_goal,
+                                    robot_pose,
+                                    mission_cb.goal_tolerance,
+                                ));
                                 Some(MissionEvent::Advance {
                                     reached_idx: current_idx,
                                     reached_goal: current_goal,
@@ -328,6 +392,11 @@ fn main() -> Result<(), DynError> {
                                 );
                                 st.current_waypoint_idx = Some(0);
                                 st.last_goal_publish_at = Some(now);
+                                st.active_goal = Some(new_active_goal(
+                                    next_goal,
+                                    robot_pose,
+                                    mission_cb.goal_tolerance,
+                                ));
                                 Some(MissionEvent::Loop {
                                     reached_idx: current_idx,
                                     reached_goal: current_goal,
@@ -338,6 +407,7 @@ fn main() -> Result<(), DynError> {
                                 st.current_waypoint_idx = None;
                                 st.mission_completed = true;
                                 st.last_goal_publish_at = None;
+                                st.active_goal = None;
                                 Some(MissionEvent::Complete {
                                     reached_idx: current_idx,
                                     reached_goal: current_goal,
@@ -449,8 +519,9 @@ fn main() -> Result<(), DynError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_bool, parse_mission_frame, parse_waypoints, resolve_waypoint,
-        should_republish_goal, MissionFrame, GOAL_REPUBLISH_INTERVAL,
+        arm_goal_completion_if_progressed, new_active_goal, parse_bool, parse_mission_frame,
+        parse_waypoints, resolve_waypoint, should_republish_goal, MissionFrame,
+        GOAL_PROGRESS_ARM_DISTANCE, GOAL_REPUBLISH_INTERVAL,
     };
     use rust_robotics_core::Point2D;
     use std::time::{Duration, Instant};
@@ -521,5 +592,33 @@ mod tests {
             Some(now),
             now + GOAL_REPUBLISH_INTERVAL
         ));
+    }
+
+    #[test]
+    fn new_active_goal_requires_progress_when_goal_is_already_close() {
+        let active_goal = new_active_goal(Point2D::new(0.1, 0.1), Point2D::new(0.0, 0.0), 0.2);
+        assert!(!active_goal.completion_armed);
+    }
+
+    #[test]
+    fn arm_goal_completion_when_robot_moves_after_publish() {
+        let mut active_goal = new_active_goal(Point2D::new(0.1, 0.1), Point2D::new(0.0, 0.0), 0.2);
+
+        arm_goal_completion_if_progressed(
+            &mut active_goal,
+            Point2D::new(GOAL_PROGRESS_ARM_DISTANCE + 0.01, 0.0),
+            0.2,
+        );
+
+        assert!(active_goal.completion_armed);
+    }
+
+    #[test]
+    fn arm_goal_completion_when_robot_is_seen_outside_tolerance() {
+        let mut active_goal = new_active_goal(Point2D::new(0.1, 0.1), Point2D::new(0.0, 0.0), 0.2);
+
+        arm_goal_completion_if_progressed(&mut active_goal, Point2D::new(0.5, 0.5), 0.2);
+
+        assert!(active_goal.completion_armed);
     }
 }

--- a/ros2_nodes/waypoint_navigator_node/src/main.rs
+++ b/ros2_nodes/waypoint_navigator_node/src/main.rs
@@ -3,7 +3,7 @@ use safe_drive::{
     context::Context,
     error::DynError,
     logger::Logger,
-    msg::common_interfaces::{geometry_msgs, nav_msgs},
+    msg::common_interfaces::{geometry_msgs, nav_msgs, std_msgs},
     pr_info, pr_warn,
 };
 use std::{
@@ -19,6 +19,8 @@ const DEFAULT_WAYPOINT_FRAME: &str = "map";
 const GOAL_FRAME_ID: &str = "map";
 const GOAL_REPUBLISH_INTERVAL: Duration = Duration::from_secs(2);
 const GOAL_PROGRESS_ARM_DISTANCE: f64 = 0.05;
+const GOAL_COMPLETION_ARM_DELAY: Duration = Duration::from_millis(500);
+const NAVIGATION_CANCEL_TOPIC: &str = "/navigation_cancel";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MissionFrame {
@@ -56,6 +58,7 @@ struct NavigatorState {
 struct ActiveGoalState {
     published_goal: Point2D,
     published_robot_pose: Point2D,
+    published_at: Instant,
     completion_armed: bool,
 }
 
@@ -225,10 +228,16 @@ fn resolve_waypoint(
     }
 }
 
-fn new_active_goal(goal: Point2D, robot_pose: Point2D, goal_tolerance: f64) -> ActiveGoalState {
+fn new_active_goal(
+    goal: Point2D,
+    robot_pose: Point2D,
+    goal_tolerance: f64,
+    published_at: Instant,
+) -> ActiveGoalState {
     ActiveGoalState {
         published_goal: goal,
         published_robot_pose: robot_pose,
+        published_at,
         completion_armed: distance(robot_pose, goal) > goal_tolerance,
     }
 }
@@ -237,6 +246,7 @@ fn arm_goal_completion_if_progressed(
     active_goal: &mut ActiveGoalState,
     robot_pose: Point2D,
     goal_tolerance: f64,
+    now: Instant,
 ) {
     if active_goal.completion_armed {
         return;
@@ -244,9 +254,21 @@ fn arm_goal_completion_if_progressed(
 
     let moved_since_publish = distance(robot_pose, active_goal.published_robot_pose);
     let remaining_distance = distance(robot_pose, active_goal.published_goal);
-    if moved_since_publish >= GOAL_PROGRESS_ARM_DISTANCE || remaining_distance > goal_tolerance {
+    let elapsed_since_publish = now.saturating_duration_since(active_goal.published_at);
+    if moved_since_publish >= GOAL_PROGRESS_ARM_DISTANCE
+        || remaining_distance > goal_tolerance
+        || elapsed_since_publish >= GOAL_COMPLETION_ARM_DELAY
+    {
         active_goal.completion_armed = true;
     }
+}
+
+fn publish_cancel(
+    publisher: &safe_drive::topic::publisher::Publisher<std_msgs::msg::Empty>,
+) -> Result<(), DynError> {
+    let msg = std_msgs::msg::Empty::new().ok_or("failed to allocate Empty")?;
+    publisher.send(&msg)?;
+    Ok(())
 }
 
 fn publish_goal(
@@ -279,6 +301,8 @@ fn main() -> Result<(), DynError> {
 
     let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>(&odom_topic, None)?;
     let goal_pub = node.create_publisher::<geometry_msgs::msg::PoseStamped>("/goal_pose", None)?;
+    let cancel_pub =
+        node.create_publisher::<std_msgs::msg::Empty>(NAVIGATION_CANCEL_TOPIC, None)?;
 
     let state = Arc::new(Mutex::new(NavigatorState::default()));
     let logger = Logger::new("waypoint_navigator_node");
@@ -332,6 +356,7 @@ fn main() -> Result<(), DynError> {
                                 goal,
                                 robot_pose,
                                 mission_cb.goal_tolerance,
+                                now,
                             ));
                             Some(MissionEvent::Start { next_idx: 0, goal })
                         }
@@ -347,6 +372,7 @@ fn main() -> Result<(), DynError> {
                                     active_goal,
                                     robot_pose,
                                     mission_cb.goal_tolerance,
+                                    now,
                                 );
                             }
                             let completion_armed = st
@@ -377,6 +403,7 @@ fn main() -> Result<(), DynError> {
                                     next_goal,
                                     robot_pose,
                                     mission_cb.goal_tolerance,
+                                    now,
                                 ));
                                 Some(MissionEvent::Advance {
                                     reached_idx: current_idx,
@@ -396,6 +423,7 @@ fn main() -> Result<(), DynError> {
                                     next_goal,
                                     robot_pose,
                                     mission_cb.goal_tolerance,
+                                    now,
                                 ));
                                 Some(MissionEvent::Loop {
                                     reached_idx: current_idx,
@@ -483,6 +511,10 @@ fn main() -> Result<(), DynError> {
                     reached_idx,
                     reached_goal,
                 }) => {
+                    if let Err(err) = publish_cancel(&cancel_pub) {
+                        pr_warn!(log_odom, "failed to publish navigation cancel: {}", err);
+                        return;
+                    }
                     pr_info!(
                         log_odom,
                         "mission complete at waypoint {}/{} ({:.2}, {:.2})",
@@ -521,7 +553,7 @@ mod tests {
     use super::{
         arm_goal_completion_if_progressed, new_active_goal, parse_bool, parse_mission_frame,
         parse_waypoints, resolve_waypoint, should_republish_goal, MissionFrame,
-        GOAL_PROGRESS_ARM_DISTANCE, GOAL_REPUBLISH_INTERVAL,
+        GOAL_COMPLETION_ARM_DELAY, GOAL_PROGRESS_ARM_DISTANCE, GOAL_REPUBLISH_INTERVAL,
     };
     use rust_robotics_core::Point2D;
     use std::time::{Duration, Instant};
@@ -596,18 +628,22 @@ mod tests {
 
     #[test]
     fn new_active_goal_requires_progress_when_goal_is_already_close() {
-        let active_goal = new_active_goal(Point2D::new(0.1, 0.1), Point2D::new(0.0, 0.0), 0.2);
+        let now = Instant::now();
+        let active_goal = new_active_goal(Point2D::new(0.1, 0.1), Point2D::new(0.0, 0.0), 0.2, now);
         assert!(!active_goal.completion_armed);
     }
 
     #[test]
     fn arm_goal_completion_when_robot_moves_after_publish() {
-        let mut active_goal = new_active_goal(Point2D::new(0.1, 0.1), Point2D::new(0.0, 0.0), 0.2);
+        let now = Instant::now();
+        let mut active_goal =
+            new_active_goal(Point2D::new(0.1, 0.1), Point2D::new(0.0, 0.0), 0.2, now);
 
         arm_goal_completion_if_progressed(
             &mut active_goal,
             Point2D::new(GOAL_PROGRESS_ARM_DISTANCE + 0.01, 0.0),
             0.2,
+            now,
         );
 
         assert!(active_goal.completion_armed);
@@ -615,9 +651,27 @@ mod tests {
 
     #[test]
     fn arm_goal_completion_when_robot_is_seen_outside_tolerance() {
-        let mut active_goal = new_active_goal(Point2D::new(0.1, 0.1), Point2D::new(0.0, 0.0), 0.2);
+        let now = Instant::now();
+        let mut active_goal =
+            new_active_goal(Point2D::new(0.1, 0.1), Point2D::new(0.0, 0.0), 0.2, now);
 
-        arm_goal_completion_if_progressed(&mut active_goal, Point2D::new(0.5, 0.5), 0.2);
+        arm_goal_completion_if_progressed(&mut active_goal, Point2D::new(0.5, 0.5), 0.2, now);
+
+        assert!(active_goal.completion_armed);
+    }
+
+    #[test]
+    fn arm_goal_completion_after_short_settle_delay() {
+        let now = Instant::now();
+        let mut active_goal =
+            new_active_goal(Point2D::new(0.1, 0.1), Point2D::new(0.0, 0.0), 0.2, now);
+
+        arm_goal_completion_if_progressed(
+            &mut active_goal,
+            Point2D::new(0.0, 0.0),
+            0.2,
+            now + GOAL_COMPLETION_ARM_DELAY,
+        );
 
         assert!(active_goal.completion_armed);
     }

--- a/ros2_nodes/waypoint_navigator_node/src/main.rs
+++ b/ros2_nodes/waypoint_navigator_node/src/main.rs
@@ -1,0 +1,338 @@
+use rust_robotics_core::Point2D;
+use safe_drive::{
+    context::Context,
+    error::DynError,
+    logger::Logger,
+    msg::common_interfaces::{geometry_msgs, nav_msgs},
+    pr_info, pr_warn,
+};
+use std::{
+    env, io,
+    sync::{Arc, Mutex},
+};
+
+const DEFAULT_WAYPOINTS: &str = "0.5,0.0;0.5,0.5;0.0,0.5";
+const DEFAULT_GOAL_TOLERANCE: f64 = 0.35;
+const GOAL_FRAME_ID: &str = "map";
+
+#[derive(Clone)]
+struct MissionConfig {
+    waypoints: Vec<Point2D>,
+    goal_tolerance: f64,
+    loop_mission: bool,
+}
+
+#[derive(Default)]
+struct NavigatorState {
+    current_waypoint_idx: Option<usize>,
+    mission_completed: bool,
+}
+
+enum MissionEvent {
+    Start { next_idx: usize },
+    Advance { reached_idx: usize, next_idx: usize },
+    Loop { reached_idx: usize, next_idx: usize },
+    Complete { reached_idx: usize },
+}
+
+fn parse_waypoints(raw: &str) -> Result<Vec<Point2D>, String> {
+    let mut waypoints = Vec::new();
+
+    for (index, entry) in raw.split(';').enumerate() {
+        let trimmed = entry.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut parts = trimmed.split(',').map(str::trim);
+        let x = parts
+            .next()
+            .ok_or_else(|| format!("waypoint {} is missing x", index))?;
+        let y = parts
+            .next()
+            .ok_or_else(|| format!("waypoint {} is missing y", index))?;
+        if parts.next().is_some() {
+            return Err(format!(
+                "waypoint {} must be 'x,y' but got '{}'",
+                index, trimmed
+            ));
+        }
+
+        let x = x
+            .parse::<f64>()
+            .map_err(|_| format!("waypoint {} has invalid x '{}'", index, x))?;
+        let y = y
+            .parse::<f64>()
+            .map_err(|_| format!("waypoint {} has invalid y '{}'", index, y))?;
+        if !x.is_finite() || !y.is_finite() {
+            return Err(format!(
+                "waypoint {} must contain finite coordinates, got '{}'",
+                index, trimmed
+            ));
+        }
+        waypoints.push(Point2D::new(x, y));
+    }
+
+    if waypoints.is_empty() {
+        return Err("mission must contain at least one waypoint".to_string());
+    }
+
+    Ok(waypoints)
+}
+
+fn parse_bool(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+fn load_mission_config() -> Result<MissionConfig, String> {
+    let waypoint_spec = env::var("WAYPOINT_NAV_WAYPOINTS")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_WAYPOINTS.to_string());
+    let waypoints = parse_waypoints(&waypoint_spec)?;
+
+    let goal_tolerance = match env::var("WAYPOINT_NAV_GOAL_TOLERANCE") {
+        Ok(raw) if !raw.trim().is_empty() => raw
+            .trim()
+            .parse::<f64>()
+            .map_err(|_| format!("invalid WAYPOINT_NAV_GOAL_TOLERANCE '{}'", raw))?,
+        _ => DEFAULT_GOAL_TOLERANCE,
+    };
+    if !goal_tolerance.is_finite() || goal_tolerance <= 0.0 {
+        return Err(format!(
+            "WAYPOINT_NAV_GOAL_TOLERANCE must be positive and finite, got {}",
+            goal_tolerance
+        ));
+    }
+
+    let loop_mission = match env::var("WAYPOINT_NAV_LOOP") {
+        Ok(raw) if !raw.trim().is_empty() => {
+            parse_bool(&raw).ok_or_else(|| format!("invalid WAYPOINT_NAV_LOOP '{}'", raw))?
+        }
+        _ => false,
+    };
+
+    Ok(MissionConfig {
+        waypoints,
+        goal_tolerance,
+        loop_mission,
+    })
+}
+
+fn format_waypoints(waypoints: &[Point2D]) -> String {
+    waypoints
+        .iter()
+        .enumerate()
+        .map(|(idx, point)| format!("{}:({:.2},{:.2})", idx + 1, point.x, point.y))
+        .collect::<Vec<_>>()
+        .join(" -> ")
+}
+
+fn distance(a: Point2D, b: Point2D) -> f64 {
+    ((a.x - b.x).powi(2) + (a.y - b.y).powi(2)).sqrt()
+}
+
+fn publish_goal(
+    publisher: &safe_drive::topic::publisher::Publisher<geometry_msgs::msg::PoseStamped>,
+    waypoint: Point2D,
+) -> Result<(), DynError> {
+    let mut msg = geometry_msgs::msg::PoseStamped::new().ok_or("failed to allocate PoseStamped")?;
+    let _ = msg.header.frame_id.assign(GOAL_FRAME_ID);
+    msg.pose.position.x = waypoint.x;
+    msg.pose.position.y = waypoint.y;
+    msg.pose.position.z = 0.0;
+    msg.pose.orientation.w = 1.0;
+    msg.pose.orientation.x = 0.0;
+    msg.pose.orientation.y = 0.0;
+    msg.pose.orientation.z = 0.0;
+    publisher.send(&msg)?;
+    Ok(())
+}
+
+fn main() -> Result<(), DynError> {
+    let mission =
+        load_mission_config().map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+
+    let ctx = Context::new()?;
+    let node = ctx.create_node("waypoint_navigator_node", None, Default::default())?;
+
+    let odom_sub = node.create_subscriber::<nav_msgs::msg::Odometry>("/odom", None)?;
+    let goal_pub = node.create_publisher::<geometry_msgs::msg::PoseStamped>("/goal_pose", None)?;
+
+    let state = Arc::new(Mutex::new(NavigatorState::default()));
+    let logger = Logger::new("waypoint_navigator_node");
+    pr_info!(
+        logger,
+        "waypoint navigator started: {} waypoint(s), tolerance={:.2} m, loop={}",
+        mission.waypoints.len(),
+        mission.goal_tolerance,
+        mission.loop_mission
+    );
+    pr_info!(logger, "mission: {}", format_waypoints(&mission.waypoints));
+
+    let mut selector = ctx.create_selector()?;
+    let mission_cb = mission.clone();
+    let state_odom = state.clone();
+    let log_odom = Logger::new("waypoint_navigator_node");
+    selector.add_subscriber(
+        odom_sub,
+        Box::new(move |msg| {
+            let robot_pose = Point2D::new(msg.pose.pose.position.x, msg.pose.pose.position.y);
+
+            let event = {
+                let mut st = match state_odom.lock() {
+                    Ok(guard) => guard,
+                    Err(_) => {
+                        pr_warn!(log_odom, "failed to lock mission state on /odom");
+                        return;
+                    }
+                };
+
+                if st.mission_completed {
+                    None
+                } else {
+                    match st.current_waypoint_idx {
+                        None => {
+                            st.current_waypoint_idx = Some(0);
+                            Some(MissionEvent::Start { next_idx: 0 })
+                        }
+                        Some(current_idx) => {
+                            let current_goal = mission_cb.waypoints[current_idx];
+                            if distance(robot_pose, current_goal) > mission_cb.goal_tolerance {
+                                None
+                            } else if current_idx + 1 < mission_cb.waypoints.len() {
+                                let next_idx = current_idx + 1;
+                                st.current_waypoint_idx = Some(next_idx);
+                                Some(MissionEvent::Advance {
+                                    reached_idx: current_idx,
+                                    next_idx,
+                                })
+                            } else if mission_cb.loop_mission {
+                                st.current_waypoint_idx = Some(0);
+                                Some(MissionEvent::Loop {
+                                    reached_idx: current_idx,
+                                    next_idx: 0,
+                                })
+                            } else {
+                                st.current_waypoint_idx = None;
+                                st.mission_completed = true;
+                                Some(MissionEvent::Complete {
+                                    reached_idx: current_idx,
+                                })
+                            }
+                        }
+                    }
+                }
+            };
+
+            match event {
+                Some(MissionEvent::Start { next_idx }) => {
+                    let goal = mission_cb.waypoints[next_idx];
+                    if let Err(err) = publish_goal(&goal_pub, goal) {
+                        pr_warn!(log_odom, "failed to publish first goal: {}", err);
+                        return;
+                    }
+                    pr_info!(
+                        log_odom,
+                        "starting mission at waypoint {}/{} -> ({:.2}, {:.2})",
+                        next_idx + 1,
+                        mission_cb.waypoints.len(),
+                        goal.x,
+                        goal.y
+                    );
+                }
+                Some(MissionEvent::Advance {
+                    reached_idx,
+                    next_idx,
+                }) => {
+                    let reached = mission_cb.waypoints[reached_idx];
+                    let next = mission_cb.waypoints[next_idx];
+                    if let Err(err) = publish_goal(&goal_pub, next) {
+                        pr_warn!(log_odom, "failed to publish next goal: {}", err);
+                        return;
+                    }
+                    pr_info!(
+                        log_odom,
+                        "reached waypoint {}/{} at ({:.2}, {:.2}); next -> ({:.2}, {:.2})",
+                        reached_idx + 1,
+                        mission_cb.waypoints.len(),
+                        reached.x,
+                        reached.y,
+                        next.x,
+                        next.y
+                    );
+                }
+                Some(MissionEvent::Loop {
+                    reached_idx,
+                    next_idx,
+                }) => {
+                    let reached = mission_cb.waypoints[reached_idx];
+                    let next = mission_cb.waypoints[next_idx];
+                    if let Err(err) = publish_goal(&goal_pub, next) {
+                        pr_warn!(log_odom, "failed to publish looped goal: {}", err);
+                        return;
+                    }
+                    pr_info!(
+                        log_odom,
+                        "completed mission lap at waypoint {}/{} ({:.2}, {:.2}); restarting -> ({:.2}, {:.2})",
+                        reached_idx + 1,
+                        mission_cb.waypoints.len(),
+                        reached.x,
+                        reached.y,
+                        next.x,
+                        next.y
+                    );
+                }
+                Some(MissionEvent::Complete { reached_idx }) => {
+                    let reached = mission_cb.waypoints[reached_idx];
+                    pr_info!(
+                        log_odom,
+                        "mission complete at waypoint {}/{} ({:.2}, {:.2})",
+                        reached_idx + 1,
+                        mission_cb.waypoints.len(),
+                        reached.x,
+                        reached.y
+                    );
+                }
+                None => {}
+            }
+        }),
+    );
+
+    loop {
+        selector.wait()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_bool, parse_waypoints};
+
+    #[test]
+    fn parse_waypoints_accepts_semicolon_delimited_points() {
+        let mission = parse_waypoints("0.5,0.0; 1.0, -0.5; -2.5,3.0").unwrap();
+        assert_eq!(mission.len(), 3);
+        assert!((mission[0].x - 0.5).abs() < 1e-9);
+        assert!((mission[1].y + 0.5).abs() < 1e-9);
+        assert!((mission[2].x + 2.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_waypoints_rejects_bad_pairs() {
+        let err = parse_waypoints("0.5;1.0,2.0").unwrap_err();
+        assert!(err.contains("missing y"));
+    }
+
+    #[test]
+    fn parse_bool_accepts_common_values() {
+        assert_eq!(parse_bool("true"), Some(true));
+        assert_eq!(parse_bool("ON"), Some(true));
+        assert_eq!(parse_bool("0"), Some(false));
+        assert_eq!(parse_bool("no"), Some(false));
+        assert_eq!(parse_bool("maybe"), None);
+    }
+}

--- a/ros2_nodes/waypoint_navigator_node/src/main.rs
+++ b/ros2_nodes/waypoint_navigator_node/src/main.rs
@@ -9,12 +9,14 @@ use safe_drive::{
 use std::{
     env, io,
     sync::{Arc, Mutex},
+    time::{Duration, Instant},
 };
 
 const DEFAULT_ODOM_TOPIC: &str = "/odom";
 const DEFAULT_WAYPOINTS: &str = "0.5,0.0;0.5,0.5;0.0,0.5";
 const DEFAULT_GOAL_TOLERANCE: f64 = 0.35;
 const GOAL_FRAME_ID: &str = "map";
+const GOAL_REPUBLISH_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Clone)]
 struct MissionConfig {
@@ -27,6 +29,7 @@ struct MissionConfig {
 struct NavigatorState {
     current_waypoint_idx: Option<usize>,
     mission_completed: bool,
+    last_goal_publish_at: Option<Instant>,
 }
 
 enum MissionEvent {
@@ -34,6 +37,7 @@ enum MissionEvent {
     Advance { reached_idx: usize, next_idx: usize },
     Loop { reached_idx: usize, next_idx: usize },
     Complete { reached_idx: usize },
+    Republish { current_idx: usize },
 }
 
 fn parse_waypoints(raw: &str) -> Result<Vec<Point2D>, String> {
@@ -137,6 +141,13 @@ fn distance(a: Point2D, b: Point2D) -> f64 {
     ((a.x - b.x).powi(2) + (a.y - b.y).powi(2)).sqrt()
 }
 
+fn should_republish_goal(last_goal_publish_at: Option<Instant>, now: Instant) -> bool {
+    match last_goal_publish_at {
+        Some(last_sent_at) => now.duration_since(last_sent_at) >= GOAL_REPUBLISH_INTERVAL,
+        None => true,
+    }
+}
+
 fn publish_goal(
     publisher: &safe_drive::topic::publisher::Publisher<geometry_msgs::msg::PoseStamped>,
     waypoint: Point2D,
@@ -188,6 +199,7 @@ fn main() -> Result<(), DynError> {
         odom_sub,
         Box::new(move |msg| {
             let robot_pose = Point2D::new(msg.pose.pose.position.x, msg.pose.pose.position.y);
+            let now = Instant::now();
 
             let event = {
                 let mut st = match state_odom.lock() {
@@ -204,21 +216,29 @@ fn main() -> Result<(), DynError> {
                     match st.current_waypoint_idx {
                         None => {
                             st.current_waypoint_idx = Some(0);
+                            st.last_goal_publish_at = Some(now);
                             Some(MissionEvent::Start { next_idx: 0 })
                         }
                         Some(current_idx) => {
                             let current_goal = mission_cb.waypoints[current_idx];
                             if distance(robot_pose, current_goal) > mission_cb.goal_tolerance {
-                                None
+                                if should_republish_goal(st.last_goal_publish_at, now) {
+                                    st.last_goal_publish_at = Some(now);
+                                    Some(MissionEvent::Republish { current_idx })
+                                } else {
+                                    None
+                                }
                             } else if current_idx + 1 < mission_cb.waypoints.len() {
                                 let next_idx = current_idx + 1;
                                 st.current_waypoint_idx = Some(next_idx);
+                                st.last_goal_publish_at = Some(now);
                                 Some(MissionEvent::Advance {
                                     reached_idx: current_idx,
                                     next_idx,
                                 })
                             } else if mission_cb.loop_mission {
                                 st.current_waypoint_idx = Some(0);
+                                st.last_goal_publish_at = Some(now);
                                 Some(MissionEvent::Loop {
                                     reached_idx: current_idx,
                                     next_idx: 0,
@@ -226,6 +246,7 @@ fn main() -> Result<(), DynError> {
                             } else {
                                 st.current_waypoint_idx = None;
                                 st.mission_completed = true;
+                                st.last_goal_publish_at = None;
                                 Some(MissionEvent::Complete {
                                     reached_idx: current_idx,
                                 })
@@ -304,6 +325,21 @@ fn main() -> Result<(), DynError> {
                         reached.y
                     );
                 }
+                Some(MissionEvent::Republish { current_idx }) => {
+                    let goal = mission_cb.waypoints[current_idx];
+                    if let Err(err) = publish_goal(&goal_pub, goal) {
+                        pr_warn!(log_odom, "failed to republish active goal: {}", err);
+                        return;
+                    }
+                    pr_info!(
+                        log_odom,
+                        "republishing waypoint {}/{} -> ({:.2}, {:.2})",
+                        current_idx + 1,
+                        mission_cb.waypoints.len(),
+                        goal.x,
+                        goal.y
+                    );
+                }
                 None => {}
             }
         }),
@@ -316,7 +352,8 @@ fn main() -> Result<(), DynError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_bool, parse_waypoints};
+    use super::{parse_bool, parse_waypoints, should_republish_goal, GOAL_REPUBLISH_INTERVAL};
+    use std::time::{Duration, Instant};
 
     #[test]
     fn parse_waypoints_accepts_semicolon_delimited_points() {
@@ -340,5 +377,24 @@ mod tests {
         assert_eq!(parse_bool("0"), Some(false));
         assert_eq!(parse_bool("no"), Some(false));
         assert_eq!(parse_bool("maybe"), None);
+    }
+
+    #[test]
+    fn should_republish_goal_triggers_without_history() {
+        assert!(should_republish_goal(None, Instant::now()));
+    }
+
+    #[test]
+    fn should_republish_goal_waits_for_interval() {
+        let now = Instant::now();
+        assert!(!should_republish_goal(Some(now), now));
+        assert!(!should_republish_goal(
+            Some(now),
+            now + GOAL_REPUBLISH_INTERVAL - Duration::from_millis(1)
+        ));
+        assert!(should_republish_goal(
+            Some(now),
+            now + GOAL_REPUBLISH_INTERVAL
+        ));
     }
 }

--- a/ros2_nodes/waypoint_navigator_node/src/main.rs
+++ b/ros2_nodes/waypoint_navigator_node/src/main.rs
@@ -15,14 +15,31 @@ use std::{
 const DEFAULT_ODOM_TOPIC: &str = "/odom";
 const DEFAULT_WAYPOINTS: &str = "0.5,0.0;0.5,0.5;0.0,0.5";
 const DEFAULT_GOAL_TOLERANCE: f64 = 0.35;
+const DEFAULT_WAYPOINT_FRAME: &str = "map";
 const GOAL_FRAME_ID: &str = "map";
 const GOAL_REPUBLISH_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MissionFrame {
+    Map,
+    RelativeStart,
+}
+
+impl MissionFrame {
+    fn as_str(self) -> &'static str {
+        match self {
+            MissionFrame::Map => "map",
+            MissionFrame::RelativeStart => "relative_start",
+        }
+    }
+}
 
 #[derive(Clone)]
 struct MissionConfig {
     waypoints: Vec<Point2D>,
     goal_tolerance: f64,
     loop_mission: bool,
+    frame: MissionFrame,
 }
 
 #[derive(Default)]
@@ -30,14 +47,25 @@ struct NavigatorState {
     current_waypoint_idx: Option<usize>,
     mission_completed: bool,
     last_goal_publish_at: Option<Instant>,
+    anchor_pose: Option<Point2D>,
 }
 
 enum MissionEvent {
-    Start { next_idx: usize },
-    Advance { reached_idx: usize, next_idx: usize },
-    Loop { reached_idx: usize, next_idx: usize },
-    Complete { reached_idx: usize },
-    Republish { current_idx: usize },
+    Start { next_idx: usize, goal: Point2D },
+    Advance {
+        reached_idx: usize,
+        reached_goal: Point2D,
+        next_idx: usize,
+        next_goal: Point2D,
+    },
+    Loop {
+        reached_idx: usize,
+        reached_goal: Point2D,
+        next_idx: usize,
+        next_goal: Point2D,
+    },
+    Complete { reached_idx: usize, reached_goal: Point2D },
+    Republish { current_idx: usize, goal: Point2D },
 }
 
 fn parse_waypoints(raw: &str) -> Result<Vec<Point2D>, String> {
@@ -93,6 +121,15 @@ fn parse_bool(raw: &str) -> Option<bool> {
     }
 }
 
+fn parse_mission_frame(raw: &str) -> Option<MissionFrame> {
+    let normalized = raw.trim().to_ascii_lowercase().replace(['-', ' '], "_");
+    match normalized.as_str() {
+        "map" | "absolute" => Some(MissionFrame::Map),
+        "relative" | "relative_start" | "start_relative" => Some(MissionFrame::RelativeStart),
+        _ => None,
+    }
+}
+
 fn load_mission_config() -> Result<MissionConfig, String> {
     let waypoint_spec = env::var("WAYPOINT_NAV_WAYPOINTS")
         .ok()
@@ -121,10 +158,19 @@ fn load_mission_config() -> Result<MissionConfig, String> {
         _ => false,
     };
 
+    let frame = match env::var("WAYPOINT_NAV_FRAME") {
+        Ok(raw) if !raw.trim().is_empty() => {
+            parse_mission_frame(&raw).ok_or_else(|| format!("invalid WAYPOINT_NAV_FRAME '{}'", raw))?
+        }
+        _ => parse_mission_frame(DEFAULT_WAYPOINT_FRAME)
+            .expect("DEFAULT_WAYPOINT_FRAME must be valid"),
+    };
+
     Ok(MissionConfig {
         waypoints,
         goal_tolerance,
         loop_mission,
+        frame,
     })
 }
 
@@ -145,6 +191,20 @@ fn should_republish_goal(last_goal_publish_at: Option<Instant>, now: Instant) ->
     match last_goal_publish_at {
         Some(last_sent_at) => now.duration_since(last_sent_at) >= GOAL_REPUBLISH_INTERVAL,
         None => true,
+    }
+}
+
+fn resolve_waypoint(
+    waypoint: Point2D,
+    frame: MissionFrame,
+    anchor_pose: Option<Point2D>,
+) -> Point2D {
+    match frame {
+        MissionFrame::Map => waypoint,
+        MissionFrame::RelativeStart => {
+            let anchor = anchor_pose.unwrap_or(Point2D::origin());
+            Point2D::new(anchor.x + waypoint.x, anchor.y + waypoint.y)
+        }
     }
 }
 
@@ -183,10 +243,11 @@ fn main() -> Result<(), DynError> {
     let logger = Logger::new("waypoint_navigator_node");
     pr_info!(
         logger,
-        "waypoint navigator started: {} waypoint(s), tolerance={:.2} m, loop={}",
+        "waypoint navigator started: {} waypoint(s), tolerance={:.2} m, loop={}, frame={}",
         mission.waypoints.len(),
         mission.goal_tolerance,
-        mission.loop_mission
+        mission.loop_mission,
+        mission.frame.as_str()
     );
     pr_info!(logger, "waypoint odom topic: {}", odom_topic);
     pr_info!(logger, "mission: {}", format_waypoints(&mission.waypoints));
@@ -213,35 +274,65 @@ fn main() -> Result<(), DynError> {
                 if st.mission_completed {
                     None
                 } else {
+                    if mission_cb.frame == MissionFrame::RelativeStart && st.anchor_pose.is_none() {
+                        st.anchor_pose = Some(robot_pose);
+                    }
+
                     match st.current_waypoint_idx {
                         None => {
+                            let goal = resolve_waypoint(
+                                mission_cb.waypoints[0],
+                                mission_cb.frame,
+                                st.anchor_pose,
+                            );
                             st.current_waypoint_idx = Some(0);
                             st.last_goal_publish_at = Some(now);
-                            Some(MissionEvent::Start { next_idx: 0 })
+                            Some(MissionEvent::Start { next_idx: 0, goal })
                         }
                         Some(current_idx) => {
-                            let current_goal = mission_cb.waypoints[current_idx];
+                            let current_goal = resolve_waypoint(
+                                mission_cb.waypoints[current_idx],
+                                mission_cb.frame,
+                                st.anchor_pose,
+                            );
                             if distance(robot_pose, current_goal) > mission_cb.goal_tolerance {
                                 if should_republish_goal(st.last_goal_publish_at, now) {
                                     st.last_goal_publish_at = Some(now);
-                                    Some(MissionEvent::Republish { current_idx })
+                                    Some(MissionEvent::Republish {
+                                        current_idx,
+                                        goal: current_goal,
+                                    })
                                 } else {
                                     None
                                 }
                             } else if current_idx + 1 < mission_cb.waypoints.len() {
                                 let next_idx = current_idx + 1;
+                                let next_goal = resolve_waypoint(
+                                    mission_cb.waypoints[next_idx],
+                                    mission_cb.frame,
+                                    st.anchor_pose,
+                                );
                                 st.current_waypoint_idx = Some(next_idx);
                                 st.last_goal_publish_at = Some(now);
                                 Some(MissionEvent::Advance {
                                     reached_idx: current_idx,
+                                    reached_goal: current_goal,
                                     next_idx,
+                                    next_goal,
                                 })
                             } else if mission_cb.loop_mission {
+                                let next_goal = resolve_waypoint(
+                                    mission_cb.waypoints[0],
+                                    mission_cb.frame,
+                                    st.anchor_pose,
+                                );
                                 st.current_waypoint_idx = Some(0);
                                 st.last_goal_publish_at = Some(now);
                                 Some(MissionEvent::Loop {
                                     reached_idx: current_idx,
+                                    reached_goal: current_goal,
                                     next_idx: 0,
+                                    next_goal,
                                 })
                             } else {
                                 st.current_waypoint_idx = None;
@@ -249,6 +340,7 @@ fn main() -> Result<(), DynError> {
                                 st.last_goal_publish_at = None;
                                 Some(MissionEvent::Complete {
                                     reached_idx: current_idx,
+                                    reached_goal: current_goal,
                                 })
                             }
                         }
@@ -257,8 +349,7 @@ fn main() -> Result<(), DynError> {
             };
 
             match event {
-                Some(MissionEvent::Start { next_idx }) => {
-                    let goal = mission_cb.waypoints[next_idx];
+                Some(MissionEvent::Start { next_idx, goal }) => {
                     if let Err(err) = publish_goal(&goal_pub, goal) {
                         pr_warn!(log_odom, "failed to publish first goal: {}", err);
                         return;
@@ -274,59 +365,64 @@ fn main() -> Result<(), DynError> {
                 }
                 Some(MissionEvent::Advance {
                     reached_idx,
+                    reached_goal,
                     next_idx,
+                    next_goal,
                 }) => {
-                    let reached = mission_cb.waypoints[reached_idx];
-                    let next = mission_cb.waypoints[next_idx];
-                    if let Err(err) = publish_goal(&goal_pub, next) {
+                    if let Err(err) = publish_goal(&goal_pub, next_goal) {
                         pr_warn!(log_odom, "failed to publish next goal: {}", err);
                         return;
                     }
                     pr_info!(
                         log_odom,
-                        "reached waypoint {}/{} at ({:.2}, {:.2}); next -> ({:.2}, {:.2})",
+                        "reached waypoint {}/{} at ({:.2}, {:.2}); next waypoint {}/{} -> ({:.2}, {:.2})",
                         reached_idx + 1,
                         mission_cb.waypoints.len(),
-                        reached.x,
-                        reached.y,
-                        next.x,
-                        next.y
+                        reached_goal.x,
+                        reached_goal.y,
+                        next_idx + 1,
+                        mission_cb.waypoints.len(),
+                        next_goal.x,
+                        next_goal.y
                     );
                 }
                 Some(MissionEvent::Loop {
                     reached_idx,
+                    reached_goal,
                     next_idx,
+                    next_goal,
                 }) => {
-                    let reached = mission_cb.waypoints[reached_idx];
-                    let next = mission_cb.waypoints[next_idx];
-                    if let Err(err) = publish_goal(&goal_pub, next) {
+                    if let Err(err) = publish_goal(&goal_pub, next_goal) {
                         pr_warn!(log_odom, "failed to publish looped goal: {}", err);
                         return;
                     }
                     pr_info!(
                         log_odom,
-                        "completed mission lap at waypoint {}/{} ({:.2}, {:.2}); restarting -> ({:.2}, {:.2})",
+                        "completed mission lap at waypoint {}/{} ({:.2}, {:.2}); restarting at waypoint {}/{} -> ({:.2}, {:.2})",
                         reached_idx + 1,
                         mission_cb.waypoints.len(),
-                        reached.x,
-                        reached.y,
-                        next.x,
-                        next.y
+                        reached_goal.x,
+                        reached_goal.y,
+                        next_idx + 1,
+                        mission_cb.waypoints.len(),
+                        next_goal.x,
+                        next_goal.y
                     );
                 }
-                Some(MissionEvent::Complete { reached_idx }) => {
-                    let reached = mission_cb.waypoints[reached_idx];
+                Some(MissionEvent::Complete {
+                    reached_idx,
+                    reached_goal,
+                }) => {
                     pr_info!(
                         log_odom,
                         "mission complete at waypoint {}/{} ({:.2}, {:.2})",
                         reached_idx + 1,
                         mission_cb.waypoints.len(),
-                        reached.x,
-                        reached.y
+                        reached_goal.x,
+                        reached_goal.y
                     );
                 }
-                Some(MissionEvent::Republish { current_idx }) => {
-                    let goal = mission_cb.waypoints[current_idx];
+                Some(MissionEvent::Republish { current_idx, goal }) => {
                     if let Err(err) = publish_goal(&goal_pub, goal) {
                         pr_warn!(log_odom, "failed to republish active goal: {}", err);
                         return;
@@ -352,7 +448,11 @@ fn main() -> Result<(), DynError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_bool, parse_waypoints, should_republish_goal, GOAL_REPUBLISH_INTERVAL};
+    use super::{
+        parse_bool, parse_mission_frame, parse_waypoints, resolve_waypoint,
+        should_republish_goal, MissionFrame, GOAL_REPUBLISH_INTERVAL,
+    };
+    use rust_robotics_core::Point2D;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -377,6 +477,31 @@ mod tests {
         assert_eq!(parse_bool("0"), Some(false));
         assert_eq!(parse_bool("no"), Some(false));
         assert_eq!(parse_bool("maybe"), None);
+    }
+
+    #[test]
+    fn parse_mission_frame_accepts_relative_aliases() {
+        assert_eq!(parse_mission_frame("map"), Some(MissionFrame::Map));
+        assert_eq!(
+            parse_mission_frame("relative_start"),
+            Some(MissionFrame::RelativeStart)
+        );
+        assert_eq!(
+            parse_mission_frame("relative"),
+            Some(MissionFrame::RelativeStart)
+        );
+        assert_eq!(parse_mission_frame("bad"), None);
+    }
+
+    #[test]
+    fn resolve_waypoint_offsets_relative_start_frame() {
+        let resolved = resolve_waypoint(
+            Point2D::new(0.5, -0.2),
+            MissionFrame::RelativeStart,
+            Some(Point2D::new(-2.0, -0.5)),
+        );
+        assert!((resolved.x + 1.5).abs() < 1e-9);
+        assert!((resolved.y + 0.7).abs() < 1e-9);
     }
 
     #[test]

--- a/scripts/speed_comparison.py
+++ b/scripts/speed_comparison.py
@@ -162,19 +162,15 @@ from PathPlanning.CubicSpline.cubic_spline_planner import CubicSpline2D  # noqa:
 
 
 def ekf_motion_model(x, u, dt=0.1):
-    F = np.array(
-        [[1.0, 0, 0, 0], [0, 1.0, 0, 0], [0, 0, 1.0, 0], [0, 0, 0, 1.0]]
-    )
     yaw = x[2, 0]
-    B = np.array(
+    return np.array(
         [
-            [dt * math.cos(yaw), 0],
-            [dt * math.sin(yaw), 0],
-            [0.0, dt],
-            [1.0, 0.0],
+            [x[0, 0] + dt * u[0, 0] * math.cos(yaw)],
+            [x[1, 0] + dt * u[0, 0] * math.sin(yaw)],
+            [x[2, 0] + dt * u[1, 0]],
+            [u[0, 0]],
         ]
     )
-    return F @ x + B @ u
 
 
 def ekf_jacob_f(x, u, dt=0.1):
@@ -182,10 +178,10 @@ def ekf_jacob_f(x, u, dt=0.1):
     v = u[0, 0]
     return np.array(
         [
-            [1.0, 0.0, -dt * v * math.sin(yaw), dt * math.cos(yaw)],
-            [0.0, 1.0, dt * v * math.cos(yaw), dt * math.sin(yaw)],
+            [1.0, 0.0, -dt * v * math.sin(yaw), 0.0],
+            [0.0, 1.0, dt * v * math.cos(yaw), 0.0],
             [0.0, 0.0, 1.0, 0.0],
-            [0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0, 0.0],
         ]
     )
 


### PR DESCRIPTION
## What changed
- add `ekf_localizer_node` to publish `/ekf_odom` and `/ekf_pose` from raw `/odom`
- make `path_planner_node`, `dwa_planner_node`, and `waypoint_navigator_node` consume a configurable odom topic via `RUST_NAV_ODOM_TOPIC`
- extend `navigation_demo.launch.py` and mission wrappers to launch the EKF-backed stack and pass launch arguments correctly through `ros2 launch`
- update README and ROS2 integration docs for the EKF-backed mission flow
- fix EKF velocity-state propagation so the filtered odom stream does not diverge during longer runs

## Why
The next navigation-stack slice needs a filtered odometry stream that can sit between Gazebo `/odom` and the planner / mission nodes. While wiring that in, a core EKF bug showed up: the velocity state was being accumulated each step instead of tracking the commanded velocity, which caused filtered odometry to blow up over time.

## Impact
- the mission stack can run against `/ekf_odom` instead of raw `/odom`
- launch wrappers now honor mission / EKF arguments reliably
- EKF output stays in the same order of magnitude as raw odometry instead of diverging

## Root cause
The EKF motion model in `rust_robotics_localization::EKFLocalizer` treated the velocity state as an additive integrator (`v' = v + u_v`) rather than setting it from the current control input (`v' = u_v`). Its Jacobian and benchmark mirror also no longer matched the intended state definition.

## Validation
- `cargo test -p rust_robotics_localization ekf --manifest-path Cargo.toml`
- `cargo build --release --manifest-path ros2_nodes/ekf_localizer_node/Cargo.toml`
- `cargo build --release --manifest-path ros2_nodes/path_planner_node/Cargo.toml`
- `cargo build --release --manifest-path ros2_nodes/dwa_planner_node/Cargo.toml`
- `cargo build --release --manifest-path ros2_nodes/waypoint_navigator_node/Cargo.toml`
- `python3 -m py_compile ros2_nodes/launch/navigation_demo.launch.py`
- `bash -n ros2_nodes/launch/run_gazebo_demo.sh`
- `bash -n ros2_nodes/launch/run_gazebo_mission_demo.sh`
- Gazebo mission demo smoke check with `ROS_DOMAIN_ID=42` confirming `ekf_localizer_node`, `/ekf_odom`, `/cmd_vel`, and mission waypoint completion logs
- Gazebo short rerun with `ROS_DOMAIN_ID=43` confirming `/ekf_odom` stays aligned with raw `/odom` after the EKF velocity fix

## Follow-up
- investigate the intermittent static startup case where the robot can remain idle after launch even though the stack is up
