### PR TITLE
Corrected SLAM: split gate, tuning sprint findings, scan-to-map ICP foundation

### DIFF
--- a/.github/workflows/ros2-smoke.yml
+++ b/.github/workflows/ros2-smoke.yml
@@ -31,6 +31,14 @@ on:
         options:
           - baseline
           - biased
+      revaluation_start_index:
+        description: "Zero-based matrix row to start from"
+        required: false
+        default: "0"
+      revaluation_max_runs:
+        description: "Maximum rows to run; 0 runs all remaining rows"
+        required: false
+        default: "0"
 
 env:
   CARGO_TERM_COLOR: always
@@ -123,6 +131,8 @@ jobs:
         ROS_DOMAIN_ID_BASE=120 \
         SLAM_REVALUATION_PROFILE_SET="${{ inputs.revaluation_profile_set }}" \
         SLAM_REVALUATION_ODOM_PROFILE_SET="${{ inputs.revaluation_odom_profile_set }}" \
+        SLAM_REVALUATION_START_INDEX="${{ inputs.revaluation_start_index }}" \
+        SLAM_REVALUATION_MAX_RUNS="${{ inputs.revaluation_max_runs }}" \
         timeout 75m ./ros2_nodes/launch/run_navigation_revaluation_matrix.sh
 
     - name: Upload corrected-frame revaluation reports

--- a/.github/workflows/ros2-smoke.yml
+++ b/.github/workflows/ros2-smoke.yml
@@ -120,7 +120,7 @@ jobs:
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_revaluation == 'true' }}
       run: |
         source /opt/ros/jazzy/setup.bash
-        ROS_DOMAIN_ID_BASE=200 \
+        ROS_DOMAIN_ID_BASE=120 \
         SLAM_REVALUATION_PROFILE_SET="${{ inputs.revaluation_profile_set }}" \
         SLAM_REVALUATION_ODOM_PROFILE_SET="${{ inputs.revaluation_odom_profile_set }}" \
         timeout 75m ./ros2_nodes/launch/run_navigation_revaluation_matrix.sh

--- a/.github/workflows/ros2-smoke.yml
+++ b/.github/workflows/ros2-smoke.yml
@@ -5,6 +5,32 @@ on:
     branches: [ main, dev/*, feat/*, task/* ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      run_revaluation:
+        description: "Run corrected-frame revaluation matrix and upload reports"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      revaluation_profile_set:
+        description: "ICP profile set for revaluation"
+        required: false
+        default: "baseline"
+        type: choice
+        options:
+          - baseline
+          - tuning
+      revaluation_odom_profile_set:
+        description: "SLAM input odom profile set for revaluation"
+        required: false
+        default: "baseline"
+        type: choice
+        options:
+          - baseline
+          - biased
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,7 +45,7 @@ env:
 jobs:
   navigation-smoke:
     runs-on: ubuntu-24.04
-    timeout-minutes: 35
+    timeout-minutes: 120
     steps:
     - uses: actions/checkout@v4
 
@@ -89,3 +115,20 @@ jobs:
       run: |
         source /opt/ros/jazzy/setup.bash
         ROS_DOMAIN_ID=90 ENABLE_SLAM_CORRECTED_FRAME=true timeout 20m ./ros2_nodes/launch/run_navigation_smoke_test.sh
+
+    - name: Run corrected-frame revaluation matrix
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_revaluation == 'true' }}
+      run: |
+        source /opt/ros/jazzy/setup.bash
+        ROS_DOMAIN_ID_BASE=200 \
+        SLAM_REVALUATION_PROFILE_SET="${{ inputs.revaluation_profile_set }}" \
+        SLAM_REVALUATION_ODOM_PROFILE_SET="${{ inputs.revaluation_odom_profile_set }}" \
+        timeout 75m ./ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+
+    - name: Upload corrected-frame revaluation reports
+      if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.run_revaluation == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: corrected-slam-revaluation-${{ inputs.revaluation_profile_set }}-${{ inputs.revaluation_odom_profile_set }}
+        path: reports/slam_revaluation/
+        if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ That switches the mission stack to `NAV_ODOM_TOPIC=/slam_odom` and `NAV_GLOBAL_F
 
 Corrected mode also exposes two extra observability topics:
 
-- `/slam_diagnostics` (`std_msgs/String`) with per-scan ICP convergence, error, `blend_alpha`, `gate_reason`, and applied correction deltas
+- `/slam_diagnostics` (`std_msgs/String`) with per-scan ICP convergence, error distribution, inlier ratio, `blend_alpha`, `gate_reason`, and applied correction deltas
 - `/slam_ground_truth_status` (`std_msgs/String`) with relative-start Gazebo ground-truth error metrics derived from `gz topic -e -t /world/default/dynamic_pose/info --json-output`
 
 The ground-truth monitor defaults to the spawned model name (`GROUND_TRUTH_ENTITY_NAME=$TURTLEBOT3_MODEL`) and compares `/ekf_odom` plus `/slam_odom` against the model pose after subtracting the first ground-truth sample. You can override the Gazebo source with `GROUND_TRUTH_GZ_POSE_TOPIC` if needed.

--- a/crates/rust_robotics_slam/src/icp_matching.rs
+++ b/crates/rust_robotics_slam/src/icp_matching.rs
@@ -25,6 +25,7 @@ use std::f64;
 // ICP parameters
 const EPS: f64 = 0.0001;
 const MAX_ITER: usize = 100;
+const INLIER_DISTANCE_THRESHOLD: f64 = 0.05;
 
 pub struct ICPResult {
     pub rotation: DMatrix<f64>,
@@ -34,6 +35,16 @@ pub struct ICPResult {
     pub final_error: f64,
     /// Mean nearest-neighbor distance \[m/point\]: `final_error / point_count`.
     pub final_error_mean: f64,
+    /// Mean nearest-neighbor distance before the first ICP update \[m/point\].
+    pub initial_error_mean: f64,
+    /// Median nearest-neighbor distance after applying the final transform.
+    pub final_error_median: f64,
+    /// 90th percentile nearest-neighbor distance after applying the final transform.
+    pub final_error_p90: f64,
+    /// Fraction of final associations below 5 cm. Useful as a simple ICP quality diagnostic.
+    pub inlier_ratio_5cm: f64,
+    /// Relative reduction from initial to final mean error. Negative values are clamped to 0.
+    pub relative_error_reduction: f64,
     pub point_count: usize,
     pub converged: bool,
 }
@@ -50,6 +61,7 @@ pub fn icp_matching(previous_points: &DMatrix<f64>, current_points: &DMatrix<f64
     let mut h_matrix: Option<DMatrix<f64>> = None;
     let mut d_error = f64::INFINITY;
     let mut pre_error = f64::INFINITY;
+    let mut initial_error = f64::NAN;
     let mut count = 0;
     let mut current_pts = current_points.clone();
 
@@ -57,6 +69,9 @@ pub fn icp_matching(previous_points: &DMatrix<f64>, current_points: &DMatrix<f64
         count += 1;
 
         let (indexes, error) = nearest_neighbor_association(previous_points, &current_pts);
+        if initial_error.is_nan() {
+            initial_error = error;
+        }
         let previous_indexed = select_columns(previous_points, &indexes);
         let (rt, tt) = svd_motion_estimation(&previous_indexed, &current_pts);
 
@@ -88,6 +103,24 @@ pub fn icp_matching(previous_points: &DMatrix<f64>, current_points: &DMatrix<f64
 
     let point_count = current_points.ncols().max(1);
     let final_error_mean = pre_error / point_count as f64;
+    let initial_error_mean = initial_error / point_count as f64;
+    let final_distances = nearest_neighbor_distances(previous_points, &current_pts);
+    let final_error_median = percentile(final_distances.clone(), 0.50);
+    let final_error_p90 = percentile(final_distances.clone(), 0.90);
+    let inlier_count = final_distances
+        .iter()
+        .filter(|distance| **distance <= INLIER_DISTANCE_THRESHOLD)
+        .count();
+    let inlier_ratio_5cm = if final_distances.is_empty() {
+        0.0
+    } else {
+        inlier_count as f64 / final_distances.len() as f64
+    };
+    let relative_error_reduction = if initial_error_mean.is_finite() && initial_error_mean > 0.0 {
+        ((initial_error_mean - final_error_mean) / initial_error_mean).max(0.0)
+    } else {
+        0.0
+    };
 
     ICPResult {
         rotation,
@@ -95,6 +128,11 @@ pub fn icp_matching(previous_points: &DMatrix<f64>, current_points: &DMatrix<f64
         iterations: count,
         final_error: pre_error,
         final_error_mean,
+        initial_error_mean,
+        final_error_median,
+        final_error_p90,
+        inlier_ratio_5cm,
+        relative_error_reduction,
         point_count,
         converged: d_error <= EPS && count < MAX_ITER,
     }
@@ -169,6 +207,56 @@ fn nearest_neighbor_association(
         }
         (indexes, error)
     }
+}
+
+fn nearest_neighbor_distances(
+    previous_points: &DMatrix<f64>,
+    current_points: &DMatrix<f64>,
+) -> Vec<f64> {
+    let dim = previous_points.nrows();
+
+    if dim == 2 {
+        let prev_svecs: Vec<SVector<f64, 2>> = (0..previous_points.ncols())
+            .map(|i| SVector::<f64, 2>::from([previous_points[(0, i)], previous_points[(1, i)]]))
+            .collect();
+        let tree = KdTree::new(&prev_svecs, 2);
+
+        (0..current_points.ncols())
+            .map(|j| {
+                let query =
+                    SVector::<f64, 2>::from([current_points[(0, j)], current_points[(1, j)]]);
+                let (_, sq_dist) = tree.search(&query);
+                sq_dist.sqrt()
+            })
+            .collect()
+    } else {
+        let mut distances = Vec::with_capacity(current_points.ncols());
+        for j in 0..current_points.ncols() {
+            let current_point = current_points.column(j);
+            let mut min_dist = f64::INFINITY;
+
+            for i in 0..previous_points.ncols() {
+                let prev_point = previous_points.column(i);
+                let dist = (current_point - prev_point).norm();
+                if dist < min_dist {
+                    min_dist = dist;
+                }
+            }
+            distances.push(min_dist);
+        }
+        distances
+    }
+}
+
+fn percentile(mut values: Vec<f64>, q: f64) -> f64 {
+    values.retain(|value| value.is_finite());
+    if values.is_empty() {
+        return f64::NAN;
+    }
+    values.sort_by(|a, b| a.total_cmp(b));
+    let clamped_q = q.clamp(0.0, 1.0);
+    let idx = ((values.len() - 1) as f64 * clamped_q).round() as usize;
+    values[idx]
 }
 
 /// Select columns from matrix based on indices
@@ -318,6 +406,11 @@ mod tests {
         assert!(result.converged);
         assert!((result.translation[0] + translation.x).abs() < 0.1);
         assert!((result.translation[1] + translation.y).abs() < 0.1);
+        assert!(result.initial_error_mean.is_finite());
+        assert!(result.final_error_median.is_finite());
+        assert!(result.final_error_p90.is_finite());
+        assert!((0.0..=1.0).contains(&result.inlier_ratio_5cm));
+        assert!((0.0..=1.0).contains(&result.relative_error_reduction));
     }
 
     #[test]

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -441,23 +441,66 @@ Practical reading:
   yaw branches** so the yaw blend can be admitted while XY is still
   rejected. That avoids the current "all-or-nothing" XY/yaw coupling.
 
+### Split ICP gate validates: yaw_loose_018 keeps XY and improves YAW
+
+Commit `4f705b0` split `compute_icp_blend_decision` into two independent
+axis decisions (XY and yaw) with their own thresholds and motion gates.
+A new tuning profile `yaw_loose_018` was added in `7ca7297`, raising
+only `SLAM_ICP_REJECT_ERROR_YAW` to `0.018` while keeping the XY
+threshold at the default `0.011`. The validation slice
+(`baseline odom × yaw_loose_018 × all 4 scenarios`, Actions run
+`26061138051`) shows the split works as designed:
+
+| scenario              | improvement_xy | slam_better_xy | improvement_yaw | slam_better_yaw |
+| --------------------- | --------------:| --------------:| ---------------:| ---------------:|
+| short_default         | +0.003         | True           | +0.019          | True            |
+| three_hops            |  0.000         | True           | +0.009          | True            |
+| long_two_legs         | -0.001         | False          | +0.001          | True            |
+| rich_geometry_turns   | +0.001         | True           | -0.008          | False           |
+| **average**           | **+0.0008**    | **3/4**        | **+0.005**      | **3/4**         |
+
+Direct comparison to `loose_error` (same yaw threshold but XY also
+loosened to 0.018) shows the split eliminates the XY regression
+completely:
+
+| scenario              | yaw_loose_018 XY | loose_error XY | yaw_loose_018 YAW | loose_error YAW |
+| --------------------- | ----------------:| --------------:| -----------------:| ---------------:|
+| short_default         | +0.003           | -0.023         | +0.019            | +0.005          |
+| three_hops            |  0.000           | -0.011         | +0.009            | +0.043          |
+| long_two_legs         | -0.001           | -0.045         | +0.001            | -0.001          |
+| rich_geometry_turns   | +0.001           | -0.022         | -0.008            | +0.027          |
+
+Aggregate gate counts for `yaw_loose_018`: `high_error:219`,
+`low_motion:268`, `icp_attenuated:159`, `icp_rejected:328`. The 159
+icp_attenuated samples are the new yaw-only blend admissions that
+the previous single-gate could not produce without also opening the
+XY axis.
+
+Conclusions:
+
+- The split-gate design is correct and the implementation is sound.
+- `yaw_loose_018` is strictly better than `default` on XY (avg +0.0008
+  vs 0) and improves yaw on 3 of 4 scenarios. It is a candidate
+  default tuning.
+- The one mixed scenario is `rich_geometry_turns` where yaw degraded
+  by 8 mrad. Worth checking whether a different `SLAM_ICP_REJECT_ERROR_YAW`
+  (e.g. 0.025) or a `BLEND_ALPHA_YAW` reduction recovers that yaw too.
+- The legacy `loose_error` / `loose_error_low_alpha` /
+  `very_loose_error` profiles loosen both axes and are now strictly
+  worse than `yaw_loose_018` on baseline odom. They could be retired
+  or kept only as negative controls.
+
 ### Followups not addressed yet
 
-- Re-run the missed loose_error_low_alpha slice (matrix indices
-  20-23, 4 runs) to see if reducing blend alpha eliminates the XY
-  regression while keeping the yaw improvement. With ~19 min per run
-  including the rich_geometry_turns step, the next slice should fit
-  within the 75-minute step timeout.
-- `very_loose_error` (`SLAM_ICP_REJECT_ERROR=0.025`) rows are not a
-  priority; if loose_error already hurts XY at 0.018, very_loose will
-  hurt more.
-- Investigate the yaw-only blend split above. This is a code change
-  in `compute_icp_blend_decision()` and `blend_motion_delta()` in
-  `ros2_nodes/slam_node/src/main.rs`, not a tuning sweep.
-- Biased odom × tuning sweep is still pending. Run it only after the
-  yaw-only blend question is resolved, otherwise the result is
-  predictable from the unbiased data above.
-- The revaluation matrix script does not write the CSV row until the
-  whole step succeeds; on step timeout the last completed run's row
-  is lost even though the log is uploaded. Consider flushing the CSV
-  per-run so partial sweeps are self-describing.
+- Re-run on **biased odom** (`odom_xy_scale_3pct`,
+  `odom_yaw_drift_3deg_per_m`) with `yaw_loose_018` to see whether the
+  yaw improvement helps under odom drift. This is the original
+  motivation for tuning corrected SLAM.
+- Try a `yaw_loose_025` profile (looser still) and a
+  `yaw_loose_018_low_alpha` (`SLAM_ICP_BLEND_ALPHA_YAW=0.10`) to see if
+  the `rich_geometry_turns` yaw regression goes away.
+- The revaluation matrix script still does not flush the CSV row
+  per-run; consider doing this so partial sweeps from step timeouts
+  remain self-describing.
+- Existing `loose_error*` and `very_loose_error` profiles can be
+  retired once split-gate equivalents are validated.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -650,8 +650,9 @@ profiles, each suited to a different downstream priority:
 | `yaw_loose_018_low_alpha`      | balance: smaller XY win (+0.8 mm) plus much smaller yaw damage (-5 mrad), one scenario wins yaw. |
 
 The `loose_error*` and `very_loose_error` profiles in the tuning
-matrix are now strictly worse on every comparison done in this
-sprint and should be removed when the matrix is next edited.
+matrix were strictly worse on every comparison done in this sprint
+and were retired from `run_navigation_revaluation_matrix.sh` after
+this sprint closed.
 
 ### Sprint conclusion
 
@@ -688,5 +689,3 @@ The 2026-05-17/18 corrected-SLAM tuning sprint achieved:
   the current data supports for overcoming the `xy_scale` structural
   limit. Likely a multi-week effort and a meaningful design change
   (persistent local submap, ICP target swap, drift consolidation).
-- Retire `loose_error`, `loose_error_low_alpha`, and
-  `very_loose_error` from the tuning matrix.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -395,18 +395,69 @@ Reshaped path (current): `0.55,0.0;0.55,0.5;0.0,0.5` — three waypoints,
 two 90-degree turns, ~1.6 m total, all inside the working-scenario
 corridor at relative `x <= 0.55`. Pending fresh validation.
 
+### Baseline odom × loose_error on all four scenarios — XY worse, YAW better
+
+After `rich_geometry_turns` was reshaped to the all-diagonal three-hops
+pattern `(0.55,0.05); (0.20,0.55); (0,0)` and validated as completing
+(run `26017689809`: `mission_completed=true`, 134 mid-mission scans,
+49 high_error + 85 low_motion), a focused 8-run slice was triggered to
+compare `loose_error` and `loose_error_low_alpha` across all four
+scenarios on the unbiased baseline odom (Actions run `26018186549`,
+`navigation_revaluation_20260518T065743Z`). The step hit the 75-minute
+timeout after the loose_error half completed, so the four loose_error
+runs and the rich_geometry_turns log are usable; loose_error_low_alpha
+rows were not produced.
+
+Results for **baseline (unbiased) odom × loose_error**:
+
+| scenario              | improvement_xy | improvement_yaw | slam_better_yaw |
+| --------------------- | --------------:| ---------------:| ---------------:|
+| short_default         | -0.023         | +0.005          | True            |
+| three_hops            | -0.011         | +0.043          | True            |
+| long_two_legs         | -0.045         | -0.001          | False           |
+| rich_geometry_turns   | -0.022         | +0.027          | True            |
+
+(rich_geometry_turns row taken from the mid-mission log; the CSV row
+was not written because the step timed out during summary generation.)
+
+The pattern is consistent on clean odom: scan-to-scan ICP corrections
+**hurt XY by 1–4 cm but help or stay neutral on yaw**, often making
+`slam_better_yaw=True`. The earlier biased-odom regression
+(`loose_error` made XY 3-4x worse) is therefore not a biased-odom
+specific failure mode — it is the same XY noise injection that already
+happens on clean odom, amplified by the 3 percent scale bias.
+
+Practical reading:
+
+- The default `SLAM_ICP_REJECT_ERROR=0.011` is well tuned for XY
+  accuracy on this robot+world. Loosening it makes XY worse on every
+  scenario tested so far, including the new positive-control
+  `rich_geometry_turns`.
+- Scan-to-scan ICP on a TurtleBot3 burger is more reliable as a
+  **yaw** correction than as a **translation** correction. If the
+  goal is yaw accuracy, the gate can be loosened; if the goal is XY
+  accuracy, default is the right setting.
+- The simplest next improvement is to **split the gate into XY and
+  yaw branches** so the yaw blend can be admitted while XY is still
+  rejected. That avoids the current "all-or-nothing" XY/yaw coupling.
+
 ### Followups not addressed yet
 
-- `very_loose_error` (`SLAM_ICP_REJECT_ERROR=0.025`) matrix rows 60-62
-  from the older biased sweep were never executed; do not re-run loose
-  sweeps on short_default / three_hops / long_two_legs (those are
-  rotation-dominated and the loose threshold just admits noise).
-  Re-evaluate only after rich_geometry_turns is reliably completing.
-- Once `rich_geometry_turns` passes the baseline+default validation, the
-  natural next sweep is **baseline odom × tuning ICP profiles × all four
-  scenarios** (28 runs). That isolates whether `loose_error` helps when
-  ICP actually has signal, without the biased odom confound. Only then
-  expand to biased odom.
-- The biased-odom revaluation still has no positive-control scenario for
-  drift correction. Consider `long_loop_return` (6-10 m, returns near
-  start) after rich_geometry_turns stabilizes.
+- Re-run the missed loose_error_low_alpha slice (matrix indices
+  20-23, 4 runs) to see if reducing blend alpha eliminates the XY
+  regression while keeping the yaw improvement. With ~19 min per run
+  including the rich_geometry_turns step, the next slice should fit
+  within the 75-minute step timeout.
+- `very_loose_error` (`SLAM_ICP_REJECT_ERROR=0.025`) rows are not a
+  priority; if loose_error already hurts XY at 0.018, very_loose will
+  hurt more.
+- Investigate the yaw-only blend split above. This is a code change
+  in `compute_icp_blend_decision()` and `blend_motion_delta()` in
+  `ros2_nodes/slam_node/src/main.rs`, not a tuning sweep.
+- Biased odom × tuning sweep is still pending. Run it only after the
+  yaw-only blend question is resolved, otherwise the result is
+  predictable from the unbiased data above.
+- The revaluation matrix script does not write the CSV row until the
+  whole step succeeds; on step timeout the last completed run's row
+  is lost even though the log is uploaded. Consider flushing the CSV
+  per-run so partial sweeps are self-describing.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -689,3 +689,7 @@ The 2026-05-17/18 corrected-SLAM tuning sprint achieved:
   the current data supports for overcoming the `xy_scale` structural
   limit. Likely a multi-week effort and a meaningful design change
   (persistent local submap, ICP target swap, drift consolidation).
+  Design draft for this change lives in
+  `docs/scan_to_map_icp_design.md`; the first follow-on PR should
+  be Phase 1 in that doc (pure helpers + unit tests, no behavior
+  change).

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -539,19 +539,88 @@ What this rules out and what is still open:
   previous scan. That is a substantially larger change than gate
   tuning.
 
+### yaw_loose_018 under yaw_drift_3deg_per_m — first biased-odom win, with a yaw paradox
+
+Actions run `26069242809` ran the same `yaw_loose_018` profile under
+the 3-degree-per-meter yaw-drift biased odom, indices 156-159 in the
+biased matrix.
+
+| scenario              | improvement_xy | slam_better_xy | improvement_yaw | slam_better_yaw |
+| --------------------- | --------------:| --------------:| ---------------:| ---------------:|
+| short_default         | +0.003         | True           | -0.017          | False           |
+| three_hops            | -0.000         | False          | -0.017          | False           |
+| long_two_legs         | +0.003         | True           | -0.026          | False           |
+| rich_geometry_turns   | +0.002         | True           | -0.025          | False           |
+| **average**           | **+0.0020**    | **3/4**        | **-0.021**      | 0/4             |
+
+This is the first time in this sprint that corrected SLAM has **beaten
+raw odom on XY under any biased odom profile**. `better_xy=3/4` and
+avg XY improvement of +2 mm, against a profile that adds 3° per
+meter of yaw drift to the SLAM input odom.
+
+But yaw is dramatically worse: every scenario regresses by 17-26 mrad
+(about 1.0-1.5°). The XY win and the yaw loss happen at the same
+time, on the same scans.
+
+Why xy_scale and yaw_drift differ structurally:
+
+- `xy_scale_3pct`: every per-scan translation is scaled by 1.03. ICP
+  sees the same per-scan motion as raw odom (both translation and
+  yaw match). There is no scan-to-scan signal that the bias exists,
+  so no correction is possible. Result: corrected XY tracks raw XY.
+- `yaw_drift_3deg_per_m`: the bias is yaw rotation per meter
+  travelled. When the robot drives straight, raw odom reports a
+  small yaw rotation, but the LIDAR scans show no rotation. So
+  `odom_dyaw != icp_dyaw` with a consistent sign — the scan-to-scan
+  ICP **does** see this bias and the gate can act on it.
+
+That signal propagates through `compose_pose_local`: the corrected
+pose's yaw stays closer to true, so each subsequent translation is
+composed in roughly the right direction. The net effect is the +2 mm
+XY improvement. **The XY win is a side-effect of yaw correction**, not
+of XY-axis ICP blending.
+
+The yaw paradox (XY better, yaw worse) — likely explanation:
+
+- Per-scan yaw drift bias at the typical inter-scan motion is small
+  (~3 mrad / scan for 5 cm forward motion at 3°/m). That is the
+  same order as the ICP yaw noise floor.
+- ICP yaw_delta is dominated by noise at that magnitude, with random
+  per-scan sign.
+- Blending a noisy yaw correction at a low rate (alpha_yaw ~ 0.1
+  attenuated) over many scans does not match a single sustained
+  drift sign — it integrates random noise plus a small directional
+  component, and the noise dominates.
+- The XY win happens because even a small consistent yaw correction
+  (over the threshold) is enough to keep the body frame oriented
+  better, while the yaw error itself oscillates around a slightly
+  wrong mean.
+
+The corrected SLAM tuning track now has its first concrete biased-odom
+result: `yaw_loose_018` on `yaw_drift_3deg_per_m` wins on XY on 3/4
+scenarios. It is not a full win because yaw itself regresses; the
+practical question is whether downstream code cares more about XY or
+yaw.
+
 ### Followups not addressed yet
 
-- Same `yaw_loose_018` slice under `odom_yaw_drift_3deg_per_m` (the
-  yaw-bias odom profile). If the split-gate yaw blend can correct
-  yaw drift cumulatively, this is where the improvement would
-  appear. Indices 156-159 in the biased matrix.
-- Try `yaw_loose_025` and `yaw_loose_018_low_alpha`
-  (`SLAM_ICP_BLEND_ALPHA_YAW=0.10`) on baseline odom to see whether
-  the `rich_geometry_turns` yaw regression at -8 mrad can be
-  recovered.
-- Implement scan-to-map ICP in `slam_node` so the corrected frame
-  has an unbiased reference. This is the only path the current data
-  supports for beating raw odom on biased XY.
+- Test `yaw_loose_018_low_alpha` (`SLAM_ICP_BLEND_ALPHA_YAW=0.10` or
+  lower) on `yaw_drift_3deg_per_m`. The hypothesis is that reducing
+  the yaw blend alpha will limit noise injection while still keeping
+  the directional correction; this should reduce or eliminate the
+  yaw regression while preserving the XY win.
+- Add an `yaw_drift_1deg_per_m` slice for completeness — at lower
+  drift the per-scan signal is even smaller relative to noise, so
+  the yaw regression may be smaller or larger depending on the
+  noise-to-signal ratio.
+- Try `yaw_loose_025` (looser still) under `yaw_drift_3deg_per_m`.
+  If admitting more attenuated samples picks up more real signal,
+  yaw could improve; if it admits more noise, yaw could get worse.
+- The `xy_scale` structural limit and the partial `yaw_drift` win
+  together motivate scan-to-map ICP as the next major change. Under
+  scan-to-map, the per-scan ICP residual is against an accumulated
+  unbiased reference, so even `xy_scale` bias becomes visible to the
+  solver.
 - Retire `loose_error*` and `very_loose_error` profiles from the
   tuning matrix; the split-gate `yaw_loose_*` family is strictly
   better on both baseline and biased data.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -245,72 +245,92 @@ That is, letting more ICP through made corrected SLAM 3-4x worse on the same
 biased odom run. Lowering blend alpha helped (smaller correction per scan),
 but the direction of the correction was still wrong.
 
-### Structural root cause: biased map cannot bias-correct
+### Why loose_error made things worse — open question, not "biased map"
 
-In the current evaluation, the SLAM input odom is biased
-(`SLAM_INPUT_ODOM_XY_SCALE=1.03`) and the SLAM map is built from that same
-biased odom. ICP fits each new scan against a map already deformed by the bias,
-so a "better" match reinforces the bias instead of correcting it. The gate is
-not at fault; the experiment cannot reward bias correction in principle. This
-also explains why earlier sweeps could not produce a profile that was both
-gate-active and `slam_better_xy=True` on biased odom.
+An earlier draft of this section claimed the root cause was that the SLAM map
+is built from biased odom and ICP therefore reinforces the bias. **That
+hypothesis is incorrect for the current SLAM node.** The ICP step in
+`ros2_nodes/slam_node/src/main.rs` is scan-to-scan, not scan-to-map:
 
-A separate but real bug in the tuning matrix at the time of this sprint:
-`strict_error` was set to `SLAM_ICP_REJECT_ERROR=0.011`, which is the same as
-`DEFAULT_ICP_REJECT_ERROR` (see line 33 of
-`ros2_nodes/slam_node/src/main.rs`). `strict_error` and `strict_low_alpha`
-were therefore functionally duplicates of `default` and `low_alpha`. This is
-worth fixing the next time the tuning matrix is touched, but it does not
-change the structural conclusion above.
+- Line 830: `let icp_result = icp_matching(previous, &current_scan);`
+- The persistent `st.map` (`OccupancyGridMap`) is updated with `pose` at line
+  911 and republished, but it is **not** an input to `icp_matching`. The map
+  affects RViz and navigation planning, not the ICP correction itself.
 
-### Decision: pause tuning, take Path A next
+Because `icp_matching` only sees the previous and current LIDAR scan, the
+biased odom does not pre-deform the surface ICP fits to. ICP should in
+principle see the true per-scan relative motion and produce an `icp_delta`
+that cancels the biased odom integration.
 
-The tuning sweep is paused until the evaluation framework is changed so that
-ICP can in principle improve corrected SLAM under odom bias.
+Why loose_error nevertheless made corrected SLAM 3-4x worse on
+`odom_xy_scale_3pct` is therefore still open. Candidate explanations to
+investigate before doing more sweeps:
 
-Path A — restructure the evaluation so that the SLAM map is built from
-**unbiased** odom and the bias is injected later, only on the input odom path
-used for the corrected-frame estimate. This makes the map an honest reference
-and gives ICP something to correct against.
+1. **Biased initial guess feeds the ICP solver.** If `icp_matching` is
+   initialized from the biased odom delta (or any pose prior derived from
+   `raw_odom`), it can converge to a local minimum near the biased pose
+   instead of the true relative motion.
+2. **Frame / sign error when composing `icp_delta` with `odom_delta`.** The
+   `blend_motion_delta(...) -> compose_pose_local(...)` chain assumes the
+   ICP delta is in the same body frame and the same sign convention as the
+   odom delta. A mismatch would point ICP in the wrong direction whenever
+   it actually gets weight.
+3. **Per-scan true motion is below the LIDAR noise floor.** On a slow
+   TurtleBot3 with short scenarios, one inter-scan motion can be smaller
+   than the residual noise, so `icp_delta` is dominated by noise. Loosening
+   the reject threshold then admits noise as a correction.
+4. **`gate_reason=attenuated_*` already implies the gate distrusted these
+   matches**, but the attenuated alpha is still nonzero. With a high
+   inter-scan rate, even small wrong corrections accumulate.
 
-Sketch:
+Any of (1)-(3) is a real bug in the node, not just a tuning question. Until
+they are ruled out, the loose-profile result should not be read as "ICP gating
+needs to be tighter"; it should be read as "we do not yet know what
+`icp_delta` is actually pointing at when the gate allows it through".
 
-- Keep `SLAM_INPUT_ODOM_XY_SCALE` / `SLAM_INPUT_ODOM_YAW_SCALE` style knobs,
-  but route them only through the corrected-frame input, not through the
-  mapping step.
-- Either (a) build the map in a pre-pass with unbiased odom and freeze it for
-  the corrected-frame run, or (b) split the SLAM node so the mapping update
-  and the ICP correction update consume two different odom sources, with bias
-  applied only to the ICP-correction input.
-- Reuse the existing biased odom profile names (`odom_xy_scale_3pct`,
-  `odom_yaw_drift_3deg_per_m`, etc.) so the matrix harness does not need to
-  change shape.
-- Re-run the tuning sweep (`default`, `low_alpha`, plus a corrected
-  `strict_error` / `loose_error` / `very_loose_error`) against
-  `odom_xy_scale_3pct` and `odom_yaw_drift_3deg_per_m` on the existing
-  scenarios, with the mid-mission diagnostics already in place.
+### Separate bug: strict_error == default
 
-Alternatives considered:
+In `ros2_nodes/launch/run_navigation_revaluation_matrix.sh`, the tuning
+profile `strict_error` was set to `SLAM_ICP_REJECT_ERROR=0.011`, which is the
+same as `DEFAULT_ICP_REJECT_ERROR` at line 33 of
+`ros2_nodes/slam_node/src/main.rs`. `strict_error` and `strict_low_alpha` are
+therefore functional duplicates of `default` and `low_alpha`. Fix the next
+time the tuning matrix is touched (e.g., drop to `0.008`).
 
+### Decision: pause tuning, investigate ICP delta path first
+
+The tuning sweep is paused. The next active task is not another evaluation
+restructure but a code-level investigation of the ICP delta path in
+`slam_node`:
+
+- Confirm whether `icp_matching` receives any prior derived from the biased
+  odom.
+- Confirm the body-frame convention used by `icp_delta` matches
+  `relative_motion_local(...)` / `compose_pose_local(...)`.
+- Add per-scan ground-truth-vs-`icp_delta` logging in a short bench so the
+  direction of `icp_delta` can be checked independently of the gate.
+
+Only after that does it make sense to revisit:
+
+- Path A: restructure the evaluation (e.g., scan-to-map ICP with an honest
+  reference map, or a pre-pass map frozen from unbiased odom).
 - Path B: inject bias as a `/scan` or entity-pose offset instead of odom
-  scale. This also gives ICP something to correct, but requires building a
-  new bias injection path and matching ground truth.
-- Path C: drop bias evaluation from the corrected-SLAM tuning loop and treat
-  ICP gating as purely a noise-robustness mechanism on clean odom.
-- Path D: stop tuning and document findings (this section). Done.
+  scale.
+- Path C: treat ICP gating purely as a noise-robustness mechanism on clean
+  odom.
 
-Path D is done; Path A is the next active task. Path B is a fallback if Path A
-runs into a structural blocker in the SLAM node. Path C is intentionally not
-pursued because the biased-odom matrix is the main lever we have for
-demonstrating value of corrected SLAM.
+Path D (this section) is done. Path A and Path B are deferred until the
+investigation above resolves where `icp_delta` is actually pointing.
 
 ### Followups not addressed yet
 
 - `very_loose_error` (`SLAM_ICP_REJECT_ERROR=0.025`) matrix rows 60-62 were
-  never executed; the workflow run hit a step timeout at 6/9 results. Re-run
-  if/when revaluation is re-enabled, but only after Path A is in place,
-  otherwise the result is just "more loose, more wrong".
+  never executed; the workflow run hit a step timeout at 6/9 results. Do
+  not re-run loose sweeps until the ICP delta direction question above is
+  resolved; otherwise the result is just "more loose, more wrong, same
+  unknown cause".
 - The `strict_error` / `strict_low_alpha` duplicate-of-default bug above.
 - The biased-odom revaluation still has no positive-control scenario where
-  ICP is expected to clearly improve raw odom. `rich_geometry_turns` from the
-  Scenario Roadmap above is the obvious candidate to add alongside Path A.
+  ICP is expected to clearly improve raw odom. `rich_geometry_turns` from
+  the Scenario Roadmap above is the obvious candidate to add once the ICP
+  delta direction is trusted.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -1,0 +1,164 @@
+# Corrected SLAM Evaluation Plan
+
+Last updated: 2026-05-17
+
+## Decision Summary
+
+Corrected SLAM remains experimental. The current pipeline has working ROS2 wiring,
+TF, diagnostics, Gazebo ground-truth comparison, synthetic ICP acceptance, and a
+multi-scenario revaluation harness. It has not yet shown stable superiority over
+raw / EKF odometry, so it should not become the default navigation frame.
+
+The next decision point is not another single ICP threshold tweak. The evaluation
+must separate:
+
+- cases where ICP should be accepted and improve odometry
+- cases where ICP should be rejected or attenuated
+- cases where raw odometry is already too accurate for short missions to reveal
+  a meaningful improvement
+
+## Test Tiers
+
+### Smoke
+
+Purpose: verify launch, topics, TF, mission completion, diagnostics availability,
+and absence of obvious runtime breakage.
+
+Runs: every PR through `ros2-smoke.yml`.
+
+Do not require corrected SLAM to beat raw odometry here yet. Accuracy thresholds
+in smoke should be limited to safety guards, such as no NaN, no huge correction
+jump, and no catastrophic ground-truth error.
+
+Current corrected-frame smoke safety guards are intentionally loose and
+configurable:
+
+- `SMOKE_MAX_SLAM_XY_ERROR` (default `0.50`)
+- `SMOKE_MAX_SLAM_YAW_ERROR` (default `0.524`, about 30 degrees)
+- `SMOKE_MAX_SLAM_XY_MAX` (default `0.75`)
+- `SMOKE_MAX_APPLIED_TRANSLATION_DELTA` (default `0.20`, XY magnitude)
+- `SMOKE_MAX_APPLIED_YAW_DELTA` (default `0.35`)
+
+### Acceptance
+
+Purpose: positive-control ICP behavior.
+
+Runs: every PR.
+
+Current command:
+
+```bash
+./ros2_nodes/launch/run_slam_icp_acceptance_test.sh
+```
+
+Expected behavior: clean synthetic scan matching reaches `status=icp_ok`,
+`gate_reason=accepted`, and `blend_applied=true`.
+
+### Revaluation
+
+Purpose: corrected-frame accuracy and gate-policy decisions.
+
+Runs: manually, nightly, or before release. Store artifacts.
+
+Current command:
+
+```bash
+./ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+python3 scripts/summarize_slam_revaluation.py reports/slam_revaluation/*.csv
+```
+
+The matrix now writes CSV, JSONL, a Markdown summary, and per-run logs under
+`reports/slam_revaluation/`.
+
+GitHub Actions route: run the `ROS2 Smoke` workflow manually with
+`run_revaluation=true`. The workflow keeps normal PR smoke behavior unchanged,
+then uploads `reports/slam_revaluation/` as an artifact for the manual run.
+
+## Scenario Roadmap
+
+Existing scenarios:
+
+- `short_default`
+- `three_hops`
+- `long_two_legs`
+
+Existing odom mechanism profiles:
+
+- `raw_realistic`
+- `odom_xy_scale_1pct`
+- `odom_xy_scale_3pct`
+- `odom_yaw_drift_1deg_per_m`
+- `odom_yaw_drift_3deg_per_m`
+- `odom_turn_yaw_scale_3pct`
+
+Add scenarios in this order:
+
+1. `rich_geometry_turns`: 3-5 m, asymmetric obstacles, several 90 degree turns.
+   This should be a positive-control Gazebo scenario for accepted ICP.
+2. `long_loop_return`: 6-10 m, returns near the start. This reveals accumulated
+   drift and map-frame consistency problems.
+3. `corridor_degenerate`: parallel walls or weak longitudinal constraints. This
+   should reject or attenuate ambiguous ICP.
+4. `stop_and_go_low_motion`: low speed, stops, and restarts. This validates
+   low-motion rejection and static drift behavior.
+5. `wheel_slip_segment`: localized odom degradation. This is more realistic than
+   constant scale or yaw drift.
+
+## ICP Gate Metrics
+
+The current gate uses ICP mean error, iteration count, motion size, and correction
+size. Keep that policy, but treat gate decisions as a classification problem.
+
+Metrics now emitted in `/slam_diagnostics` and revaluation artifacts:
+
+- `icp_inlier_ratio_5cm`
+- `icp_error_median`
+- `icp_error_p90`
+- `icp_relative_error_reduction`
+
+Recommended next metrics:
+
+- trimmed mean residual
+- odom-prior innovation in XY and yaw
+- geometry conditioning or observability score
+
+Recommended gate classes:
+
+- `accepted`
+- `attenuated`
+- `rejected_bad_match`
+- `rejected_degenerate`
+- `rejected_low_motion`
+- `rejected_large_innovation`
+
+Low-motion rejection is appropriate for scan-to-scan ICP. During near-zero motion,
+sensor noise and nearest-neighbor instability can be larger than true motion, so
+integrating corrections can create static drift. Revisit this only after adding
+scan-to-map or local-submap matching.
+
+## Regression Promotion
+
+Promote accuracy checks gradually:
+
+1. Smoke keeps plumbing checks only.
+2. Add safety guards: bounded max XY/yaw error and bounded per-frame correction.
+3. Add loose non-regression: corrected RMSE may not exceed raw RMSE by more than
+   a small epsilon.
+4. Require improvement only for positive-control scenarios with injected odom
+   drift and rich geometry.
+5. Consider default mode only after aggregate matrix results show non-regression
+   in baseline scenarios, clear improvement in drift scenarios, and safe rejects
+   in negative-control scenarios.
+
+## Default-Mode Gate
+
+Corrected SLAM can become a default candidate only when all of these are true:
+
+- baseline realistic odom has completion rate at least equal to raw odom
+- baseline corrected RMSE is no worse than raw RMSE plus a small epsilon
+- catastrophic correction count is zero
+- biased scale / yaw / slip scenarios show stable median improvement
+- negative-control scenarios do not produce false accepted corrections
+- gate metrics and reasons are preserved in machine-readable artifacts
+
+Until then, keep `ENABLE_SLAM_CORRECTED_FRAME=true` as an experimental opt-in.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -351,14 +351,62 @@ Paths considered earlier:
 - Path D (document findings, pause tuning): done in this section.
 - Path E (new, the actual next step): scenario-side fix described above.
 
+### First rich_geometry_turns attempt — scenario design works, path was too tight
+
+The first shape committed for `rich_geometry_turns` was
+`0.55,0.0;1.10,0.0;1.10,0.55;0.55,0.55` (4 waypoints, 2.2 m, two 90-degree
+turns). The mission did **not** complete on the baseline odom + default
+profile validation run (Actions run `26015254947`,
+`navigation_revaluation_20260518T053249Z`). The robot reached waypoint 1
+`(0.55, 0)` and then republished waypoint 2 `(1.10, 0)` until the 240 s
+timeout: world `(-0.9, -0.5)` requires squeezing between the
+turtlebot3_world cylinder columns at `x=-1.1` and `x=0`, where the path
+clearance to the `(-1.1, 0)` cylinder is only about 0.5 m. After DWA
+costmap inflation the navigable corridor is roughly 0.245 m on each side,
+which the burger could not fit through reliably. The existing successful
+scenarios (`short_default`, `three_hops`, `long_two_legs`) all stay at
+relative `x <= 0.55`, i.e. world `x <= -1.45`, and never cross any
+cylinder column — that is why they complete.
+
+However the 1314 mid-mission diagnostic samples captured during that
+failed run are an unexpectedly clean positive control for the scenario
+design itself:
+
+- `icp_initial_error_mean = 0.110` (large per-scan nearest-neighbor
+  distance before ICP transform; consistent with the robot actually
+  rotating and translating between scans)
+- `icp_error_mean = 0.014` after ICP convergence
+- `icp_relative_error_reduction = 0.873` (about 87 percent)
+- `icp_inlier_ratio_5cm = 0.991`
+- `icp_iterations = 28` (median; converges with effort, well below the
+  100-iteration cap)
+- All 1314 samples gated `high_error` because `0.014 > DEFAULT_ICP_REJECT_ERROR (0.011)`
+
+This is the regime the previous scenarios never reached: ICP is finding
+a meaningful correction signal, but the default reject threshold is just
+below the converged residual floor and rejects every match. With
+`loose_error (0.018)` the same samples would mostly be admitted through
+the attenuated path with nonzero blend alpha. So once a navigable
+rich_geometry_turns variant exists, the next tuning question becomes:
+"on this scenario, with this much actual ICP signal, does `loose_error`
+help, hurt, or stay neutral?"
+
+Reshaped path (current): `0.55,0.0;0.55,0.5;0.0,0.5` — three waypoints,
+two 90-degree turns, ~1.6 m total, all inside the working-scenario
+corridor at relative `x <= 0.55`. Pending fresh validation.
+
 ### Followups not addressed yet
 
-- `very_loose_error` (`SLAM_ICP_REJECT_ERROR=0.025`) matrix rows 60-62 were
-  never executed; the workflow run hit a step timeout at 6/9 results. Do
-  not re-run loose sweeps until a positive-control scenario with sustained
-  forward motion is in place. Without one, looser thresholds just admit
-  more LIDAR noise.
-- The `strict_error` / `strict_low_alpha` duplicate-of-default bug above.
-- The biased-odom revaluation still has no positive-control scenario. Add
-  `rich_geometry_turns` (and optionally `long_loop_return`) per the
-  Scenario Roadmap before the next tuning sprint.
+- `very_loose_error` (`SLAM_ICP_REJECT_ERROR=0.025`) matrix rows 60-62
+  from the older biased sweep were never executed; do not re-run loose
+  sweeps on short_default / three_hops / long_two_legs (those are
+  rotation-dominated and the loose threshold just admits noise).
+  Re-evaluate only after rich_geometry_turns is reliably completing.
+- Once `rich_geometry_turns` passes the baseline+default validation, the
+  natural next sweep is **baseline odom × tuning ICP profiles × all four
+  scenarios** (28 runs). That isolates whether `loose_error` helps when
+  ICP actually has signal, without the biased odom confound. Only then
+  expand to biased odom.
+- The biased-odom revaluation still has no positive-control scenario for
+  drift correction. Consider `long_loop_return` (6-10 m, returns near
+  start) after rich_geometry_turns stabilizes.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -1,6 +1,6 @@
 # Corrected SLAM Evaluation Plan
 
-Last updated: 2026-05-17
+Last updated: 2026-05-18
 
 ## Decision Summary
 
@@ -162,3 +162,155 @@ Corrected SLAM can become a default candidate only when all of these are true:
 - gate metrics and reasons are preserved in machine-readable artifacts
 
 Until then, keep `ENABLE_SLAM_CORRECTED_FRAME=true` as an experimental opt-in.
+
+## 2026-05-17/18 Tuning Sweep — Findings and Course Correction
+
+This section records the tuning revaluation sprint on branch
+`dev/corrected-slam-eval`. The headline result is that the existing biased-odom
+revaluation framework cannot reward ICP for correcting odometry bias, so further
+single-knob ICP threshold tuning against it is not useful. The tuning track is
+paused; the next step is to restructure the evaluation (see "Path A" below).
+
+### Instrumentation gap (fixed)
+
+`ros2_nodes/launch/run_navigation_smoke_test.sh` originally only captured
+`/slam_diagnostics` at startup and after the mission finished. Both of those
+windows have the robot stationary at the goal pose, so every gate histogram in
+prior reports was dominated by `gate_reason=low_motion` with `icp_rejected`. The
+mid-mission ICP behavior was simply not observed.
+
+Fix shipped on `dev/corrected-slam-eval`:
+
+- `5af6305` `Capture /slam_diagnostics across the mission window`
+- `474578e` `Move mission-window diagnostics subscriber before further startup waits`
+
+The smoke script now starts a background `ros2 topic echo
+/slam_diagnostics` right after the startup topic check, keeps it running for
+the whole mission, stops it after `/mission_status` capture, and dumps the
+mid-mission stream under a `Mission-window slam diagnostics:` heading in the
+log. The mission diagnostics file is also dumped on cleanup failure so a
+timed-out run is still inspectable. Sample counts went from about 22 (stationary
+only) to several hundred (mid-motion) per run.
+
+Any conclusion drawn from gate histograms in reports older than `5af6305`
+should be re-checked with this instrumentation; "low_motion dominant" was an
+instrumentation artifact, not a property of the gate.
+
+### Attenuated gate states are real and frequent
+
+With mid-mission capture in place, `gate_reason` now shows three states that
+were essentially invisible before:
+
+- `attenuated_error`
+- `attenuated_iterations`
+- `attenuated_low_motion`
+
+These come from `compute_icp_blend_decision()` in
+`ros2_nodes/slam_node/src/main.rs` (around lines 395-502). After the hard
+rejects (`translation_outlier`, `yaw_outlier`, `high_error`,
+`slow_convergence`, `low_motion`), the function attenuates the blend via
+`ramp_weight` of error, iterations, translation, yaw, and motion. When the
+combined scale drops below 1.0 the diagnostics emit `attenuated_<smallest
+weight>` and `status=icp_attenuated`; otherwise the run is `accepted` and
+`status=icp_ok`. blend_alpha is then `base_alpha * scale`.
+
+This means ICP is contributing to the corrected frame in attenuated form much
+more often than the older "almost always low_motion" picture suggested.
+
+### Loose ICP reject-error sweep made SLAM strictly worse
+
+`837cbb9` added two loose profiles to the tuning sweep in
+`ros2_nodes/launch/run_navigation_revaluation_matrix.sh`:
+
+- `loose_error` (`SLAM_ICP_REJECT_ERROR=0.018`)
+- `loose_error_low_alpha` (`SLAM_ICP_BLEND_ALPHA=0.10 SLAM_ICP_REJECT_ERROR=0.018`)
+
+(plus an unfinished `very_loose_error` at `0.025`).
+
+The motivation was that the default reject threshold `0.011` sits below the
+observed LIDAR noise floor near `0.013`, so almost every ICP match was being
+rejected on residual alone. Loosening to `0.018` did open the gate: the
+attenuated states started firing during motion and corrections actually blended
+in.
+
+Against the biased odom profile `odom_xy_scale_3pct`, however, `improvement_xy`
+moved the wrong way:
+
+- `default`              about `-0.005`
+- `loose_error`          about `-0.021`
+- `loose_error_low_alpha` about `-0.013`
+- `loose_error` on `long_two_legs` about `-0.023`
+
+That is, letting more ICP through made corrected SLAM 3-4x worse on the same
+biased odom run. Lowering blend alpha helped (smaller correction per scan),
+but the direction of the correction was still wrong.
+
+### Structural root cause: biased map cannot bias-correct
+
+In the current evaluation, the SLAM input odom is biased
+(`SLAM_INPUT_ODOM_XY_SCALE=1.03`) and the SLAM map is built from that same
+biased odom. ICP fits each new scan against a map already deformed by the bias,
+so a "better" match reinforces the bias instead of correcting it. The gate is
+not at fault; the experiment cannot reward bias correction in principle. This
+also explains why earlier sweeps could not produce a profile that was both
+gate-active and `slam_better_xy=True` on biased odom.
+
+A separate but real bug in the tuning matrix at the time of this sprint:
+`strict_error` was set to `SLAM_ICP_REJECT_ERROR=0.011`, which is the same as
+`DEFAULT_ICP_REJECT_ERROR` (see line 33 of
+`ros2_nodes/slam_node/src/main.rs`). `strict_error` and `strict_low_alpha`
+were therefore functionally duplicates of `default` and `low_alpha`. This is
+worth fixing the next time the tuning matrix is touched, but it does not
+change the structural conclusion above.
+
+### Decision: pause tuning, take Path A next
+
+The tuning sweep is paused until the evaluation framework is changed so that
+ICP can in principle improve corrected SLAM under odom bias.
+
+Path A — restructure the evaluation so that the SLAM map is built from
+**unbiased** odom and the bias is injected later, only on the input odom path
+used for the corrected-frame estimate. This makes the map an honest reference
+and gives ICP something to correct against.
+
+Sketch:
+
+- Keep `SLAM_INPUT_ODOM_XY_SCALE` / `SLAM_INPUT_ODOM_YAW_SCALE` style knobs,
+  but route them only through the corrected-frame input, not through the
+  mapping step.
+- Either (a) build the map in a pre-pass with unbiased odom and freeze it for
+  the corrected-frame run, or (b) split the SLAM node so the mapping update
+  and the ICP correction update consume two different odom sources, with bias
+  applied only to the ICP-correction input.
+- Reuse the existing biased odom profile names (`odom_xy_scale_3pct`,
+  `odom_yaw_drift_3deg_per_m`, etc.) so the matrix harness does not need to
+  change shape.
+- Re-run the tuning sweep (`default`, `low_alpha`, plus a corrected
+  `strict_error` / `loose_error` / `very_loose_error`) against
+  `odom_xy_scale_3pct` and `odom_yaw_drift_3deg_per_m` on the existing
+  scenarios, with the mid-mission diagnostics already in place.
+
+Alternatives considered:
+
+- Path B: inject bias as a `/scan` or entity-pose offset instead of odom
+  scale. This also gives ICP something to correct, but requires building a
+  new bias injection path and matching ground truth.
+- Path C: drop bias evaluation from the corrected-SLAM tuning loop and treat
+  ICP gating as purely a noise-robustness mechanism on clean odom.
+- Path D: stop tuning and document findings (this section). Done.
+
+Path D is done; Path A is the next active task. Path B is a fallback if Path A
+runs into a structural blocker in the SLAM node. Path C is intentionally not
+pursued because the biased-odom matrix is the main lever we have for
+demonstrating value of corrected SLAM.
+
+### Followups not addressed yet
+
+- `very_loose_error` (`SLAM_ICP_REJECT_ERROR=0.025`) matrix rows 60-62 were
+  never executed; the workflow run hit a step timeout at 6/9 results. Re-run
+  if/when revaluation is re-enabled, but only after Path A is in place,
+  otherwise the result is just "more loose, more wrong".
+- The `strict_error` / `strict_low_alpha` duplicate-of-default bug above.
+- The biased-odom revaluation still has no positive-control scenario where
+  ICP is expected to clearly improve raw odom. `rich_geometry_turns` from the
+  Scenario Roadmap above is the obvious candidate to add alongside Path A.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -245,48 +245,72 @@ That is, letting more ICP through made corrected SLAM 3-4x worse on the same
 biased odom run. Lowering blend alpha helped (smaller correction per scan),
 but the direction of the correction was still wrong.
 
-### Why loose_error made things worse — open question, not "biased map"
+### Why loose_error made things worse — ICP is noise-dominated during in-place rotation
 
-An earlier draft of this section claimed the root cause was that the SLAM map
-is built from biased odom and ICP therefore reinforces the bias. **That
-hypothesis is incorrect for the current SLAM node.** The ICP step in
-`ros2_nodes/slam_node/src/main.rs` is scan-to-scan, not scan-to-map:
+Two earlier drafts of this section were wrong. The first claimed the SLAM
+map is built from biased odom and ICP therefore reinforces the bias; that is
+false because the SLAM node uses **scan-to-scan** ICP (`icp_matching` at
+`ros2_nodes/slam_node/src/main.rs:830` takes `previous_scan` and
+`current_scan`; the persistent `st.map` is for publishing / navigation only,
+not an ICP input). The second draft suggested a sign bug in
+`icp_motion_delta`; investigation rules that out as well.
 
-- Line 830: `let icp_result = icp_matching(previous, &current_scan);`
-- The persistent `st.map` (`OccupancyGridMap`) is updated with `pose` at line
-  911 and republished, but it is **not** an input to `icp_matching`. The map
-  affects RViz and navigation planning, not the ICP correction itself.
+The investigation:
 
-Because `icp_matching` only sees the previous and current LIDAR scan, the
-biased odom does not pre-deform the surface ICP fits to. ICP should in
-principle see the true per-scan relative motion and produce an `icp_delta`
-that cancels the biased odom integration.
+- `icp_matching` (`crates/rust_robotics_slam/src/icp_matching.rs:60`)
+  takes only point matrices; there is no pose-prior argument. There is no
+  biased initial guess. Hypothesis "biased ICP init" is rejected.
+- `svd_motion_estimation` returns `(R, t)` satisfying
+  `previous ≈ R * current + t`, i.e. the transform that maps `current_scan`
+  back into the `previous_scan` frame. Equivalently, this transform is the
+  robot motion expressed in the previous body frame:
+  `T_prev←curr = robot_motion_in_prev_body_frame`. So
+  `result.translation` directly **is** the robot motion delta, with the
+  intended sign. `icp_motion_delta` is correct.
+- The `icp_matching` library test (`icp_matching.rs:407`) checks
+  `(result.translation[0] + translation.x).abs() < 0.1`, which can be read
+  as a sign flip in isolation, but in that test `apply_2d_transformation`
+  shifts `previous_points` by `translation`, so `T_prev←curr = -translation`
+  exactly because the synthetic robot motion is `-translation`. The
+  assertion is consistent with the body-frame motion interpretation.
+- Mid-mission logs from the loose-profile run confirm `icp_dx`, `icp_dy`,
+  and `icp_dyaw` are in the same body frame and the same sign convention
+  as `odom_dx`, `odom_dy`, `odom_dyaw`. Example, from
+  `navigation_revaluation_20260518T003221Z_logs/55_odom_xy_scale_3pct_loose_error_three_hops.log`:
+  `odom_dx=0.013, odom_dy=-0.001, odom_dyaw=-0.126`,
+  `icp_dx=0.011,  icp_dy= 0.014,  icp_dyaw=-0.137`.
 
-Why loose_error nevertheless made corrected SLAM 3-4x worse on
-`odom_xy_scale_3pct` is therefore still open. Candidate explanations to
-investigate before doing more sweeps:
+So why did loose_error make corrected SLAM 3-4x worse? Looking at those
+same log lines, `raw_yaw` is sweeping from `-2.181` to `-3.137` over ~8 scans
+while `raw_x` / `raw_y` are nearly constant. The robot is doing an in-place
+or near-in-place rotation. In that regime:
 
-1. **Biased initial guess feeds the ICP solver.** If `icp_matching` is
-   initialized from the biased odom delta (or any pose prior derived from
-   `raw_odom`), it can converge to a local minimum near the biased pose
-   instead of the true relative motion.
-2. **Frame / sign error when composing `icp_delta` with `odom_delta`.** The
-   `blend_motion_delta(...) -> compose_pose_local(...)` chain assumes the
-   ICP delta is in the same body frame and the same sign convention as the
-   odom delta. A mismatch would point ICP in the wrong direction whenever
-   it actually gets weight.
-3. **Per-scan true motion is below the LIDAR noise floor.** On a slow
-   TurtleBot3 with short scenarios, one inter-scan motion can be smaller
-   than the residual noise, so `icp_delta` is dominated by noise. Loosening
-   the reject threshold then admits noise as a correction.
-4. **`gate_reason=attenuated_*` already implies the gate distrusted these
-   matches**, but the attenuated alpha is still nonzero. With a high
-   inter-scan rate, even small wrong corrections accumulate.
+- True forward motion per scan is roughly zero.
+- Biased odom (`SLAM_INPUT_ODOM_XY_SCALE=1.03`) and TurtleBot3 wheel-odom
+  noise both fabricate a small nonzero `odom_dx`.
+- ICP scan-to-scan also fabricates a nonzero translation because the LIDAR
+  noise floor (~1.3 cm mean residual) is comparable to the true per-scan
+  translation, so `icp_dx` / `icp_dy` are dominated by noise rather than
+  signal. The `icp_dy=0.014` vs `odom_dy=-0.001` mismatch in the example
+  above is exactly this noise: even the sign of the small ICP translation
+  is essentially random during in-place rotation.
 
-Any of (1)-(3) is a real bug in the node, not just a tuning question. Until
-they are ruled out, the loose-profile result should not be read as "ICP gating
-needs to be tighter"; it should be read as "we do not yet know what
-`icp_delta` is actually pointing at when the gate allows it through".
+The default reject threshold (`0.011`) was below the LIDAR noise floor and
+rejected almost every match — including the noise corrections — which is
+why default sat near `improvement_xy ≈ -0.005` (a small safety bias rather
+than a real correction). Loosening to `0.018` admitted those noise
+corrections through the `attenuated_error` path with `blend_alpha ≈ 0.08`
+to `0.15`. Even at that small alpha, integrating a stream of noisy
+corrections over a multi-hop mission pulled the corrected estimate further
+from ground truth than just trusting biased odom.
+
+So the loose-profile regression is **not** a bug in the node and **not**
+fixed by another threshold tweak. It is structural to scan-to-scan ICP on
+this robot+scenario combination:
+
+- short missions with significant in-place rotation,
+- low forward speed,
+- a LIDAR with residual noise comparable to per-scan true motion.
 
 ### Separate bug: strict_error == default
 
@@ -297,40 +321,44 @@ same as `DEFAULT_ICP_REJECT_ERROR` at line 33 of
 therefore functional duplicates of `default` and `low_alpha`. Fix the next
 time the tuning matrix is touched (e.g., drop to `0.008`).
 
-### Decision: pause tuning, investigate ICP delta path first
+### Decision: pause tuning, fix the scenario set before any more sweeps
 
-The tuning sweep is paused. The next active task is not another evaluation
-restructure but a code-level investigation of the ICP delta path in
-`slam_node`:
+Single-knob ICP gate tuning on the current scenarios cannot show ICP doing
+useful work — there is barely a forward-motion regime in which ICP signal
+exceeds noise. The next active task is scenario-side, not gate-side:
 
-- Confirm whether `icp_matching` receives any prior derived from the biased
-  odom.
-- Confirm the body-frame convention used by `icp_delta` matches
-  `relative_motion_local(...)` / `compose_pose_local(...)`.
-- Add per-scan ground-truth-vs-`icp_delta` logging in a short bench so the
-  direction of `icp_delta` can be checked independently of the gate.
+- Add a positive-control scenario with sustained forward motion and rich
+  geometry (`rich_geometry_turns` from the Scenario Roadmap is the obvious
+  candidate: 3-5 m, asymmetric obstacles, several discrete 90 degree
+  turns). Validate it on default and unbiased odom first; only then revisit
+  loose-profile sweeps.
+- Optionally add `long_loop_return` (6-10 m, returns near start) to expose
+  accumulated drift that ICP should be able to correct.
+- Until such a scenario exists, do not draw more conclusions from
+  short_default / three_hops / long_two_legs about ICP gate tuning. Use
+  them only as smoke/safety scenarios.
 
-Only after that does it make sense to revisit:
+Paths considered earlier:
 
-- Path A: restructure the evaluation (e.g., scan-to-map ICP with an honest
-  reference map, or a pre-pass map frozen from unbiased odom).
-- Path B: inject bias as a `/scan` or entity-pose offset instead of odom
-  scale.
-- Path C: treat ICP gating purely as a noise-robustness mechanism on clean
-  odom.
-
-Path D (this section) is done. Path A and Path B are deferred until the
-investigation above resolves where `icp_delta` is actually pointing.
+- Path A (restructure evaluation so the SLAM map is built from unbiased
+  odom): **not justified** for the current node; the map is not an ICP
+  input.
+- Path B (inject bias as `/scan` or entity-pose offset): still a fallback,
+  but not the next move.
+- Path C (treat ICP gating purely as noise-robustness on clean odom): in
+  effect this is what the current default already is. The matrix should
+  acknowledge that.
+- Path D (document findings, pause tuning): done in this section.
+- Path E (new, the actual next step): scenario-side fix described above.
 
 ### Followups not addressed yet
 
 - `very_loose_error` (`SLAM_ICP_REJECT_ERROR=0.025`) matrix rows 60-62 were
   never executed; the workflow run hit a step timeout at 6/9 results. Do
-  not re-run loose sweeps until the ICP delta direction question above is
-  resolved; otherwise the result is just "more loose, more wrong, same
-  unknown cause".
+  not re-run loose sweeps until a positive-control scenario with sustained
+  forward motion is in place. Without one, looser thresholds just admit
+  more LIDAR noise.
 - The `strict_error` / `strict_low_alpha` duplicate-of-default bug above.
-- The biased-odom revaluation still has no positive-control scenario where
-  ICP is expected to clearly improve raw odom. `rich_geometry_turns` from
-  the Scenario Roadmap above is the obvious candidate to add once the ICP
-  delta direction is trusted.
+- The biased-odom revaluation still has no positive-control scenario. Add
+  `rich_geometry_turns` (and optionally `long_loop_return`) per the
+  Scenario Roadmap before the next tuning sprint.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -68,7 +68,10 @@ python3 scripts/summarize_slam_revaluation.py reports/slam_revaluation/*.csv
 ```
 
 The matrix now writes CSV, JSONL, a Markdown summary, and per-run logs under
-`reports/slam_revaluation/`.
+`reports/slam_revaluation/`. If the script is killed mid-scenario (e.g. by a
+CI step timeout), an EXIT/INT/TERM trap emits a partial row tagged with
+`exit_code=killed` and `mission_completed=false` so partial sweeps stay
+self-describing.
 
 GitHub Actions route: run the `ROS2 Smoke` workflow manually with
 `run_revaluation=true`. The workflow keeps normal PR smoke behavior unchanged,
@@ -687,6 +690,3 @@ The 2026-05-17/18 corrected-SLAM tuning sprint achieved:
   (persistent local submap, ICP target swap, drift consolidation).
 - Retire `loose_error`, `loose_error_low_alpha`, and
   `very_loose_error` from the tuning matrix.
-- The revaluation matrix script still does not flush the CSV row
-  per-run; consider doing this so partial sweeps from step timeouts
-  remain self-describing.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -676,12 +676,78 @@ The 2026-05-17/18 corrected-SLAM tuning sprint achieved:
    scan-to-scan ICP fundamentally cannot extract a correction
    signal. Scan-to-map ICP is the next major change needed.
 
+### yaw_loose_018 series under yaw_drift_1deg_per_m — XY win does NOT scale with drift
+
+Actions run `26077863455` ran `yaw_loose_018` and
+`yaw_loose_018_low_alpha` against `odom_yaw_drift_1deg_per_m`,
+indices 88-95 in the 6-profile biased matrix (after retiring
+`loose_error*` and `very_loose_error`).
+
+`yaw_loose_018 × yaw_drift_1deg_per_m`:
+
+| scenario              | improvement_xy | slam_better_xy | improvement_yaw | slam_better_yaw |
+| --------------------- | --------------:| --------------:| ---------------:| ---------------:|
+| short_default         | +0.004         | True           | +0.026          | True            |
+| three_hops            | +0.001         | True           | -0.013          | False           |
+| long_two_legs         | +0.001         | True           | -0.010          | False           |
+| rich_geometry_turns   | +0.005         | True           | -0.006          | False           |
+| **average**           | **+0.0027**    | **4/4**        | **-0.001**      | **1/4**         |
+
+`yaw_loose_018_low_alpha × yaw_drift_1deg_per_m`:
+
+| scenario              | improvement_xy | slam_better_xy | improvement_yaw | slam_better_yaw |
+| --------------------- | --------------:| --------------:| ---------------:| ---------------:|
+| short_default         | +0.001         | True           | +0.012          | True            |
+| three_hops            | +0.001         | True           | -0.011          | False           |
+| long_two_legs         | +0.001         | True           | -0.004          | False           |
+| rich_geometry_turns   | +0.000         | True           | -0.008          | False           |
+| **average**           | **+0.0008**    | **4/4**        | **-0.003**      | **1/4**         |
+
+Cross-drift comparison for the high-alpha profile
+(`yaw_loose_018`):
+
+| drift level | avg imp_xy | better_xy | avg imp_yaw | better_yaw |
+| ----------- | ----------:| ---------:| -----------:| ----------:|
+| 1°/m        | +0.0027    | 4/4       | -0.001      | 1/4        |
+| 3°/m        | +0.0020    | 3/4       | -0.021      | 0/4        |
+
+Two unexpected findings:
+
+- **XY improvement does NOT scale linearly with drift, and is
+  slightly larger at 1°/m than 3°/m**. The expected story —
+  bigger drift, bigger ICP signal, bigger XY correction — does
+  not hold. The likely reason is that at 3°/m the per-scan yaw
+  bias starts pushing ICP into the noise-dominated regime where
+  more of the captured yaw correction is random per-scan jitter
+  (see the noise-integration hypothesis confirmed in the
+  3°/m × low_alpha section). At 1°/m the per-scan yaw bias is
+  smaller but more consistent in sign, so the small accepted
+  corrections accumulate cleanly.
+- **All 4 scenarios now beat raw on XY**, including
+  `short_default`. At 3°/m, `short_default` for the low_alpha
+  profile actually regressed (-0.001 m). At 1°/m the same
+  scenario shows +0.001 m. The win pattern is no longer scenario-
+  dependent at low drift.
+
+The yaw paradox also shrinks proportionally. At 3°/m the high-
+alpha profile loses -21 mrad on average; at 1°/m it loses only
+-1 mrad on average, and `short_default` actually wins yaw by
++26 mrad. For the low-alpha profile, the picture is similar:
+1°/m loses -3 mrad on average vs -5 mrad at 3°/m.
+
+Practical conclusion for the split-gate profiles:
+
+- `yaw_loose_018` is the better trade under 1°/m: bigger XY win
+  (+2.7 mm avg vs +0.8 mm) and yaw is essentially break-even.
+- `yaw_loose_018_low_alpha` is the better trade under 3°/m:
+  smaller XY win (+0.8 mm), much less yaw damage (-5 vs -21
+  mrad).
+- Under unknown drift, `yaw_loose_018_low_alpha` is the safer
+  default because it is never the worst on either axis. Under
+  known mild drift, `yaw_loose_018` extracts more XY signal.
+
 ### Followups not addressed yet
 
-- Run `yaw_loose_018` and `yaw_loose_018_low_alpha` on the lighter
-  `odom_yaw_drift_1deg_per_m` to see whether the XY win scales
-  linearly with drift and whether the yaw paradox shrinks
-  proportionally.
 - Try a `yaw_loose_025_low_alpha` to see if combining looser
   threshold with low alpha picks up more directional signal without
   noise penalty.
@@ -690,6 +756,7 @@ The 2026-05-17/18 corrected-SLAM tuning sprint achieved:
   limit. Likely a multi-week effort and a meaningful design change
   (persistent local submap, ICP target swap, drift consolidation).
   Design draft for this change lives in
-  `docs/scan_to_map_icp_design.md`; the first follow-on PR should
-  be Phase 1 in that doc (pure helpers + unit tests, no behavior
-  change).
+  `docs/scan_to_map_icp_design.md`. Phase 1 (pure helpers +
+  unit tests, no behavior change) is merged on
+  `dev/corrected-slam-eval`; the next follow-on PR should be
+  Phase 2 (submap state plumbing + `SLAM_ICP_MODE` env switch).

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -602,28 +602,91 @@ scenarios. It is not a full win because yaw itself regresses; the
 practical question is whether downstream code cares more about XY or
 yaw.
 
+### yaw_loose_018_low_alpha under yaw_drift — noise hypothesis confirmed
+
+Actions run `26070749878` ran `yaw_loose_018_low_alpha`
+(`SLAM_ICP_REJECT_ERROR_YAW=0.018`, `SLAM_ICP_BLEND_ALPHA_YAW=0.10`)
+against `odom_yaw_drift_3deg_per_m`, indices 176-179 in the
+9-profile biased matrix.
+
+| scenario              | improvement_xy | slam_better_xy | improvement_yaw | slam_better_yaw |
+| --------------------- | --------------:| --------------:| ---------------:| ---------------:|
+| short_default         | -0.001         | False          | -0.004          | False           |
+| three_hops            | +0.001         | True           | -0.019          | False           |
+| long_two_legs         | +0.002         | True           | -0.021          | False           |
+| rich_geometry_turns   | +0.001         | True           | **+0.023**      | **True**        |
+| **average**           | **+0.0008**    | **3/4**        | **-0.005**      | **1/4**         |
+
+Head-to-head with `yaw_loose_018` (same yaw threshold, default
+alpha 0.35) on the same biased odom profile:
+
+| scenario              | hi α XY | low α XY | hi α YAW | low α YAW       |
+| --------------------- | -------:| --------:| --------:| ---------------:|
+| short_default         | +0.003  | -0.001   | -0.017   | -0.004          |
+| three_hops            |  0.000  | +0.001   | -0.017   | -0.019          |
+| long_two_legs         | +0.003  | +0.002   | -0.026   | -0.021          |
+| rich_geometry_turns   | +0.002  | +0.001   | -0.025   | **+0.023 flip** |
+| **average**           | +0.0020 | +0.0008  | **-0.021** | **-0.005**    |
+
+The noise-integration hypothesis is confirmed: dropping the yaw
+blend alpha from 0.35 to 0.10 reduces yaw error magnitude by ~4x on
+average (-21 mrad → -5 mrad) and flips `rich_geometry_turns` yaw
+from -25 mrad to +23 mrad (the first positive yaw improvement under
+biased odom). XY win shrinks roughly in half (+2.0 → +0.8 mm), still
+positive, still better on 3 of 4 scenarios.
+
+### Profile selection guidance
+
+The split-gate sprint produced two genuinely useful corrected-SLAM
+profiles, each suited to a different downstream priority:
+
+| profile                        | use case                                                                                         |
+| ------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `default`                      | XY accuracy on clean odom; baseline safety. Reject everything that risks XY noise injection.     |
+| `yaw_loose_018`                | maximize XY benefit under yaw drift bias (+2 mm avg, 3/4 scenarios), accept yaw regression.      |
+| `yaw_loose_018_low_alpha`      | balance: smaller XY win (+0.8 mm) plus much smaller yaw damage (-5 mrad), one scenario wins yaw. |
+
+The `loose_error*` and `very_loose_error` profiles in the tuning
+matrix are now strictly worse on every comparison done in this
+sprint and should be removed when the matrix is next edited.
+
+### Sprint conclusion
+
+The 2026-05-17/18 corrected-SLAM tuning sprint achieved:
+
+1. **Instrumentation fix** (mission-window diagnostics capture).
+2. **Three retracted structural hypotheses** (biased map, sign bug,
+   biased ICP init) along with the evidence that ruled each out.
+3. **rich_geometry_turns positive-control scenario** (validated
+   after several iterations on path shape).
+4. **Split-gate ICP** (`compute_icp_blend_decision` and
+   `blend_motion_delta` now act per-axis with independent error and
+   alpha thresholds for XY and yaw).
+5. **First biased-odom XY win in this sprint**:
+   `yaw_loose_018 × yaw_drift_3deg_per_m` produces 3/4 scenarios
+   with improvement_xy > 0.
+6. **Resolution of the yaw paradox**: lowering yaw blend alpha
+   reduces yaw error by 4x and flips one scenario into actual yaw
+   improvement.
+7. **Structural ceiling identified**: under `xy_scale_3pct`,
+   scan-to-scan ICP fundamentally cannot extract a correction
+   signal. Scan-to-map ICP is the next major change needed.
+
 ### Followups not addressed yet
 
-- Test `yaw_loose_018_low_alpha` (`SLAM_ICP_BLEND_ALPHA_YAW=0.10` or
-  lower) on `yaw_drift_3deg_per_m`. The hypothesis is that reducing
-  the yaw blend alpha will limit noise injection while still keeping
-  the directional correction; this should reduce or eliminate the
-  yaw regression while preserving the XY win.
-- Add an `yaw_drift_1deg_per_m` slice for completeness — at lower
-  drift the per-scan signal is even smaller relative to noise, so
-  the yaw regression may be smaller or larger depending on the
-  noise-to-signal ratio.
-- Try `yaw_loose_025` (looser still) under `yaw_drift_3deg_per_m`.
-  If admitting more attenuated samples picks up more real signal,
-  yaw could improve; if it admits more noise, yaw could get worse.
-- The `xy_scale` structural limit and the partial `yaw_drift` win
-  together motivate scan-to-map ICP as the next major change. Under
-  scan-to-map, the per-scan ICP residual is against an accumulated
-  unbiased reference, so even `xy_scale` bias becomes visible to the
-  solver.
-- Retire `loose_error*` and `very_loose_error` profiles from the
-  tuning matrix; the split-gate `yaw_loose_*` family is strictly
-  better on both baseline and biased data.
+- Run `yaw_loose_018` and `yaw_loose_018_low_alpha` on the lighter
+  `odom_yaw_drift_1deg_per_m` to see whether the XY win scales
+  linearly with drift and whether the yaw paradox shrinks
+  proportionally.
+- Try a `yaw_loose_025_low_alpha` to see if combining looser
+  threshold with low alpha picks up more directional signal without
+  noise penalty.
+- Implement scan-to-map ICP in `slam_node`. This is the only path
+  the current data supports for overcoming the `xy_scale` structural
+  limit. Likely a multi-week effort and a meaningful design change
+  (persistent local submap, ICP target swap, drift consolidation).
+- Retire `loose_error`, `loose_error_low_alpha`, and
+  `very_loose_error` from the tuning matrix.
 - The revaluation matrix script still does not flush the CSV row
   per-run; consider doing this so partial sweeps from step timeouts
   remain self-describing.

--- a/docs/corrected_slam_evaluation_plan.md
+++ b/docs/corrected_slam_evaluation_plan.md
@@ -490,17 +490,71 @@ Conclusions:
   worse than `yaw_loose_018` on baseline odom. They could be retired
   or kept only as negative controls.
 
+### yaw_loose_018 under biased odom (`odom_xy_scale_3pct`)
+
+Actions run `26065679633` ran the same `yaw_loose_018` profile under
+the 3-percent XY scale biased odom, indices 92-95 in the biased
+matrix.
+
+| scenario              | improvement_xy | slam_better_xy | improvement_yaw | slam_better_yaw |
+| --------------------- | --------------:| --------------:| ---------------:| ---------------:|
+| short_default         | -0.003         | False          | -0.001          | False           |
+| three_hops            | -0.003         | False          | +0.003          | True            |
+| long_two_legs         | -0.002         | False          | +0.009          | True            |
+| rich_geometry_turns   | -0.007         | False          | -0.000          | False           |
+| **average**           | **-0.0037**    | **0/4**        | +0.003          | 2/4             |
+
+Side-by-side context (XY averages, baseline vs biased odom across
+profiles):
+
+| profile               | baseline avg XY | biased avg XY (3% scale) |
+| --------------------- | ---------------:| ------------------------:|
+| default               | ~0              | -0.005                   |
+| loose_error           | -0.025          | -0.022                   |
+| **yaw_loose_018**     | **+0.0008**     | **-0.0037**              |
+
+The split-gate result is consistent with the broader picture:
+
+- Under biased odom, `yaw_loose_018` is much less damaging than
+  `loose_error` on XY (-0.0037 vs -0.022) and roughly matches the
+  default safety bias (-0.005).
+- However, `yaw_loose_018` still cannot make corrected SLAM beat raw
+  odom on biased XY (`better_xy = 0/4`). YAW improves on 2/4
+  scenarios with small magnitudes (+3 to +9 mrad).
+- This is the expected structural ceiling for scan-to-scan ICP under
+  cumulative odom bias: each per-scan motion the solver fits is also
+  biased, so there is no out-of-frame reference to anchor the
+  accumulated error. The split gate avoids actively making things
+  worse; it does not provide cumulative bias correction.
+
+What this rules out and what is still open:
+
+- Single-knob ICP tuning on the current scan-to-scan node cannot
+  produce a profile that simultaneously beats raw odom XY under bias
+  and improves yaw. The split-gate is the right design but cannot
+  overcome the structural limit on its own.
+- To meaningfully correct cumulative bias, the SLAM node needs
+  scan-to-map (or scan-to-submap) ICP so each new scan is aligned
+  against an unbiased accumulated reference, not against the
+  previous scan. That is a substantially larger change than gate
+  tuning.
+
 ### Followups not addressed yet
 
-- Re-run on **biased odom** (`odom_xy_scale_3pct`,
-  `odom_yaw_drift_3deg_per_m`) with `yaw_loose_018` to see whether the
-  yaw improvement helps under odom drift. This is the original
-  motivation for tuning corrected SLAM.
-- Try a `yaw_loose_025` profile (looser still) and a
-  `yaw_loose_018_low_alpha` (`SLAM_ICP_BLEND_ALPHA_YAW=0.10`) to see if
-  the `rich_geometry_turns` yaw regression goes away.
+- Same `yaw_loose_018` slice under `odom_yaw_drift_3deg_per_m` (the
+  yaw-bias odom profile). If the split-gate yaw blend can correct
+  yaw drift cumulatively, this is where the improvement would
+  appear. Indices 156-159 in the biased matrix.
+- Try `yaw_loose_025` and `yaw_loose_018_low_alpha`
+  (`SLAM_ICP_BLEND_ALPHA_YAW=0.10`) on baseline odom to see whether
+  the `rich_geometry_turns` yaw regression at -8 mrad can be
+  recovered.
+- Implement scan-to-map ICP in `slam_node` so the corrected frame
+  has an unbiased reference. This is the only path the current data
+  supports for beating raw odom on biased XY.
+- Retire `loose_error*` and `very_loose_error` profiles from the
+  tuning matrix; the split-gate `yaw_loose_*` family is strictly
+  better on both baseline and biased data.
 - The revaluation matrix script still does not flush the CSV row
   per-run; consider doing this so partial sweeps from step timeouts
   remain self-describing.
-- Existing `loose_error*` and `very_loose_error` profiles can be
-  retired once split-gate equivalents are validated.

--- a/docs/ros2_integration.md
+++ b/docs/ros2_integration.md
@@ -212,7 +212,7 @@ That switches the planner stack to `/slam_odom`, uses `map` as the global frame,
 
 Corrected mode also enables:
 
-- `/slam_diagnostics` (`std_msgs/String`) with per-scan ICP convergence, `icp_error_mean` (mean NN distance in meters per point), `blend_alpha`, `gate_reason`, and applied correction deltas
+- `/slam_diagnostics` (`std_msgs/String`) with per-scan ICP convergence, `icp_error_mean` (mean NN distance in meters per point), `icp_error_median`, `icp_error_p90`, `icp_inlier_ratio_5cm`, `icp_relative_error_reduction`, `blend_alpha`, `gate_reason`, and applied correction deltas
 - `/slam_ground_truth_status` (`std_msgs/String`) with relative-start Gazebo ground-truth error metrics computed from `gz topic -e -t /world/default/dynamic_pose/info --json-output`
 
 The ground-truth monitor defaults to `GROUND_TRUTH_ENTITY_NAME=$TURTLEBOT3_MODEL`, subtracts the first world pose sample, and compares `/ekf_odom` plus `/slam_odom` against that relative ground-truth trajectory. Override `GROUND_TRUTH_GZ_POSE_TOPIC` or `GROUND_TRUTH_ENTITY_NAME` if your Gazebo world uses different names.
@@ -338,9 +338,11 @@ By default, generated reports are ignored by git and written under:
 ```text
 reports/slam_revaluation/navigation_revaluation_<UTC timestamp>.csv
 reports/slam_revaluation/navigation_revaluation_<UTC timestamp>.jsonl
+reports/slam_revaluation/navigation_revaluation_<UTC timestamp>.summary.md
+reports/slam_revaluation/navigation_revaluation_<UTC timestamp>_logs/
 ```
 
-Each row records the scenario, exit code, mission completion flag, waypoint string, last ground-truth metrics (`raw_xy_error`, `slam_xy_error`, RMSE/max fields, `improvement_xy`, `slam_better_xy`), and last SLAM ICP diagnostics (`icp_error_mean`, `blend_alpha`, `gate_reason`, plus status/gate counts observed in the captured smoke output).
+Each row records the scenario, exit code, mission completion flag, waypoint string, last ground-truth metrics (`raw_xy_error`, `slam_xy_error`, RMSE/max fields, `improvement_xy`, `slam_better_xy`), and last SLAM ICP diagnostics (`icp_error_mean`, `icp_error_p90`, `icp_inlier_ratio_5cm`, `icp_relative_error_reduction`, `blend_alpha`, `gate_reason`, plus status/gate counts observed in the captured smoke output). The Markdown summary embeds `scripts/summarize_slam_revaluation.py` output, and the per-run logs preserve the raw smoke output used to derive each row.
 
 Useful overrides:
 
@@ -361,7 +363,10 @@ That keeps `/ekf_odom` as the raw baseline used by `/slam_ground_truth_status`, 
 
 - `raw_realistic`: raw EKF odom as SLAM input
 - `odom_xy_scale_1pct`: `ENABLE_SLAM_INPUT_ODOM_BIAS=true SLAM_INPUT_ODOM_XY_SCALE=1.01`
+- `odom_xy_scale_3pct`: `ENABLE_SLAM_INPUT_ODOM_BIAS=true SLAM_INPUT_ODOM_XY_SCALE=1.03`
 - `odom_yaw_drift_1deg_per_m`: `ENABLE_SLAM_INPUT_ODOM_BIAS=true SLAM_INPUT_ODOM_YAW_BIAS_PER_METER=0.017453292519943295`
+- `odom_yaw_drift_3deg_per_m`: `ENABLE_SLAM_INPUT_ODOM_BIAS=true SLAM_INPUT_ODOM_YAW_BIAS_PER_METER=0.05235987755982988`
+- `odom_turn_yaw_scale_3pct`: `ENABLE_SLAM_INPUT_ODOM_BIAS=true SLAM_INPUT_ODOM_YAW_SCALE=1.03`
 
 To run a small ICP tuning sweep, enable the `tuning` profile set:
 

--- a/docs/scan_to_map_icp_design.md
+++ b/docs/scan_to_map_icp_design.md
@@ -1,0 +1,362 @@
+# Scan-to-Map ICP Design
+
+Status: design draft, no code merged yet.
+Audience: next agent picking up corrected-SLAM work on `dev/corrected-slam-eval`.
+Companion to `docs/corrected_slam_evaluation_plan.md`.
+
+## Why this exists
+
+The 2026-05-17/18 tuning sprint established a structural ceiling
+for the current scan-to-scan ICP path:
+
+- Under `odom_xy_scale_3pct`, every per-scan motion fed to ICP is
+  already biased by the same factor as raw odom. ICP cannot
+  recover a signal that the bias exists, so corrected SLAM tracks
+  raw odom on XY by construction.
+- Under `odom_yaw_drift_*deg_per_m`, scan-to-scan ICP does extract
+  a yaw correction signal (the LIDAR does not rotate when the
+  drift says it should), but each per-scan correction is at the
+  ICP yaw noise floor. Lowering blend alpha reduces yaw damage
+  but does not deliver consistent yaw improvement.
+
+The single change that unblocks both regimes is to match each new
+scan against a **local accumulated reference** rather than against
+the immediately preceding scan. That reference accumulates in the
+**corrected frame**, so it is anchored against the running output
+of the corrected-SLAM pose, not against per-scan biased motion.
+Even under cumulative bias, the submap stays globally consistent
+(modulo the corrections we already made), so the residual ICP
+transform sees the accumulated odom error rather than only the
+per-scan delta.
+
+## Non-goals
+
+- Full graph-SLAM or loop closure. The target is a **local**
+  submap, not a global map. Loop closure would be a separate,
+  larger change.
+- Replacing the occupancy grid mapping pipeline. The occupancy
+  grid (`st.map`) keeps consuming corrected poses as today.
+- Changing the ROS topic interface. `/slam_diagnostics`,
+  `/corrected_pose`, `/corrected_odom` keep their current
+  fields; new fields are additive.
+- Changing the EKF / odom blending stack outside of `slam_node`.
+
+## High-level approach
+
+Today `slam_node` keeps exactly one `previous_scan: Option<DMatrix<f64>>`
+in body frame at the previous pose. ICP runs `icp_matching(previous, current)`
+and returns a body-frame motion delta from `previous` to `current`.
+
+The new path keeps two things:
+
+1. A **local submap** as a point cloud in the **corrected world
+   frame**, populated by transforming each accepted scan from its
+   body frame into the corrected pose at the time of that scan.
+2. The previous corrected pose, so that each new scan can be
+   transformed into a **predicted world-frame point cloud** using
+   `predicted_pose = compose_pose_local(prev_corrected_pose, odom_delta)`.
+
+ICP then runs between (submap_world, predicted_current_scan_world)
+and returns a **residual world-frame transform**. That residual is
+the correction we should apply on top of the odom-only prediction.
+
+```text
+        body-frame scan
+              │
+              ▼
+   predicted_pose = compose(prev_corrected, odom_delta)
+              │
+              ▼
+   current_scan_world = predicted_pose * current_scan_body
+              │
+              ▼
+   ICP(submap_world, current_scan_world)
+              │
+              ▼
+   residual_world  ─►  blend / gate  ─►  applied_correction_world
+              │                                │
+              ▼                                ▼
+   corrected_pose = predicted_pose ⊕ applied_correction_world
+              │
+              ▼
+   submap ← submap ∪ (corrected_pose * current_scan_body), pruned
+```
+
+This is a structural change but it reuses every existing
+component: `icp_matching`, `compute_icp_blend_decision`,
+`blend_motion_delta`, `compose_pose_local`. The new code is in
+two seams: building the predicted world-frame scan, and
+maintaining the submap.
+
+## Data structures
+
+### Submap
+
+A bounded `DMatrix<f64>` of points in the corrected world frame.
+
+- Storage: `Option<DMatrix<f64>>` so the first scan can bootstrap
+  it the same way `previous_scan` is bootstrapped today.
+- Capacity policy: rolling buffer of the last `N` accepted scans,
+  with two complementary cap checks:
+  - `SLAM_SUBMAP_MAX_SCANS` (default ~20): bounds memory and
+    ICP cost at high scan rate.
+  - `SLAM_SUBMAP_RADIUS_M` (default ~3.0 m around the current
+    corrected pose): drops points that have left the local
+    region, so the submap stays a *local* reference rather than
+    a growing global cloud.
+- Decimation: each scan is subsampled by the existing
+  `subsample_points_for_icp` stride before insertion, so submap
+  point count stays bounded.
+- Initialization gate: hold the first `SLAM_SUBMAP_BOOTSTRAP_SCANS`
+  (default 3) scans before allowing ICP to run against the
+  submap. Until then, fall back to scan-to-scan ICP (or pure
+  odom). This avoids running ICP against an effectively
+  single-scan submap that is no better than scan-to-scan.
+
+### State additions in `SlamNodeState`
+
+```rust
+// existing:
+previous_scan: Option<DMatrix<f64>>,
+previous_raw_odom_at_scan: Option<Pose2D>,
+
+// new:
+local_submap_world: Option<DMatrix<f64>>,
+local_submap_scan_count: usize,
+previous_corrected_pose_at_scan: Option<Pose2D>,
+```
+
+`previous_scan` is kept for the scan-to-scan fallback during
+bootstrap and for diagnostics. After bootstrap it is no longer
+read by the ICP path.
+
+## ICP target swap
+
+In `main.rs` around the existing block:
+
+```rust
+if let Some(previous) = st.previous_scan.as_ref() {
+    let icp_result = icp_matching(previous, &current_scan);
+    ...
+}
+```
+
+The new branch is:
+
+```rust
+let predicted_pose = match st.previous_corrected_pose_at_scan {
+    Some(prev) => compose_pose_local(prev, odom_delta_or_zero(odom_delta)),
+    None => raw_pose,
+};
+if let Some(submap) = st.local_submap_world.as_ref() {
+    if st.local_submap_scan_count >= bootstrap_scans {
+        let current_world = transform_scan_to_world(&current_scan, predicted_pose);
+        let icp_result = icp_matching(submap, &current_world);
+        // icp_result.translation / rotation are now in the world frame.
+        // Treat them as the residual on top of predicted_pose.
+        icp_delta = icp_world_residual_to_motion_delta(&icp_result);
+    } else {
+        // bootstrap fallback: keep scan-to-scan
+        ...
+    }
+}
+```
+
+Two helpers are new:
+
+- `transform_scan_to_world(scan_body: &DMatrix<f64>, pose: Pose2D) -> DMatrix<f64>`
+  builds a `2×N` matrix where each column is the body-frame point
+  rotated by `pose.yaw` and translated by `(pose.x, pose.y)`.
+  This is a pure utility, easy to unit-test on synthetic input.
+- `icp_world_residual_to_motion_delta(result: &ICPResult) -> Option<MotionDelta>`
+  reuses the existing `icp_motion_delta` logic but interprets
+  the result as a world-frame residual (because the input was in
+  world frame). The `MotionDelta` returned is in world frame,
+  not body frame.
+
+That last point matters: today `icp_delta` is a body-frame motion
+delta because both inputs to ICP were body-frame scans separated
+by motion. After the swap, both inputs are world-frame point
+clouds at the same predicted pose, so the residual is a
+world-frame transform.
+
+The blending stage adapts:
+
+- Today: `blended_delta = blend_motion_delta(odom_delta, icp_delta, alpha, alpha_yaw, ...)`
+  where both deltas are in body frame.
+- New: `applied_correction = blend(zero_delta, icp_residual_world, alpha, alpha_yaw, ...)`
+  and `corrected_pose = compose_world(predicted_pose, applied_correction)`.
+
+The simplest way to preserve gate behavior is to compute the
+*equivalent body-frame delta* and reuse the existing
+`compute_icp_blend_decision` and `blend_motion_delta` unchanged.
+That keeps gating math identical and isolates the change to the
+target-selection seam.
+
+## Drift consolidation (submap update)
+
+After applying the correction, the corrected pose is the new
+truth-of-record. Insert the current scan into the submap using
+that pose:
+
+```rust
+let current_world_corrected =
+    transform_scan_to_world(&current_scan, st.corrected_pose);
+st.local_submap_world =
+    Some(append_and_prune(
+        st.local_submap_world.take(),
+        current_world_corrected,
+        st.corrected_pose,
+        SubmapBudget {
+            max_scans,
+            max_radius_m,
+        },
+    ));
+st.local_submap_scan_count += 1;
+```
+
+`append_and_prune` does two things:
+
+1. Concatenate the new world-frame scan onto the existing submap
+   (column-append on the `DMatrix`).
+2. Drop points whose Euclidean distance from
+   `st.corrected_pose.{x,y}` is greater than `max_radius_m`.
+   This is the local-window prune that keeps the submap
+   bounded as the robot drives.
+
+Optionally also drop the oldest scan once the buffer reaches
+`max_scans` scans. The simplest implementation keeps a parallel
+`VecDeque<DMatrix<f64>>` of per-scan world clouds and rebuilds
+the concatenated submap each insert. At 5 Hz scan rate × 20-scan
+buffer × 320-point decimated scans, that is 6 400 points and a
+20-iteration insert cost, which is negligible compared to the ICP
+solve itself.
+
+The submap stores **corrected** world-frame points, so a per-scan
+correction immediately benefits the next scan's ICP target.
+That is the consolidation we want: each correction "sticks" by
+modifying the reference used by the next match.
+
+## Gating semantics carry-over
+
+The existing per-axis gate parameters (`SLAM_ICP_REJECT_ERROR`,
+`SLAM_ICP_REJECT_ERROR_YAW`, `SLAM_ICP_BLEND_ALPHA*`,
+`SLAM_ICP_FULL_WEIGHT_ERROR*`, etc.) are defined as **mean
+nearest-neighbor distance** thresholds. That metric is well-defined
+for either scan-to-scan or scan-to-map inputs, but the numeric
+magnitude differs:
+
+- Scan-to-scan: error is dominated by per-frame LIDAR noise and
+  small structural changes; floor is ~1.0 cm in the current
+  setup.
+- Scan-to-map: error is dominated by submap point density and
+  accumulated map noise; floor depends on submap point count
+  and decimation stride. Likely lower (~5-8 mm) when the submap
+  is well-populated because there are more candidate matches
+  per current point.
+
+So the gate thresholds will need re-tuning under scan-to-map.
+Concretely, the first matrix sweep with scan-to-map should treat
+the gate as if all thresholds are unknown:
+
+1. Run `default` profile and read the per-scenario mean error
+   distribution from diagnostics. That sets the new noise floor.
+2. Derive a new `SLAM_ICP_REJECT_ERROR*` from that floor (same
+   rule of thumb: noise floor + small margin).
+3. Add the new profile to the matrix script as a separate ICP
+   profile, not as a replacement for `default`, so the
+   scan-to-scan and scan-to-map paths can be A/B-compared on the
+   same biased odom matrix.
+
+## Backward compatibility / rollout
+
+Add a single environment flag:
+
+```text
+SLAM_ICP_MODE = scan_to_scan | scan_to_map   # default: scan_to_scan
+```
+
+This lets:
+
+- The default smoke test, the synthetic ICP acceptance smoke,
+  and the existing tuning matrix keep their current behavior
+  with zero code-path change.
+- A new matrix profile set (or per-profile env addition) opts in
+  to scan-to-map for evaluation.
+- Once scan-to-map demonstrates non-regression on baseline
+  scenarios and improvement on biased scenarios, the default
+  can flip.
+
+This is the same incremental promotion rule already documented
+in `corrected_slam_evaluation_plan.md` § Regression Promotion.
+
+## Implementation phases
+
+This is a multi-week effort. Suggested phasing:
+
+1. **Helpers + unit tests** (single PR, no behavior change):
+   - `transform_scan_to_world(scan_body, pose) -> scan_world`
+   - `append_and_prune(existing, new_world, pose, budget) -> submap`
+   - `icp_world_residual_to_body_delta(residual_world, predicted_pose) -> MotionDelta`
+   - Unit tests on synthetic point clouds for each.
+2. **Submap state + dual-mode plumbing** (single PR, scan_to_map
+   gated off by default):
+   - Add `SLAM_ICP_MODE` env, add submap state to `SlamNodeState`.
+   - In the scan callback, branch on `SLAM_ICP_MODE`: existing
+     path or new submap path.
+   - Diagnostics gain a new field (e.g., `submap_points`) so the
+     matrix script can see whether the new path is engaged.
+3. **Synthetic positive-control extension** (single PR):
+   - Extend `run_slam_icp_acceptance_test.sh` (or add a sibling
+     script) that drives synthetic odom with known bias plus
+     clean LIDAR. Require that scan-to-map mode produces
+     `improvement_xy > 0` and `improvement_yaw > 0` against the
+     same odom under scan-to-scan.
+4. **Matrix profile + first sweep**:
+   - Add an ICP profile entry in `run_navigation_revaluation_matrix.sh`
+     with `SLAM_ICP_MODE=scan_to_map` plus reasonable starting
+     thresholds.
+   - Run the biased odom × scan-to-map combinations to verify
+     the structural claim (xy_scale improvement, smaller yaw
+     paradox).
+5. **Gate retune + default flip** (only if step 4 shows
+   non-regression + improvement on the agreed scenarios; see
+   Default-Mode Gate in the evaluation plan):
+   - Pick scan-to-map default thresholds.
+   - Flip `SLAM_ICP_MODE` default to `scan_to_map`.
+   - Remove scan-to-scan from the tuning matrix, or keep one
+     profile entry for regression detection.
+
+## Open questions to resolve during implementation
+
+- **Submap pruning when stationary**: if the robot stops, the
+  same scan repeatedly appends near-duplicate points. Probably
+  resolved by the existing low-motion gate (don't update submap
+  when `odom_delta` is below the low-motion threshold), but
+  needs validation.
+- **Predicted-pose seeding for ICP**: ICP already runs from
+  identity. For scan-to-map we are providing a seeded prediction
+  via `transform_scan_to_world`; ICP then refines from there.
+  This is a *prior*, not just an initial guess — and it makes
+  ICP convergence more sensitive to a bad odom_delta. May need
+  to bound the max residual per scan more aggressively than
+  scan-to-scan.
+- **Memory profile for long missions**: 20-scan submap with
+  bounded radius keeps memory flat, but should be measured at
+  the end of the longest scenario (`rich_geometry_turns` or
+  longer) to confirm no slow growth.
+- **Submap reset on large jumps**: if the corrected pose ever
+  jumps (it shouldn't, but defensive guard), the submap
+  becomes stale instantly. Consider a guard: if the corrected
+  pose moves by more than `SLAM_SUBMAP_RESET_DIST_M` (e.g.,
+  2 m) within one scan, drop the submap.
+
+## Out of scope for the first PR
+
+- Submap loop closure / re-anchoring.
+- Multi-resolution submap (coarse + fine).
+- Switching ICP algorithm itself (point-to-plane, GICP).
+- Persisting the submap across node restarts.
+
+These are explicitly future work; mention them only so that the
+first PR's review does not get derailed into discussing them.

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -75,6 +75,7 @@ case "$PROFILE_SET" in
       "loose_error|raise ICP reject error past LIDAR noise floor|SLAM_ICP_REJECT_ERROR=0.018"
       "loose_error_low_alpha|raise ICP reject error and lower blend weight|SLAM_ICP_BLEND_ALPHA=0.10 SLAM_ICP_REJECT_ERROR=0.018"
       "very_loose_error|raise ICP reject error to 2.3x default|SLAM_ICP_REJECT_ERROR=0.025"
+      "yaw_loose_018|loosen yaw axis reject only; XY stays at default 0.011|SLAM_ICP_REJECT_ERROR_YAW=0.018"
     )
     ;;
   *)

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -51,7 +51,6 @@ SCENARIOS=(
   "short_default|0.4,0.0;0.1,0.4|150"
   "three_hops|0.45,0.0;0.35,0.45;0.05,0.5|200"
   "long_two_legs|0.55,0.0;0.2,0.55|200"
-  "extended_two_legs|0.7,0.0;0.4,0.7|220"
 )
 
 case "$PROFILE_SET" in

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -72,9 +72,6 @@ case "$PROFILE_SET" in
       "low_alpha|reduce accepted ICP correction weight|SLAM_ICP_BLEND_ALPHA=0.10"
       "strict_error|reject weaker ICP matches earlier|SLAM_ICP_REJECT_ERROR=0.008"
       "strict_low_alpha|lower blend weight and reject weaker ICP matches earlier|SLAM_ICP_BLEND_ALPHA=0.10 SLAM_ICP_REJECT_ERROR=0.008"
-      "loose_error|raise ICP reject error past LIDAR noise floor|SLAM_ICP_REJECT_ERROR=0.018"
-      "loose_error_low_alpha|raise ICP reject error and lower blend weight|SLAM_ICP_BLEND_ALPHA=0.10 SLAM_ICP_REJECT_ERROR=0.018"
-      "very_loose_error|raise ICP reject error to 2.3x default|SLAM_ICP_REJECT_ERROR=0.025"
       "yaw_loose_018|loosen yaw axis reject only; XY stays at default 0.011|SLAM_ICP_REJECT_ERROR_YAW=0.018"
       "yaw_loose_018_low_alpha|loosen yaw axis reject and lower yaw blend weight; XY default|SLAM_ICP_REJECT_ERROR_YAW=0.018 SLAM_ICP_BLEND_ALPHA_YAW=0.10"
     )

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -65,6 +65,9 @@ case "$PROFILE_SET" in
       "low_alpha|reduce accepted ICP correction weight|SLAM_ICP_BLEND_ALPHA=0.10"
       "strict_error|reject weaker ICP matches earlier|SLAM_ICP_REJECT_ERROR=0.011"
       "strict_low_alpha|lower blend weight and reject weaker ICP matches earlier|SLAM_ICP_BLEND_ALPHA=0.10 SLAM_ICP_REJECT_ERROR=0.011"
+      "loose_error|raise ICP reject error past LIDAR noise floor|SLAM_ICP_REJECT_ERROR=0.018"
+      "loose_error_low_alpha|raise ICP reject error and lower blend weight|SLAM_ICP_BLEND_ALPHA=0.10 SLAM_ICP_REJECT_ERROR=0.018"
+      "very_loose_error|raise ICP reject error to 2.3x default|SLAM_ICP_REJECT_ERROR=0.025"
     )
     ;;
   *)

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -76,6 +76,7 @@ case "$PROFILE_SET" in
       "loose_error_low_alpha|raise ICP reject error and lower blend weight|SLAM_ICP_BLEND_ALPHA=0.10 SLAM_ICP_REJECT_ERROR=0.018"
       "very_loose_error|raise ICP reject error to 2.3x default|SLAM_ICP_REJECT_ERROR=0.025"
       "yaw_loose_018|loosen yaw axis reject only; XY stays at default 0.011|SLAM_ICP_REJECT_ERROR_YAW=0.018"
+      "yaw_loose_018_low_alpha|loosen yaw axis reject and lower yaw blend weight; XY default|SLAM_ICP_REJECT_ERROR_YAW=0.018 SLAM_ICP_BLEND_ALPHA_YAW=0.10"
     )
     ;;
   *)

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -222,6 +222,208 @@ count_key_values_with_token() {
   printf '%s' "$values"
 }
 
+# Track the current in-flight run so that an EXIT/INT/TERM trap can emit a
+# partial CSV/JSONL row when the script is killed mid-scenario (e.g. by a CI
+# step timeout). Without this, the in-progress row never reaches the CSV.
+# Note: the smoke test is launched as a background job (SMOKE_PID) and waited
+# on with the `wait` builtin, because bash defers signal handling until a
+# foreground child exits — `wait` is interruptible, so the trap fires promptly.
+IN_FLIGHT=false
+SMOKE_PID=
+CUR_ODOM_PROFILE_NAME=
+CUR_ODOM_PROFILE_DESC=
+CUR_ODOM_PROFILE_ENV=
+CUR_PROFILE_NAME=
+CUR_PROFILE_DESC=
+CUR_PROFILE_ENV=
+CUR_SCENARIO_NAME=
+CUR_WAYPOINTS=
+CUR_MISSION_TIMEOUT=
+CUR_DOMAIN_ID=
+CUR_LOG=
+
+emit_row_from_log() {
+  # Extract metrics from $1 (log path) and append CSV+JSONL rows tagged with
+  # the supplied exit_code/mission_completed. Safe to call on a partial log.
+  local log_path="$1"
+  local exit_code="$2"
+  local mission_completed="$3"
+  local gt_line diag_line gate_reason_counts diagnostics_status_counts
+  if [[ -f "$log_path" ]]; then
+    gt_line="$(last_data_line_with "slam_xy_error=" "$log_path")"
+    diag_line="$(last_data_line_with "blend_alpha=" "$log_path")"
+    gate_reason_counts="$(count_key_values_with_token "$log_path" "gate_reason=" "gate_reason")"
+    diagnostics_status_counts="$(count_key_values_with_token "$log_path" "gate_reason=" "status")"
+  else
+    gt_line=""
+    diag_line=""
+    gate_reason_counts=""
+    diagnostics_status_counts=""
+  fi
+
+  local samples raw_xy_error slam_xy_error improvement_xy slam_better_xy
+  local raw_xy_rmse slam_xy_rmse raw_xy_max slam_xy_max
+  local raw_yaw_error slam_yaw_error improvement_yaw slam_better_yaw
+  samples="$(kv_get "$gt_line" "samples")"
+  raw_xy_error="$(kv_get "$gt_line" "raw_xy_error")"
+  slam_xy_error="$(kv_get "$gt_line" "slam_xy_error")"
+  improvement_xy="$(kv_get "$gt_line" "improvement_xy")"
+  slam_better_xy="$(kv_get "$gt_line" "slam_better_xy")"
+  raw_xy_rmse="$(kv_get "$gt_line" "raw_xy_rmse")"
+  slam_xy_rmse="$(kv_get "$gt_line" "slam_xy_rmse")"
+  raw_xy_max="$(kv_get "$gt_line" "raw_xy_max")"
+  slam_xy_max="$(kv_get "$gt_line" "slam_xy_max")"
+  raw_yaw_error="$(kv_get "$gt_line" "raw_yaw_error")"
+  slam_yaw_error="$(kv_get "$gt_line" "slam_yaw_error")"
+  improvement_yaw="$(kv_get "$gt_line" "improvement_yaw")"
+  slam_better_yaw="$(kv_get "$gt_line" "slam_better_yaw")"
+
+  local icp_status icp_error_mean icp_initial_error_mean icp_error_median
+  local icp_error_p90 icp_inlier_ratio_5cm icp_relative_error_reduction
+  local icp_iterations icp_converged scan_points blend_alpha blend_applied gate_reason
+  icp_status="$(kv_get "$diag_line" "status")"
+  icp_error_mean="$(kv_get "$diag_line" "icp_error_mean")"
+  icp_initial_error_mean="$(kv_get "$diag_line" "icp_initial_error_mean")"
+  icp_error_median="$(kv_get "$diag_line" "icp_error_median")"
+  icp_error_p90="$(kv_get "$diag_line" "icp_error_p90")"
+  icp_inlier_ratio_5cm="$(kv_get "$diag_line" "icp_inlier_ratio_5cm")"
+  icp_relative_error_reduction="$(kv_get "$diag_line" "icp_relative_error_reduction")"
+  icp_iterations="$(kv_get "$diag_line" "icp_iterations")"
+  icp_converged="$(kv_get "$diag_line" "icp_converged")"
+  scan_points="$(kv_get "$diag_line" "scan_points")"
+  blend_alpha="$(kv_get "$diag_line" "blend_alpha")"
+  blend_applied="$(kv_get "$diag_line" "blend_applied")"
+  gate_reason="$(kv_get "$diag_line" "gate_reason")"
+
+  write_csv_row "$CSV_REPORT" \
+    "$CUR_ODOM_PROFILE_NAME" \
+    "$CUR_ODOM_PROFILE_DESC" \
+    "$CUR_ODOM_PROFILE_ENV" \
+    "$CUR_PROFILE_NAME" \
+    "$CUR_PROFILE_DESC" \
+    "$CUR_PROFILE_ENV" \
+    "$CUR_SCENARIO_NAME" \
+    "$exit_code" \
+    "$mission_completed" \
+    "$CUR_DOMAIN_ID" \
+    "$CUR_WAYPOINTS" \
+    "$CUR_MISSION_TIMEOUT" \
+    "$samples" \
+    "$raw_xy_error" \
+    "$slam_xy_error" \
+    "$improvement_xy" \
+    "$slam_better_xy" \
+    "$raw_xy_rmse" \
+    "$slam_xy_rmse" \
+    "$raw_xy_max" \
+    "$slam_xy_max" \
+    "$raw_yaw_error" \
+    "$slam_yaw_error" \
+    "$improvement_yaw" \
+    "$slam_better_yaw" \
+    "$icp_status" \
+    "$icp_error_mean" \
+    "$icp_initial_error_mean" \
+    "$icp_error_median" \
+    "$icp_error_p90" \
+    "$icp_inlier_ratio_5cm" \
+    "$icp_relative_error_reduction" \
+    "$icp_iterations" \
+    "$icp_converged" \
+    "$scan_points" \
+    "$blend_alpha" \
+    "$blend_applied" \
+    "$gate_reason" \
+    "$gate_reason_counts" \
+    "$diagnostics_status_counts"
+
+  write_jsonl_row "$JSONL_REPORT" \
+    "odom_profile" "$CUR_ODOM_PROFILE_NAME" \
+    "odom_profile_description" "$CUR_ODOM_PROFILE_DESC" \
+    "odom_profile_env" "$CUR_ODOM_PROFILE_ENV" \
+    "profile" "$CUR_PROFILE_NAME" \
+    "profile_description" "$CUR_PROFILE_DESC" \
+    "profile_env" "$CUR_PROFILE_ENV" \
+    "scenario" "$CUR_SCENARIO_NAME" \
+    "exit_code" "$exit_code" \
+    "mission_completed" "$mission_completed" \
+    "ros_domain_id" "$CUR_DOMAIN_ID" \
+    "waypoints" "$CUR_WAYPOINTS" \
+    "mission_timeout_sec" "$CUR_MISSION_TIMEOUT" \
+    "samples" "$samples" \
+    "raw_xy_error" "$raw_xy_error" \
+    "slam_xy_error" "$slam_xy_error" \
+    "improvement_xy" "$improvement_xy" \
+    "slam_better_xy" "$slam_better_xy" \
+    "raw_xy_rmse" "$raw_xy_rmse" \
+    "slam_xy_rmse" "$slam_xy_rmse" \
+    "raw_xy_max" "$raw_xy_max" \
+    "slam_xy_max" "$slam_xy_max" \
+    "raw_yaw_error" "$raw_yaw_error" \
+    "slam_yaw_error" "$slam_yaw_error" \
+    "improvement_yaw" "$improvement_yaw" \
+    "slam_better_yaw" "$slam_better_yaw" \
+    "icp_status" "$icp_status" \
+    "icp_error_mean" "$icp_error_mean" \
+    "icp_initial_error_mean" "$icp_initial_error_mean" \
+    "icp_error_median" "$icp_error_median" \
+    "icp_error_p90" "$icp_error_p90" \
+    "icp_inlier_ratio_5cm" "$icp_inlier_ratio_5cm" \
+    "icp_relative_error_reduction" "$icp_relative_error_reduction" \
+    "icp_iterations" "$icp_iterations" \
+    "icp_converged" "$icp_converged" \
+    "scan_points" "$scan_points" \
+    "blend_alpha" "$blend_alpha" \
+    "blend_applied" "$blend_applied" \
+    "gate_reason" "$gate_reason" \
+    "gate_reason_counts" "$gate_reason_counts" \
+    "diagnostics_status_counts" "$diagnostics_status_counts"
+
+  CUR_LAST_SAMPLES="$samples"
+  CUR_LAST_RAW_XY="$raw_xy_error"
+  CUR_LAST_SLAM_XY="$slam_xy_error"
+  CUR_LAST_IMPROVEMENT_XY="$improvement_xy"
+  CUR_LAST_SLAM_BETTER_XY="$slam_better_xy"
+  CUR_LAST_ICP_STATUS="$icp_status"
+  CUR_LAST_ICP_ERROR_MEAN="$icp_error_mean"
+  CUR_LAST_ICP_ERROR_P90="$icp_error_p90"
+  CUR_LAST_ICP_INLIER="$icp_inlier_ratio_5cm"
+  CUR_LAST_BLEND_ALPHA="$blend_alpha"
+  CUR_LAST_GATE_REASON="$gate_reason"
+}
+
+emit_partial_row_if_in_flight() {
+  local trap_rc=$?
+  if [[ "$IN_FLIGHT" != "true" ]]; then
+    return 0
+  fi
+  IN_FLIGHT=false
+  if [[ -n "${SMOKE_PID:-}" ]] && kill -0 "$SMOKE_PID" 2>/dev/null; then
+    kill -TERM "$SMOKE_PID" 2>/dev/null || true
+    # Give the smoke test a brief grace period to flush its logs.
+    for _ in 1 2 3 4 5; do
+      if ! kill -0 "$SMOKE_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+    if kill -0 "$SMOKE_PID" 2>/dev/null; then
+      kill -KILL "$SMOKE_PID" 2>/dev/null || true
+    fi
+    wait "$SMOKE_PID" 2>/dev/null || true
+    SMOKE_PID=
+  fi
+  echo "!!! Killed mid-scenario: emitting partial row for $CUR_ODOM_PROFILE_NAME/$CUR_PROFILE_NAME/$CUR_SCENARIO_NAME" >&2
+  emit_row_from_log "$CUR_LOG" "killed" "false" || true
+  # Disarm the trap so the explicit exit below does not re-enter this handler.
+  # Then exit with the captured status so the caller (e.g. a CI step) still
+  # sees the original termination cause.
+  trap - EXIT INT TERM
+  exit "$trap_rc"
+}
+
+trap emit_partial_row_if_in_flight EXIT INT TERM
+
 mkdir -p "$(dirname "$CSV_REPORT")" "$(dirname "$JSONL_REPORT")" "$(dirname "$SUMMARY_REPORT")" "$RUN_LOG_DIR"
 write_csv_row "$CSV_REPORT" \
   "odom_profile" \
@@ -330,9 +532,29 @@ for odom_profile_entry in "${ODOM_PROFILES[@]}"; do
       echo ">>> Scenario: $name"
       echo "    WAYPOINT_NAV_WAYPOINTS=$WAYPOINT_NAV_WAYPOINTS"
       echo "    SMOKE_MISSION_TIMEOUT=${SMOKE_MISSION_TIMEOUT}s ROS_DOMAIN_ID=$ROS_DOMAIN_ID"
+
+      CUR_ODOM_PROFILE_NAME="$odom_profile_name"
+      CUR_ODOM_PROFILE_DESC="$odom_profile_description"
+      CUR_ODOM_PROFILE_ENV="$odom_profile_env"
+      CUR_PROFILE_NAME="$profile_name"
+      CUR_PROFILE_DESC="$profile_description"
+      CUR_PROFILE_ENV="$profile_env"
+      CUR_SCENARIO_NAME="$name"
+      CUR_WAYPOINTS="$WAYPOINT_NAV_WAYPOINTS"
+      CUR_MISSION_TIMEOUT="$SMOKE_MISSION_TIMEOUT"
+      CUR_DOMAIN_ID="$ROS_DOMAIN_ID"
+      CUR_LOG="$out"
+      IN_FLIGHT=true
+
       set +e
-      env "${odom_profile_env_args[@]}" "${profile_env_args[@]}" "$SMOKE" >"$out" 2>&1
+      env "${odom_profile_env_args[@]}" "${profile_env_args[@]}" "$SMOKE" >"$out" 2>&1 &
+      SMOKE_PID=$!
+      # Use `wait` (interruptible) so SIGTERM hitting this script during a
+      # long-running smoke test fires the EXIT/TERM trap promptly. Bash
+      # otherwise defers signal handling until a foreground job exits.
+      wait "$SMOKE_PID"
       rc=$?
+      SMOKE_PID=
       set -e
 
       mission_completed=false
@@ -340,122 +562,21 @@ for odom_profile_entry in "${ODOM_PROFILES[@]}"; do
         mission_completed=true
       fi
 
-      gt_line="$(last_data_line_with "slam_xy_error=" "$out")"
-      diag_line="$(last_data_line_with "blend_alpha=" "$out")"
-      gate_reason_counts="$(count_key_values_with_token "$out" "gate_reason=" "gate_reason")"
-      diagnostics_status_counts="$(count_key_values_with_token "$out" "gate_reason=" "status")"
+      emit_row_from_log "$out" "$rc" "$mission_completed"
+      IN_FLIGHT=false
 
-      samples="$(kv_get "$gt_line" "samples")"
-      raw_xy_error="$(kv_get "$gt_line" "raw_xy_error")"
-      slam_xy_error="$(kv_get "$gt_line" "slam_xy_error")"
-      improvement_xy="$(kv_get "$gt_line" "improvement_xy")"
-      slam_better_xy="$(kv_get "$gt_line" "slam_better_xy")"
-      raw_xy_rmse="$(kv_get "$gt_line" "raw_xy_rmse")"
-      slam_xy_rmse="$(kv_get "$gt_line" "slam_xy_rmse")"
-      raw_xy_max="$(kv_get "$gt_line" "raw_xy_max")"
-      slam_xy_max="$(kv_get "$gt_line" "slam_xy_max")"
-      raw_yaw_error="$(kv_get "$gt_line" "raw_yaw_error")"
-      slam_yaw_error="$(kv_get "$gt_line" "slam_yaw_error")"
-      improvement_yaw="$(kv_get "$gt_line" "improvement_yaw")"
-      slam_better_yaw="$(kv_get "$gt_line" "slam_better_yaw")"
-
-      icp_status="$(kv_get "$diag_line" "status")"
-      icp_error_mean="$(kv_get "$diag_line" "icp_error_mean")"
-      icp_initial_error_mean="$(kv_get "$diag_line" "icp_initial_error_mean")"
-      icp_error_median="$(kv_get "$diag_line" "icp_error_median")"
-      icp_error_p90="$(kv_get "$diag_line" "icp_error_p90")"
-      icp_inlier_ratio_5cm="$(kv_get "$diag_line" "icp_inlier_ratio_5cm")"
-      icp_relative_error_reduction="$(kv_get "$diag_line" "icp_relative_error_reduction")"
-      icp_iterations="$(kv_get "$diag_line" "icp_iterations")"
-      icp_converged="$(kv_get "$diag_line" "icp_converged")"
-      scan_points="$(kv_get "$diag_line" "scan_points")"
-      blend_alpha="$(kv_get "$diag_line" "blend_alpha")"
-      blend_applied="$(kv_get "$diag_line" "blend_applied")"
-      gate_reason="$(kv_get "$diag_line" "gate_reason")"
-
-      write_csv_row "$CSV_REPORT" \
-        "$odom_profile_name" \
-        "$odom_profile_description" \
-        "$odom_profile_env" \
-        "$profile_name" \
-        "$profile_description" \
-        "$profile_env" \
-        "$name" \
-        "$rc" \
-        "$mission_completed" \
-        "$ROS_DOMAIN_ID" \
-        "$WAYPOINT_NAV_WAYPOINTS" \
-        "$SMOKE_MISSION_TIMEOUT" \
-        "$samples" \
-        "$raw_xy_error" \
-        "$slam_xy_error" \
-        "$improvement_xy" \
-        "$slam_better_xy" \
-        "$raw_xy_rmse" \
-        "$slam_xy_rmse" \
-        "$raw_xy_max" \
-        "$slam_xy_max" \
-        "$raw_yaw_error" \
-        "$slam_yaw_error" \
-        "$improvement_yaw" \
-        "$slam_better_yaw" \
-        "$icp_status" \
-        "$icp_error_mean" \
-        "$icp_initial_error_mean" \
-        "$icp_error_median" \
-        "$icp_error_p90" \
-        "$icp_inlier_ratio_5cm" \
-        "$icp_relative_error_reduction" \
-        "$icp_iterations" \
-        "$icp_converged" \
-        "$scan_points" \
-        "$blend_alpha" \
-        "$blend_applied" \
-        "$gate_reason" \
-        "$gate_reason_counts" \
-        "$diagnostics_status_counts"
-
-      write_jsonl_row "$JSONL_REPORT" \
-        "odom_profile" "$odom_profile_name" \
-        "odom_profile_description" "$odom_profile_description" \
-        "odom_profile_env" "$odom_profile_env" \
-        "profile" "$profile_name" \
-        "profile_description" "$profile_description" \
-        "profile_env" "$profile_env" \
-        "scenario" "$name" \
-        "exit_code" "$rc" \
-        "mission_completed" "$mission_completed" \
-        "ros_domain_id" "$ROS_DOMAIN_ID" \
-        "waypoints" "$WAYPOINT_NAV_WAYPOINTS" \
-        "mission_timeout_sec" "$SMOKE_MISSION_TIMEOUT" \
-        "samples" "$samples" \
-        "raw_xy_error" "$raw_xy_error" \
-        "slam_xy_error" "$slam_xy_error" \
-        "improvement_xy" "$improvement_xy" \
-        "slam_better_xy" "$slam_better_xy" \
-        "raw_xy_rmse" "$raw_xy_rmse" \
-        "slam_xy_rmse" "$slam_xy_rmse" \
-        "raw_xy_max" "$raw_xy_max" \
-        "slam_xy_max" "$slam_xy_max" \
-        "raw_yaw_error" "$raw_yaw_error" \
-        "slam_yaw_error" "$slam_yaw_error" \
-        "improvement_yaw" "$improvement_yaw" \
-        "slam_better_yaw" "$slam_better_yaw" \
-        "icp_status" "$icp_status" \
-        "icp_error_mean" "$icp_error_mean" \
-        "icp_initial_error_mean" "$icp_initial_error_mean" \
-        "icp_error_median" "$icp_error_median" \
-        "icp_error_p90" "$icp_error_p90" \
-        "icp_inlier_ratio_5cm" "$icp_inlier_ratio_5cm" \
-        "icp_relative_error_reduction" "$icp_relative_error_reduction" \
-        "icp_iterations" "$icp_iterations" \
-        "icp_converged" "$icp_converged" \
-        "scan_points" "$scan_points" \
-        "blend_alpha" "$blend_alpha" \
-        "blend_applied" "$blend_applied" \
-        "gate_reason" "$gate_reason" \
-        "gate_reason_counts" "$gate_reason_counts" \
-        "diagnostics_status_counts" "$diagnostics_status_counts"
+      # Backward-compatible local aliases used by the post-run echo below.
+      samples="$CUR_LAST_SAMPLES"
+      raw_xy_error="$CUR_LAST_RAW_XY"
+      slam_xy_error="$CUR_LAST_SLAM_XY"
+      improvement_xy="$CUR_LAST_IMPROVEMENT_XY"
+      slam_better_xy="$CUR_LAST_SLAM_BETTER_XY"
+      icp_status="$CUR_LAST_ICP_STATUS"
+      icp_error_mean="$CUR_LAST_ICP_ERROR_MEAN"
+      icp_error_p90="$CUR_LAST_ICP_ERROR_P90"
+      icp_inlier_ratio_5cm="$CUR_LAST_ICP_INLIER"
+      blend_alpha="$CUR_LAST_BLEND_ALPHA"
+      gate_reason="$CUR_LAST_GATE_REASON"
 
       if [[ "$rc" -ne 0 ]]; then
         echo "    RESULT: FAIL (exit $rc)"

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -51,6 +51,7 @@ SCENARIOS=(
   "short_default|0.4,0.0;0.1,0.4|150"
   "three_hops|0.45,0.0;0.35,0.45;0.05,0.5|200"
   "long_two_legs|0.55,0.0;0.2,0.55|200"
+  "long_straight|1.2,0.0;1.5,0.6|240"
 )
 
 case "$PROFILE_SET" in

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -11,6 +11,8 @@
 #   SLAM_REVALUATION_LOG_DIR=reports/slam_revaluation/run_logs
 #   SLAM_REVALUATION_PROFILE_SET=tuning  # baseline (default) or tuning
 #   SLAM_REVALUATION_ODOM_PROFILE_SET=biased  # baseline (default) or biased
+#   SLAM_REVALUATION_START_INDEX=0  # zero-based index into the expanded matrix
+#   SLAM_REVALUATION_MAX_RUNS=0  # 0 means run all remaining rows
 #
 # Scenarios edit below: name|WAYPOINT_NAV_WAYPOINTS|SMOKE_MISSION_TIMEOUT
 # Profiles edit below: name|description|env assignments
@@ -40,6 +42,8 @@ SUMMARY_REPORT="${SLAM_REVALUATION_SUMMARY:-$REPORT_DIR/navigation_revaluation_$
 RUN_LOG_DIR="${SLAM_REVALUATION_LOG_DIR:-$REPORT_DIR/navigation_revaluation_${REPORT_STAMP}_logs}"
 PROFILE_SET="${SLAM_REVALUATION_PROFILE_SET:-baseline}"
 ODOM_PROFILE_SET="${SLAM_REVALUATION_ODOM_PROFILE_SET:-baseline}"
+START_INDEX="${SLAM_REVALUATION_START_INDEX:-0}"
+MAX_RUNS="${SLAM_REVALUATION_MAX_RUNS:-0}"
 
 # name|waypoints|mission_timeout_sec
 # Keep segments moderate: four+ waypoints often hit smoke mission timeout (stuck/recovery) in Gazebo.
@@ -92,9 +96,21 @@ case "$ODOM_PROFILE_SET" in
 esac
 
 RUN_COUNT=$((${#ODOM_PROFILES[@]} * ${#ICP_PROFILES[@]} * ${#SCENARIOS[@]}))
-LAST_DOMAIN_ID=$((BASE_ID + RUN_COUNT - 1))
+if ! [[ "$START_INDEX" =~ ^[0-9]+$ && "$MAX_RUNS" =~ ^[0-9]+$ ]]; then
+  echo "SLAM_REVALUATION_START_INDEX and SLAM_REVALUATION_MAX_RUNS must be non-negative integers." >&2
+  exit 2
+fi
+if (( START_INDEX >= RUN_COUNT )); then
+  echo "SLAM_REVALUATION_START_INDEX=$START_INDEX is outside the $RUN_COUNT run matrix." >&2
+  exit 2
+fi
+SELECTED_RUN_COUNT=$((RUN_COUNT - START_INDEX))
+if (( MAX_RUNS > 0 && MAX_RUNS < SELECTED_RUN_COUNT )); then
+  SELECTED_RUN_COUNT=$MAX_RUNS
+fi
+LAST_DOMAIN_ID=$((BASE_ID + SELECTED_RUN_COUNT - 1))
 if (( BASE_ID < 0 || LAST_DOMAIN_ID > 232 )); then
-  echo "ROS_DOMAIN_ID_BASE=$BASE_ID with $RUN_COUNT run(s) would use ROS_DOMAIN_ID $BASE_ID..$LAST_DOMAIN_ID." >&2
+  echo "ROS_DOMAIN_ID_BASE=$BASE_ID with $SELECTED_RUN_COUNT selected run(s) would use ROS_DOMAIN_ID $BASE_ID..$LAST_DOMAIN_ID." >&2
   echo "Fast DDS commonly requires ROS_DOMAIN_ID <= 232; choose a lower ROS_DOMAIN_ID_BASE." >&2
   exit 2
 fi
@@ -243,6 +259,10 @@ echo "ROOT_DIR=$ROOT_DIR"
 echo "TURTLEBOT3_MODEL=$TURTLEBOT3_MODEL"
 echo "PROFILE_SET=$PROFILE_SET"
 echo "ODOM_PROFILE_SET=$ODOM_PROFILE_SET"
+echo "RUN_COUNT=$RUN_COUNT"
+echo "START_INDEX=$START_INDEX"
+echo "MAX_RUNS=$MAX_RUNS"
+echo "SELECTED_RUN_COUNT=$SELECTED_RUN_COUNT"
 echo "CSV_REPORT=$CSV_REPORT"
 echo "JSONL_REPORT=$JSONL_REPORT"
 echo "SUMMARY_REPORT=$SUMMARY_REPORT"
@@ -250,6 +270,7 @@ echo "RUN_LOG_DIR=$RUN_LOG_DIR"
 echo
 
 run_idx=0
+selected_run_idx=0
 failed=0
 for odom_profile_entry in "${ODOM_PROFILES[@]}"; do
   IFS='|' read -r odom_profile_name odom_profile_description odom_profile_env <<<"$odom_profile_entry"
@@ -267,11 +288,20 @@ for odom_profile_entry in "${ODOM_PROFILES[@]}"; do
 
     for entry in "${SCENARIOS[@]}"; do
       IFS='|' read -r name wps mission_to <<<"$entry"
+      matrix_idx=$run_idx
+      run_idx=$((run_idx + 1))
+      if (( matrix_idx < START_INDEX )); then
+        continue
+      fi
+      if (( selected_run_idx >= SELECTED_RUN_COUNT )); then
+        continue
+      fi
+
       export WAYPOINT_NAV_WAYPOINTS="$wps"
       export SMOKE_MISSION_TIMEOUT="$mission_to"
-      export ROS_DOMAIN_ID=$((BASE_ID + run_idx))
-      printf -v run_label "%02d_%s_%s_%s" "$run_idx" "$odom_profile_name" "$profile_name" "$name"
-      run_idx=$((run_idx + 1))
+      export ROS_DOMAIN_ID=$((BASE_ID + selected_run_idx))
+      printf -v run_label "%02d_%s_%s_%s" "$matrix_idx" "$odom_profile_name" "$profile_name" "$name"
+      selected_run_idx=$((selected_run_idx + 1))
 
       out="$RUN_LOG_DIR/${run_label}.log"
       : >"$out"
@@ -435,6 +465,10 @@ done
   echo "- generated_at_utc: $REPORT_STAMP"
   echo "- profile_set: $PROFILE_SET"
   echo "- odom_profile_set: $ODOM_PROFILE_SET"
+  echo "- total_run_count: $RUN_COUNT"
+  echo "- start_index: $START_INDEX"
+  echo "- max_runs: $MAX_RUNS"
+  echo "- selected_run_count: $SELECTED_RUN_COUNT"
   echo "- turtlebot3_model: $TURTLEBOT3_MODEL"
   echo "- csv: $CSV_REPORT"
   echo "- jsonl: $JSONL_REPORT"

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -48,18 +48,16 @@ MAX_RUNS="${SLAM_REVALUATION_MAX_RUNS:-0}"
 # name|waypoints|mission_timeout_sec
 # Keep segments moderate: four+ waypoints often hit smoke mission timeout (stuck/recovery) in Gazebo.
 # rich_geometry_turns extends sustained forward motion past the LIDAR noise floor
-# (~1.3 cm mean residual) so scan-to-scan ICP has something to correct. The path
-# is an L-loop kept inside the spawn-side cylinder-free zone: turtlebot3_world has
-# cylinders at x=-1.1,0,1.1 and y=-1.1,0,1.1, and at spawn (-2.0, -0.5) the safe
-# corridor with DWA clearance is x_world < -1.45, so the relative path stays at
-# x <= 0.55. Two 90-degree turns and 1.6 m total give the scan-to-scan ICP about
-# 30 percent more sustained forward motion than long_two_legs without crossing
-# any cylinder column.
+# (~1.3 cm mean residual) so scan-to-scan ICP has something to correct. The shape
+# mirrors three_hops (3 waypoints, all-diagonal segments) plus a return-home leg
+# so total path is ~1.75 m versus three_hops's ~1.21 m. Earlier axis-aligned
+# variants (0.55,0; 0.55,0.5; 0,0.5) made the robot oscillate before reaching
+# waypoint 1; the all-diagonal version stays inside the working three_hops shape.
 SCENARIOS=(
   "short_default|0.4,0.0;0.1,0.4|150"
   "three_hops|0.45,0.0;0.35,0.45;0.05,0.5|200"
   "long_two_legs|0.55,0.0;0.2,0.55|200"
-  "rich_geometry_turns|0.55,0.0;0.55,0.5;0.0,0.5|240"
+  "rich_geometry_turns|0.55,0.05;0.20,0.55;0.0,0.0|240"
 )
 
 case "$PROFILE_SET" in

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -7,6 +7,8 @@
 # Optional:
 #   ROS_DOMAIN_ID_BASE=210  # first run uses this ID, then increments per scenario
 #   SLAM_REVALUATION_REPORT_DIR=reports/slam_revaluation
+#   SLAM_REVALUATION_SUMMARY=reports/slam_revaluation/summary.md
+#   SLAM_REVALUATION_LOG_DIR=reports/slam_revaluation/run_logs
 #   SLAM_REVALUATION_PROFILE_SET=tuning  # baseline (default) or tuning
 #   SLAM_REVALUATION_ODOM_PROFILE_SET=biased  # baseline (default) or biased
 #
@@ -34,6 +36,8 @@ REPORT_DIR="${SLAM_REVALUATION_REPORT_DIR:-$ROOT_DIR/reports/slam_revaluation}"
 REPORT_STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 CSV_REPORT="${SLAM_REVALUATION_CSV:-$REPORT_DIR/navigation_revaluation_${REPORT_STAMP}.csv}"
 JSONL_REPORT="${SLAM_REVALUATION_JSONL:-$REPORT_DIR/navigation_revaluation_${REPORT_STAMP}.jsonl}"
+SUMMARY_REPORT="${SLAM_REVALUATION_SUMMARY:-$REPORT_DIR/navigation_revaluation_${REPORT_STAMP}.summary.md}"
+RUN_LOG_DIR="${SLAM_REVALUATION_LOG_DIR:-$REPORT_DIR/navigation_revaluation_${REPORT_STAMP}_logs}"
 PROFILE_SET="${SLAM_REVALUATION_PROFILE_SET:-baseline}"
 ODOM_PROFILE_SET="${SLAM_REVALUATION_ODOM_PROFILE_SET:-baseline}"
 
@@ -75,7 +79,10 @@ case "$ODOM_PROFILE_SET" in
     ODOM_PROFILES=(
       "raw_realistic|use raw EKF odom as SLAM input|"
       "odom_xy_scale_1pct|feed SLAM input odom with 1 percent relative XY scale drift|ENABLE_SLAM_INPUT_ODOM_BIAS=true SLAM_INPUT_ODOM_XY_SCALE=1.01"
+      "odom_xy_scale_3pct|feed SLAM input odom with 3 percent relative XY scale drift|ENABLE_SLAM_INPUT_ODOM_BIAS=true SLAM_INPUT_ODOM_XY_SCALE=1.03"
       "odom_yaw_drift_1deg_per_m|feed SLAM input odom with 1 degree yaw drift per meter|ENABLE_SLAM_INPUT_ODOM_BIAS=true SLAM_INPUT_ODOM_YAW_BIAS_PER_METER=0.017453292519943295"
+      "odom_yaw_drift_3deg_per_m|feed SLAM input odom with 3 degree yaw drift per meter|ENABLE_SLAM_INPUT_ODOM_BIAS=true SLAM_INPUT_ODOM_YAW_BIAS_PER_METER=0.05235987755982988"
+      "odom_turn_yaw_scale_3pct|feed SLAM input odom with 3 percent relative yaw scale drift|ENABLE_SLAM_INPUT_ODOM_BIAS=true SLAM_INPUT_ODOM_YAW_SCALE=1.03"
     )
     ;;
   *)
@@ -187,7 +194,7 @@ count_key_values_with_token() {
   printf '%s' "$values"
 }
 
-mkdir -p "$(dirname "$CSV_REPORT")" "$(dirname "$JSONL_REPORT")"
+mkdir -p "$(dirname "$CSV_REPORT")" "$(dirname "$JSONL_REPORT")" "$(dirname "$SUMMARY_REPORT")" "$RUN_LOG_DIR"
 write_csv_row "$CSV_REPORT" \
   "odom_profile" \
   "odom_profile_description" \
@@ -216,6 +223,11 @@ write_csv_row "$CSV_REPORT" \
   "slam_better_yaw" \
   "icp_status" \
   "icp_error_mean" \
+  "icp_initial_error_mean" \
+  "icp_error_median" \
+  "icp_error_p90" \
+  "icp_inlier_ratio_5cm" \
+  "icp_relative_error_reduction" \
   "icp_iterations" \
   "icp_converged" \
   "scan_points" \
@@ -233,6 +245,8 @@ echo "PROFILE_SET=$PROFILE_SET"
 echo "ODOM_PROFILE_SET=$ODOM_PROFILE_SET"
 echo "CSV_REPORT=$CSV_REPORT"
 echo "JSONL_REPORT=$JSONL_REPORT"
+echo "SUMMARY_REPORT=$SUMMARY_REPORT"
+echo "RUN_LOG_DIR=$RUN_LOG_DIR"
 echo
 
 run_idx=0
@@ -256,9 +270,11 @@ for odom_profile_entry in "${ODOM_PROFILES[@]}"; do
       export WAYPOINT_NAV_WAYPOINTS="$wps"
       export SMOKE_MISSION_TIMEOUT="$mission_to"
       export ROS_DOMAIN_ID=$((BASE_ID + run_idx))
+      printf -v run_label "%02d_%s_%s_%s" "$run_idx" "$odom_profile_name" "$profile_name" "$name"
       run_idx=$((run_idx + 1))
 
-      out="$(mktemp)"
+      out="$RUN_LOG_DIR/${run_label}.log"
+      : >"$out"
       echo ">>> Odom profile: $odom_profile_name"
       echo "    $odom_profile_description"
       if [[ -n "$odom_profile_env" ]]; then
@@ -303,6 +319,11 @@ for odom_profile_entry in "${ODOM_PROFILES[@]}"; do
 
       icp_status="$(kv_get "$diag_line" "status")"
       icp_error_mean="$(kv_get "$diag_line" "icp_error_mean")"
+      icp_initial_error_mean="$(kv_get "$diag_line" "icp_initial_error_mean")"
+      icp_error_median="$(kv_get "$diag_line" "icp_error_median")"
+      icp_error_p90="$(kv_get "$diag_line" "icp_error_p90")"
+      icp_inlier_ratio_5cm="$(kv_get "$diag_line" "icp_inlier_ratio_5cm")"
+      icp_relative_error_reduction="$(kv_get "$diag_line" "icp_relative_error_reduction")"
       icp_iterations="$(kv_get "$diag_line" "icp_iterations")"
       icp_converged="$(kv_get "$diag_line" "icp_converged")"
       scan_points="$(kv_get "$diag_line" "scan_points")"
@@ -338,6 +359,11 @@ for odom_profile_entry in "${ODOM_PROFILES[@]}"; do
         "$slam_better_yaw" \
         "$icp_status" \
         "$icp_error_mean" \
+        "$icp_initial_error_mean" \
+        "$icp_error_median" \
+        "$icp_error_p90" \
+        "$icp_inlier_ratio_5cm" \
+        "$icp_relative_error_reduction" \
         "$icp_iterations" \
         "$icp_converged" \
         "$scan_points" \
@@ -375,6 +401,11 @@ for odom_profile_entry in "${ODOM_PROFILES[@]}"; do
         "slam_better_yaw" "$slam_better_yaw" \
         "icp_status" "$icp_status" \
         "icp_error_mean" "$icp_error_mean" \
+        "icp_initial_error_mean" "$icp_initial_error_mean" \
+        "icp_error_median" "$icp_error_median" \
+        "icp_error_p90" "$icp_error_p90" \
+        "icp_inlier_ratio_5cm" "$icp_inlier_ratio_5cm" \
+        "icp_relative_error_reduction" "$icp_relative_error_reduction" \
         "icp_iterations" "$icp_iterations" \
         "icp_converged" "$icp_converged" \
         "scan_points" "$scan_points" \
@@ -391,17 +422,34 @@ for odom_profile_entry in "${ODOM_PROFILES[@]}"; do
       else
         echo "    RESULT: OK"
         echo "    Metrics: raw_xy_error=${raw_xy_error:-n/a} slam_xy_error=${slam_xy_error:-n/a} improvement_xy=${improvement_xy:-n/a} slam_better_xy=${slam_better_xy:-n/a}"
-        echo "    ICP: status=${icp_status:-n/a} icp_error_mean=${icp_error_mean:-n/a} blend_alpha=${blend_alpha:-n/a} gate_reason=${gate_reason:-n/a}"
+        echo "    ICP: status=${icp_status:-n/a} icp_error_mean=${icp_error_mean:-n/a} icp_error_p90=${icp_error_p90:-n/a} inlier_5cm=${icp_inlier_ratio_5cm:-n/a} blend_alpha=${blend_alpha:-n/a} gate_reason=${gate_reason:-n/a}"
       fi
       echo
-      rm -f "$out"
     done
   done
 done
 
+{
+  echo "# Corrected-frame SLAM revaluation summary"
+  echo
+  echo "- generated_at_utc: $REPORT_STAMP"
+  echo "- profile_set: $PROFILE_SET"
+  echo "- odom_profile_set: $ODOM_PROFILE_SET"
+  echo "- turtlebot3_model: $TURTLEBOT3_MODEL"
+  echo "- csv: $CSV_REPORT"
+  echo "- jsonl: $JSONL_REPORT"
+  echo "- logs: $RUN_LOG_DIR"
+  echo
+  echo '```text'
+  python3 "$ROOT_DIR/scripts/summarize_slam_revaluation.py" "$CSV_REPORT"
+  echo '```'
+} >"$SUMMARY_REPORT"
+
 echo "Reports written:"
 echo "  CSV:   $CSV_REPORT"
 echo "  JSONL: $JSONL_REPORT"
+echo "  Summary: $SUMMARY_REPORT"
+echo "  Logs:    $RUN_LOG_DIR"
 echo
 
 if [[ "$failed" -eq 0 ]]; then

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -47,10 +47,15 @@ MAX_RUNS="${SLAM_REVALUATION_MAX_RUNS:-0}"
 
 # name|waypoints|mission_timeout_sec
 # Keep segments moderate: four+ waypoints often hit smoke mission timeout (stuck/recovery) in Gazebo.
+# rich_geometry_turns extends sustained forward motion past the LIDAR noise floor
+# (~1.3 cm mean residual) so scan-to-scan ICP has something to correct; it keeps
+# per-segment length at 0.55 m (matching the working scenarios) and stays clear
+# of the turtlebot3_world cylinder grid at x=-1.1,0,1.1 and y=-1.1,0,1.1.
 SCENARIOS=(
   "short_default|0.4,0.0;0.1,0.4|150"
   "three_hops|0.45,0.0;0.35,0.45;0.05,0.5|200"
   "long_two_legs|0.55,0.0;0.2,0.55|200"
+  "rich_geometry_turns|0.55,0.0;1.10,0.0;1.10,0.55;0.55,0.55|240"
 )
 
 case "$PROFILE_SET" in
@@ -63,8 +68,8 @@ case "$PROFILE_SET" in
     ICP_PROFILES=(
       "default|built-in ICP gating defaults|"
       "low_alpha|reduce accepted ICP correction weight|SLAM_ICP_BLEND_ALPHA=0.10"
-      "strict_error|reject weaker ICP matches earlier|SLAM_ICP_REJECT_ERROR=0.011"
-      "strict_low_alpha|lower blend weight and reject weaker ICP matches earlier|SLAM_ICP_BLEND_ALPHA=0.10 SLAM_ICP_REJECT_ERROR=0.011"
+      "strict_error|reject weaker ICP matches earlier|SLAM_ICP_REJECT_ERROR=0.008"
+      "strict_low_alpha|lower blend weight and reject weaker ICP matches earlier|SLAM_ICP_BLEND_ALPHA=0.10 SLAM_ICP_REJECT_ERROR=0.008"
       "loose_error|raise ICP reject error past LIDAR noise floor|SLAM_ICP_REJECT_ERROR=0.018"
       "loose_error_low_alpha|raise ICP reject error and lower blend weight|SLAM_ICP_BLEND_ALPHA=0.10 SLAM_ICP_REJECT_ERROR=0.018"
       "very_loose_error|raise ICP reject error to 2.3x default|SLAM_ICP_REJECT_ERROR=0.025"

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -51,7 +51,7 @@ SCENARIOS=(
   "short_default|0.4,0.0;0.1,0.4|150"
   "three_hops|0.45,0.0;0.35,0.45;0.05,0.5|200"
   "long_two_legs|0.55,0.0;0.2,0.55|200"
-  "long_straight|1.2,0.0;1.5,0.6|240"
+  "extended_two_legs|0.7,0.0;0.4,0.7|220"
 )
 
 case "$PROFILE_SET" in

--- a/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
+++ b/ros2_nodes/launch/run_navigation_revaluation_matrix.sh
@@ -48,14 +48,18 @@ MAX_RUNS="${SLAM_REVALUATION_MAX_RUNS:-0}"
 # name|waypoints|mission_timeout_sec
 # Keep segments moderate: four+ waypoints often hit smoke mission timeout (stuck/recovery) in Gazebo.
 # rich_geometry_turns extends sustained forward motion past the LIDAR noise floor
-# (~1.3 cm mean residual) so scan-to-scan ICP has something to correct; it keeps
-# per-segment length at 0.55 m (matching the working scenarios) and stays clear
-# of the turtlebot3_world cylinder grid at x=-1.1,0,1.1 and y=-1.1,0,1.1.
+# (~1.3 cm mean residual) so scan-to-scan ICP has something to correct. The path
+# is an L-loop kept inside the spawn-side cylinder-free zone: turtlebot3_world has
+# cylinders at x=-1.1,0,1.1 and y=-1.1,0,1.1, and at spawn (-2.0, -0.5) the safe
+# corridor with DWA clearance is x_world < -1.45, so the relative path stays at
+# x <= 0.55. Two 90-degree turns and 1.6 m total give the scan-to-scan ICP about
+# 30 percent more sustained forward motion than long_two_legs without crossing
+# any cylinder column.
 SCENARIOS=(
   "short_default|0.4,0.0;0.1,0.4|150"
   "three_hops|0.45,0.0;0.35,0.45;0.05,0.5|200"
   "long_two_legs|0.55,0.0;0.2,0.55|200"
-  "rich_geometry_turns|0.55,0.0;1.10,0.0;1.10,0.55;0.55,0.55|240"
+  "rich_geometry_turns|0.55,0.0;0.55,0.5;0.0,0.5|240"
 )
 
 case "$PROFILE_SET" in

--- a/ros2_nodes/launch/run_navigation_smoke_test.sh
+++ b/ros2_nodes/launch/run_navigation_smoke_test.sh
@@ -61,6 +61,7 @@ TMP_DIR="$(mktemp -d)"
 LAUNCH_LOG="$TMP_DIR/navigation_demo.log"
 STATUS_OUT="$TMP_DIR/mission_status.txt"
 SLAM_DIAG_OUT="$TMP_DIR/slam_diagnostics.txt"
+SLAM_DIAG_MISSION_OUT="$TMP_DIR/slam_diagnostics_mission.txt"
 SLAM_GT_STATUS_OUT="$TMP_DIR/slam_ground_truth_status.txt"
 MARKERS_OUT="$TMP_DIR/mission_markers.txt"
 ODOM_OUT="$TMP_DIR/nav_odom.txt"
@@ -69,9 +70,14 @@ TF_MAP_ODOM_OUT="$TMP_DIR/tf_map_odom.txt"
 MAP_OUT="$TMP_DIR/map.txt"
 PATH_OUT="$TMP_DIR/planned_path.txt"
 launch_pid=""
+mission_diag_pid=""
 
 cleanup() {
   local exit_code=$?
+  if [[ -n "$mission_diag_pid" ]] && kill -0 "$mission_diag_pid" 2>/dev/null; then
+    kill "$mission_diag_pid" 2>/dev/null || true
+    wait "$mission_diag_pid" 2>/dev/null || true
+  fi
   if [[ -n "$launch_pid" ]] && kill -0 "$launch_pid" 2>/dev/null; then
     kill -INT -- "-$launch_pid" 2>/dev/null || true
     wait "$launch_pid" 2>/dev/null || true
@@ -79,6 +85,11 @@ cleanup() {
 
   if [[ "$exit_code" -ne 0 ]]; then
     echo
+    if [[ -s "$SLAM_DIAG_MISSION_OUT" ]]; then
+      echo "Mission-window slam diagnostics (captured before failure):" >&2
+      cat "$SLAM_DIAG_MISSION_OUT" >&2 || true
+      echo >&2
+    fi
     echo "Smoke test failed. Launch log tail:" >&2
     tail -n 120 "$LAUNCH_LOG" >&2 || true
   fi
@@ -346,6 +357,10 @@ if [[ "$ENABLE_SLAM_CORRECTED_FRAME" == "true" ]]; then
   if [[ "$ENABLE_SLAM_GROUND_TRUTH_MONITOR" == "true" ]]; then
     capture_topic_stream_until "$SLAM_GROUND_TRUTH_STATUS_TOPIC" "std_msgs/msg/String" "$SLAM_GT_STATUS_OUT" "$SMOKE_STARTUP_TIMEOUT" "data: status=ok" "slam_xy_error="
   fi
+  : >"$SLAM_DIAG_MISSION_OUT"
+  stdbuf -oL -eL ros2 topic echo --full-length "$SLAM_DIAGNOSTICS_TOPIC" std_msgs/msg/String \
+    >"$SLAM_DIAG_MISSION_OUT" 2>>"$LAUNCH_LOG" &
+  mission_diag_pid=$!
 fi
 
 wait_for_log_pattern "mission complete at waypoint" "$SMOKE_MISSION_TIMEOUT"
@@ -354,6 +369,12 @@ wait_for_log_pattern "planned path cleared" "$SMOKE_MISSION_TIMEOUT"
 wait_for_log_pattern "published stop command after path clear" "$SMOKE_MISSION_TIMEOUT"
 
 capture_topic_stream_until "/mission_status" "std_msgs/msg/String" "$STATUS_OUT" "$SMOKE_TOPIC_CAPTURE_TIMEOUT" "data: status=completed"
+
+if [[ -n "$mission_diag_pid" ]] && kill -0 "$mission_diag_pid" 2>/dev/null; then
+  kill "$mission_diag_pid" 2>/dev/null || true
+  wait "$mission_diag_pid" 2>/dev/null || true
+fi
+mission_diag_pid=""
 
 if [[ "$ENABLE_SLAM_CORRECTED_FRAME" == "true" ]]; then
   capture_topic_stream_until "$SLAM_DIAGNOSTICS_TOPIC" "std_msgs/msg/String" "$SLAM_DIAG_OUT" "$SMOKE_TOPIC_CAPTURE_TIMEOUT" "data: status=" "icp_" "blend_alpha=" "gate_reason="
@@ -368,6 +389,11 @@ fi
 echo "Verified mission status topic:"
 cat "$STATUS_OUT"
 echo
+if [[ -s "$SLAM_DIAG_MISSION_OUT" ]]; then
+  echo "Mission-window slam diagnostics:"
+  cat "$SLAM_DIAG_MISSION_OUT"
+  echo
+fi
 echo "Verified slam diagnostics topic:"
 cat "$SLAM_DIAG_OUT"
 echo

--- a/ros2_nodes/launch/run_navigation_smoke_test.sh
+++ b/ros2_nodes/launch/run_navigation_smoke_test.sh
@@ -339,6 +339,16 @@ capture_topic_once "/map" "nav_msgs/msg/OccupancyGrid" "$MAP_OUT" "$SMOKE_STARTU
 capture_topic_once "/planned_path" "nav_msgs/msg/Path" "$PATH_OUT" "$SMOKE_STARTUP_TIMEOUT"
 capture_topic_stream_until "/mission_status" "std_msgs/msg/String" "$STATUS_OUT" "$SMOKE_STARTUP_TIMEOUT" "data: status="
 capture_topic_stream_until "$SLAM_DIAGNOSTICS_TOPIC" "std_msgs/msg/String" "$SLAM_DIAG_OUT" "$SMOKE_STARTUP_TIMEOUT" "data: status=" "icp_" "blend_alpha=" "gate_reason="
+# /slam_diagnostics is now alive; subscribe continuously so the mission
+# window (motion) is captured. The remaining startup waits plus the
+# post-completion verifications would otherwise let the robot reach the
+# goal before the later capture started, yielding only stationary samples.
+if [[ "$ENABLE_SLAM_CORRECTED_FRAME" == "true" ]]; then
+  : >"$SLAM_DIAG_MISSION_OUT"
+  stdbuf -oL -eL ros2 topic echo --full-length "$SLAM_DIAGNOSTICS_TOPIC" std_msgs/msg/String \
+    >"$SLAM_DIAG_MISSION_OUT" 2>>"$LAUNCH_LOG" &
+  mission_diag_pid=$!
+fi
 capture_topic_stream_until "/mission_markers" "visualization_msgs/msg/MarkerArray" "$MARKERS_OUT" "$SMOKE_STARTUP_TIMEOUT" "ns: mission"
 capture_nav_tf "$SMOKE_STARTUP_TIMEOUT"
 
@@ -357,10 +367,6 @@ if [[ "$ENABLE_SLAM_CORRECTED_FRAME" == "true" ]]; then
   if [[ "$ENABLE_SLAM_GROUND_TRUTH_MONITOR" == "true" ]]; then
     capture_topic_stream_until "$SLAM_GROUND_TRUTH_STATUS_TOPIC" "std_msgs/msg/String" "$SLAM_GT_STATUS_OUT" "$SMOKE_STARTUP_TIMEOUT" "data: status=ok" "slam_xy_error="
   fi
-  : >"$SLAM_DIAG_MISSION_OUT"
-  stdbuf -oL -eL ros2 topic echo --full-length "$SLAM_DIAGNOSTICS_TOPIC" std_msgs/msg/String \
-    >"$SLAM_DIAG_MISSION_OUT" 2>>"$LAUNCH_LOG" &
-  mission_diag_pid=$!
 fi
 
 wait_for_log_pattern "mission complete at waypoint" "$SMOKE_MISSION_TIMEOUT"

--- a/ros2_nodes/launch/run_navigation_smoke_test.sh
+++ b/ros2_nodes/launch/run_navigation_smoke_test.sh
@@ -50,6 +50,12 @@ export DWA_GOAL_THRESHOLD="${DWA_GOAL_THRESHOLD:-0.3}"
 SMOKE_STARTUP_TIMEOUT="${SMOKE_STARTUP_TIMEOUT:-90}"
 SMOKE_MISSION_TIMEOUT="${SMOKE_MISSION_TIMEOUT:-120}"
 SMOKE_TOPIC_CAPTURE_TIMEOUT="${SMOKE_TOPIC_CAPTURE_TIMEOUT:-20}"
+SMOKE_ENABLE_CORRECTED_SAFETY_GUARD="${SMOKE_ENABLE_CORRECTED_SAFETY_GUARD:-true}"
+SMOKE_MAX_SLAM_XY_ERROR="${SMOKE_MAX_SLAM_XY_ERROR:-0.50}"
+SMOKE_MAX_SLAM_YAW_ERROR="${SMOKE_MAX_SLAM_YAW_ERROR:-0.524}"
+SMOKE_MAX_SLAM_XY_MAX="${SMOKE_MAX_SLAM_XY_MAX:-0.75}"
+SMOKE_MAX_APPLIED_TRANSLATION_DELTA="${SMOKE_MAX_APPLIED_TRANSLATION_DELTA:-0.20}"
+SMOKE_MAX_APPLIED_YAW_DELTA="${SMOKE_MAX_APPLIED_YAW_DELTA:-0.35}"
 
 TMP_DIR="$(mktemp -d)"
 LAUNCH_LOG="$TMP_DIR/navigation_demo.log"
@@ -159,6 +165,114 @@ capture_topic_stream_until() {
   return 1
 }
 
+last_data_line_with() {
+  local token="$1"
+  local file="$2"
+  grep -F "$token" "$file" \
+    | sed -n 's/^[[:space:]]*data:[[:space:]]*//p' \
+    | sed "s/^'//; s/'$//" \
+    | tail -1 || true
+}
+
+kv_get() {
+  local line="$1"
+  local key="$2"
+  local token
+  for token in $line; do
+    if [[ "$token" == "$key="* ]]; then
+      printf '%s' "${token#*=}"
+      return 0
+    fi
+  done
+  return 0
+}
+
+assert_float_le() {
+  local label="$1"
+  local value="$2"
+  local limit="$3"
+  if [[ -z "$value" || "$value" == "na" ]]; then
+    echo "Missing numeric value for $label" >&2
+    return 1
+  fi
+  awk -v label="$label" -v value="$value" -v limit="$limit" '
+    BEGIN {
+      if ((value + 0) > (limit + 0)) {
+        printf "%s=%s exceeds limit %s\n", label, value, limit > "/dev/stderr"
+        exit 1
+      }
+    }
+  '
+}
+
+assert_abs_float_le() {
+  local label="$1"
+  local value="$2"
+  local limit="$3"
+  if [[ -z "$value" || "$value" == "na" ]]; then
+    echo "Missing numeric value for $label" >&2
+    return 1
+  fi
+  awk -v label="$label" -v value="$value" -v limit="$limit" '
+    BEGIN {
+      abs_value = value + 0
+      if (abs_value < 0) {
+        abs_value = -abs_value
+      }
+      if (abs_value > (limit + 0)) {
+        printf "|%s|=%s exceeds limit %s\n", label, abs_value, limit > "/dev/stderr"
+        exit 1
+      }
+    }
+  '
+}
+
+assert_hypot_float_le() {
+  local label="$1"
+  local x="$2"
+  local y="$3"
+  local limit="$4"
+  if [[ -z "$x" || "$x" == "na" || -z "$y" || "$y" == "na" ]]; then
+    echo "Missing numeric value for $label" >&2
+    return 1
+  fi
+  awk -v label="$label" -v x="$x" -v y="$y" -v limit="$limit" '
+    BEGIN {
+      magnitude = sqrt((x + 0) * (x + 0) + (y + 0) * (y + 0))
+      if (magnitude > (limit + 0)) {
+        printf "%s=%s exceeds limit %s\n", label, magnitude, limit > "/dev/stderr"
+        exit 1
+      }
+    }
+  '
+}
+
+validate_corrected_safety_guard() {
+  local gt_line
+  local diag_line
+  gt_line="$(last_data_line_with "slam_xy_error=" "$SLAM_GT_STATUS_OUT")"
+  diag_line="$(last_data_line_with "blend_alpha=" "$SLAM_DIAG_OUT")"
+
+  local slam_xy_error
+  local slam_yaw_error
+  local slam_xy_max
+  local applied_dx
+  local applied_dy
+  local applied_dyaw
+  slam_xy_error="$(kv_get "$gt_line" "slam_xy_error")"
+  slam_yaw_error="$(kv_get "$gt_line" "slam_yaw_error")"
+  slam_xy_max="$(kv_get "$gt_line" "slam_xy_max")"
+  applied_dx="$(kv_get "$diag_line" "applied_dx")"
+  applied_dy="$(kv_get "$diag_line" "applied_dy")"
+  applied_dyaw="$(kv_get "$diag_line" "applied_dyaw")"
+
+  assert_float_le "slam_xy_error" "$slam_xy_error" "$SMOKE_MAX_SLAM_XY_ERROR"
+  assert_float_le "slam_yaw_error" "$slam_yaw_error" "$SMOKE_MAX_SLAM_YAW_ERROR"
+  assert_float_le "slam_xy_max" "$slam_xy_max" "$SMOKE_MAX_SLAM_XY_MAX"
+  assert_hypot_float_le "applied_translation_delta" "$applied_dx" "$applied_dy" "$SMOKE_MAX_APPLIED_TRANSLATION_DELTA"
+  assert_abs_float_le "applied_dyaw" "$applied_dyaw" "$SMOKE_MAX_APPLIED_YAW_DELTA"
+}
+
 capture_nav_tf() {
   local timeout_seconds="$1"
   local deadline=$((SECONDS + timeout_seconds))
@@ -240,6 +354,16 @@ wait_for_log_pattern "planned path cleared" "$SMOKE_MISSION_TIMEOUT"
 wait_for_log_pattern "published stop command after path clear" "$SMOKE_MISSION_TIMEOUT"
 
 capture_topic_stream_until "/mission_status" "std_msgs/msg/String" "$STATUS_OUT" "$SMOKE_TOPIC_CAPTURE_TIMEOUT" "data: status=completed"
+
+if [[ "$ENABLE_SLAM_CORRECTED_FRAME" == "true" ]]; then
+  capture_topic_stream_until "$SLAM_DIAGNOSTICS_TOPIC" "std_msgs/msg/String" "$SLAM_DIAG_OUT" "$SMOKE_TOPIC_CAPTURE_TIMEOUT" "data: status=" "icp_" "blend_alpha=" "gate_reason="
+  if [[ "$ENABLE_SLAM_GROUND_TRUTH_MONITOR" == "true" ]]; then
+    capture_topic_stream_until "$SLAM_GROUND_TRUTH_STATUS_TOPIC" "std_msgs/msg/String" "$SLAM_GT_STATUS_OUT" "$SMOKE_TOPIC_CAPTURE_TIMEOUT" "data: status=ok" "slam_xy_error="
+    if [[ "$SMOKE_ENABLE_CORRECTED_SAFETY_GUARD" == "true" ]]; then
+      validate_corrected_safety_guard
+    fi
+  fi
+fi
 
 echo "Verified mission status topic:"
 cat "$STATUS_OUT"

--- a/ros2_nodes/slam_node/src/main.rs
+++ b/ros2_nodes/slam_node/src/main.rs
@@ -43,8 +43,11 @@ const DEFAULT_ICP_FULL_WEIGHT_YAW_MOTION: f64 = 0.08;
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct IcpGatingParams {
     blend_alpha: f64,
+    blend_alpha_yaw: f64,
     full_weight_error: f64,
     reject_error: f64,
+    full_weight_error_yaw: f64,
+    reject_error_yaw: f64,
     full_weight_iterations: f64,
     reject_iterations: f64,
     full_weight_translation_correction: f64,
@@ -59,8 +62,11 @@ impl Default for IcpGatingParams {
     fn default() -> Self {
         Self {
             blend_alpha: DEFAULT_ICP_BLEND_ALPHA,
+            blend_alpha_yaw: DEFAULT_ICP_BLEND_ALPHA,
             full_weight_error: DEFAULT_ICP_FULL_WEIGHT_ERROR,
             reject_error: DEFAULT_ICP_REJECT_ERROR,
+            full_weight_error_yaw: DEFAULT_ICP_FULL_WEIGHT_ERROR,
+            reject_error_yaw: DEFAULT_ICP_REJECT_ERROR,
             full_weight_iterations: DEFAULT_ICP_FULL_WEIGHT_ITERATIONS,
             reject_iterations: DEFAULT_ICP_REJECT_ITERATIONS,
             full_weight_translation_correction: DEFAULT_ICP_FULL_WEIGHT_TRANSLATION_CORRECTION,
@@ -124,13 +130,33 @@ struct ScanDiagnostics {
     applied_delta: Option<MotionDelta>,
     blend_applied: bool,
     blend_alpha: f64,
+    blend_alpha_yaw: f64,
     gate_reason: &'static str,
+    gate_reason_yaw: &'static str,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct IcpBlendDecision {
+    /// XY-axis blend weight (0..1). Backward-compatible field name `alpha` keeps existing call sites
+    /// and tests working — the XY axis is the primary blend.
     alpha: f64,
+    /// Gate reason for the XY axis. Same string set as before.
     reason: &'static str,
+    /// Yaw-axis blend weight (0..1). When yaw env overrides are unset this equals `alpha`.
+    alpha_yaw: f64,
+    /// Gate reason for the yaw axis. When yaw env overrides are unset this equals `reason`.
+    reason_yaw: &'static str,
+}
+
+impl IcpBlendDecision {
+    fn all_rejected(reason: &'static str) -> Self {
+        Self {
+            alpha: 0.0,
+            reason,
+            alpha_yaw: 0.0,
+            reason_yaw: reason,
+        }
+    }
 }
 
 fn yaw_from_quaternion(x: f64, y: f64, z: f64, w: f64) -> f64 {
@@ -227,6 +253,9 @@ fn clamp_f64(v: f64, min: f64, max: f64) -> f64 {
 }
 
 /// Loads [`IcpGatingParams`] from `SLAM_ICP_*` env vars (unset → defaults from [`IcpGatingParams::default`]).
+///
+/// The yaw-axis error and blend-alpha settings default to the XY values when their
+/// `SLAM_ICP_*_YAW` overrides are unset, preserving prior single-gate behavior.
 fn icp_gating_params_from_env() -> IcpGatingParams {
     let mut p = IcpGatingParams::default();
     p.blend_alpha = clamp_f64(
@@ -234,8 +263,17 @@ fn icp_gating_params_from_env() -> IcpGatingParams {
         0.0,
         1.0,
     );
+    p.blend_alpha_yaw = clamp_f64(
+        f64_from_env("SLAM_ICP_BLEND_ALPHA_YAW", p.blend_alpha),
+        0.0,
+        1.0,
+    );
     p.full_weight_error = f64_from_env("SLAM_ICP_FULL_WEIGHT_ERROR", p.full_weight_error).max(1e-6);
     p.reject_error = f64_from_env("SLAM_ICP_REJECT_ERROR", p.reject_error).max(p.full_weight_error + 1e-6);
+    p.full_weight_error_yaw =
+        f64_from_env("SLAM_ICP_FULL_WEIGHT_ERROR_YAW", p.full_weight_error).max(1e-6);
+    p.reject_error_yaw = f64_from_env("SLAM_ICP_REJECT_ERROR_YAW", p.reject_error)
+        .max(p.full_weight_error_yaw + 1e-6);
     p.full_weight_iterations = f64_from_env("SLAM_ICP_FULL_WEIGHT_ITERATIONS", p.full_weight_iterations).max(0.0);
     p.reject_iterations = f64_from_env("SLAM_ICP_REJECT_ITERATIONS", p.reject_iterations).max(p.full_weight_iterations + 1e-6);
     p.full_weight_translation_correction = f64_from_env(
@@ -375,16 +413,10 @@ fn compute_icp_blend_decision(
     p: &IcpGatingParams,
 ) -> IcpBlendDecision {
     if !converged {
-        return IcpBlendDecision {
-            alpha: 0.0,
-            reason: "not_converged",
-        };
+        return IcpBlendDecision::all_rejected("not_converged");
     }
     if !final_error.is_finite() {
-        return IcpBlendDecision {
-            alpha: 0.0,
-            reason: "invalid_error",
-        };
+        return IcpBlendDecision::all_rejected("invalid_error");
     }
 
     let correction = MotionDelta {
@@ -394,114 +426,137 @@ fn compute_icp_blend_decision(
     };
     let correction_translation = translation_magnitude(correction);
     let correction_yaw = correction.yaw.abs();
-    if correction_translation >= p.max_translation_correction {
-        return IcpBlendDecision {
-            alpha: 0.0,
-            reason: "translation_outlier",
-        };
-    }
-    if correction_yaw >= p.max_yaw_correction {
-        return IcpBlendDecision {
-            alpha: 0.0,
-            reason: "yaw_outlier",
-        };
-    }
 
-    let error_weight = ramp_weight(final_error, p.full_weight_error, p.reject_error);
-    if error_weight <= 0.0 {
-        return IcpBlendDecision {
-            alpha: 0.0,
-            reason: "high_error",
-        };
-    }
-
+    // Iterations gate is shared (it reflects ICP solver health, not per-axis quality).
     let iteration_weight = ramp_weight(
         iterations as f64,
         p.full_weight_iterations,
         p.reject_iterations,
     );
-    if iteration_weight <= 0.0 {
-        return IcpBlendDecision {
-            alpha: 0.0,
-            reason: "slow_convergence",
-        };
-    }
+
+    // Motion gate is split: XY axis only allows blend when robot actually translates;
+    // yaw axis allows blend when either yaw or translation motion is present.
+    let translation_motion_weight = ramp_up_weight(
+        translation_magnitude(odom),
+        p.full_weight_translation_motion * 0.25,
+        p.full_weight_translation_motion,
+    );
+    let yaw_motion_weight = ramp_up_weight(
+        odom.yaw.abs(),
+        p.full_weight_yaw_motion * 0.25,
+        p.full_weight_yaw_motion,
+    );
+    let yaw_axis_motion_weight = translation_motion_weight.max(yaw_motion_weight);
 
     let correction_translation_weight = ramp_weight(
         correction_translation,
         p.full_weight_translation_correction,
         p.max_translation_correction,
     );
-    if correction_translation_weight <= 0.0 {
-        return IcpBlendDecision {
-            alpha: 0.0,
-            reason: "translation_outlier",
-        };
-    }
-
     let correction_yaw_weight = ramp_weight(
         correction_yaw,
         p.full_weight_yaw_correction,
         p.max_yaw_correction,
     );
-    if correction_yaw_weight <= 0.0 {
-        return IcpBlendDecision {
-            alpha: 0.0,
-            reason: "yaw_outlier",
-        };
-    }
 
-    let odom_motion = translation_magnitude(odom);
-    let odom_motion_weight = ramp_up_weight(
-        odom_motion,
-        p.full_weight_translation_motion * 0.25,
-        p.full_weight_translation_motion,
-    )
-    .max(ramp_up_weight(
-        odom.yaw.abs(),
-        p.full_weight_yaw_motion * 0.25,
-        p.full_weight_yaw_motion,
-    ));
-    if odom_motion_weight <= 0.0 {
-        return IcpBlendDecision {
-            alpha: 0.0,
-            reason: "low_motion",
-        };
-    }
+    let (alpha_xy, reason_xy) = compute_axis_decision(AxisInputs {
+        base_alpha: p.blend_alpha,
+        final_error,
+        full_weight_error: p.full_weight_error,
+        reject_error: p.reject_error,
+        iteration_weight,
+        correction_size: correction_translation,
+        max_correction: p.max_translation_correction,
+        correction_weight: correction_translation_weight,
+        motion_weight: translation_motion_weight,
+        outlier_reason: "translation_outlier",
+        attenuated_correction_reason: "attenuated_translation",
+    });
 
+    let (alpha_yaw, reason_yaw) = compute_axis_decision(AxisInputs {
+        base_alpha: p.blend_alpha_yaw,
+        final_error,
+        full_weight_error: p.full_weight_error_yaw,
+        reject_error: p.reject_error_yaw,
+        iteration_weight,
+        correction_size: correction_yaw,
+        max_correction: p.max_yaw_correction,
+        correction_weight: correction_yaw_weight,
+        motion_weight: yaw_axis_motion_weight,
+        outlier_reason: "yaw_outlier",
+        attenuated_correction_reason: "attenuated_yaw",
+    });
+
+    IcpBlendDecision {
+        alpha: alpha_xy,
+        reason: reason_xy,
+        alpha_yaw,
+        reason_yaw,
+    }
+}
+
+struct AxisInputs {
+    base_alpha: f64,
+    final_error: f64,
+    full_weight_error: f64,
+    reject_error: f64,
+    iteration_weight: f64,
+    correction_size: f64,
+    max_correction: f64,
+    correction_weight: f64,
+    motion_weight: f64,
+    outlier_reason: &'static str,
+    attenuated_correction_reason: &'static str,
+}
+
+fn compute_axis_decision(a: AxisInputs) -> (f64, &'static str) {
+    if a.correction_size >= a.max_correction {
+        return (0.0, a.outlier_reason);
+    }
+    let error_weight = ramp_weight(a.final_error, a.full_weight_error, a.reject_error);
+    if error_weight <= 0.0 {
+        return (0.0, "high_error");
+    }
+    if a.iteration_weight <= 0.0 {
+        return (0.0, "slow_convergence");
+    }
+    if a.correction_weight <= 0.0 {
+        return (0.0, a.outlier_reason);
+    }
+    if a.motion_weight <= 0.0 {
+        return (0.0, "low_motion");
+    }
     let scale = error_weight
-        .min(iteration_weight)
-        .min(correction_translation_weight)
-        .min(correction_yaw_weight)
-        .min(odom_motion_weight);
-    let alpha = p.blend_alpha * scale;
+        .min(a.iteration_weight)
+        .min(a.correction_weight)
+        .min(a.motion_weight);
+    let alpha = a.base_alpha * scale;
     if alpha <= 0.0 {
-        return IcpBlendDecision {
-            alpha: 0.0,
-            reason: "rejected",
-        };
+        return (0.0, "rejected");
     }
-
     let reason = if scale < 0.999 {
-        if scale == odom_motion_weight {
+        if scale == a.motion_weight {
             "attenuated_low_motion"
         } else if scale == error_weight {
             "attenuated_error"
-        } else if scale == iteration_weight {
+        } else if scale == a.iteration_weight {
             "attenuated_iterations"
-        } else if scale == correction_translation_weight {
-            "attenuated_translation"
         } else {
-            "attenuated_yaw"
+            a.attenuated_correction_reason
         }
     } else {
         "accepted"
     };
-
-    IcpBlendDecision { alpha, reason }
+    (alpha, reason)
 }
 
-fn blend_motion_delta(odom: MotionDelta, icp: MotionDelta, alpha: f64, p: &IcpGatingParams) -> MotionDelta {
+fn blend_motion_delta(
+    odom: MotionDelta,
+    icp: MotionDelta,
+    alpha_xy: f64,
+    alpha_yaw: f64,
+    p: &IcpGatingParams,
+) -> MotionDelta {
     let correction_x = (icp.x - odom.x).clamp(
         -p.max_translation_correction,
         p.max_translation_correction,
@@ -514,9 +569,9 @@ fn blend_motion_delta(odom: MotionDelta, icp: MotionDelta, alpha: f64, p: &IcpGa
         normalize_angle(icp.yaw - odom.yaw).clamp(-p.max_yaw_correction, p.max_yaw_correction);
 
     MotionDelta {
-        x: odom.x + alpha * correction_x,
-        y: odom.y + alpha * correction_y,
-        yaw: normalize_angle(odom.yaw + alpha * correction_yaw),
+        x: odom.x + alpha_xy * correction_x,
+        y: odom.y + alpha_xy * correction_y,
+        yaw: normalize_angle(odom.yaw + alpha_yaw * correction_yaw),
     }
 }
 
@@ -547,7 +602,9 @@ fn diagnostics_status(diagnostics: ScanDiagnostics, base_blend_alpha: f64) -> &'
     if !diagnostics.had_previous_scan {
         "bootstrap"
     } else if diagnostics.blend_applied {
-        if diagnostics.blend_alpha + 1e-6 >= base_blend_alpha {
+        let xy_at_full = diagnostics.blend_alpha + 1e-6 >= base_blend_alpha;
+        let yaw_at_full = diagnostics.blend_alpha_yaw + 1e-6 >= base_blend_alpha;
+        if xy_at_full && yaw_at_full {
             "icp_ok"
         } else {
             "icp_attenuated"
@@ -589,7 +646,9 @@ fn format_slam_diagnostics(
         ),
         format!("blend_applied={}", diagnostics.blend_applied),
         format!("blend_alpha={:.3}", diagnostics.blend_alpha),
+        format!("blend_alpha_yaw={:.3}", diagnostics.blend_alpha_yaw),
         format!("gate_reason={}", diagnostics.gate_reason),
+        format!("gate_reason_yaw={}", diagnostics.gate_reason_yaw),
         format!("raw_x={:.3}", raw_pose.x),
         format!("raw_y={:.3}", raw_pose.y),
         format!("raw_yaw={:.3}", raw_pose.yaw),
@@ -865,11 +924,13 @@ fn main() -> Result<(), DynError> {
             let mut applied_delta = None;
             let mut blend_applied = false;
             let mut blend_alpha = 0.0;
+            let mut blend_alpha_yaw = 0.0;
             let mut gate_reason = if had_previous_scan {
                 "odom_only"
             } else {
                 "bootstrap"
             };
+            let mut gate_reason_yaw = gate_reason;
             let pose = if use_corrected_frame {
                 if !st.corrected_initialized {
                     st.corrected_pose = raw_pose;
@@ -886,20 +947,30 @@ fn main() -> Result<(), DynError> {
                         );
                         blend_alpha = decision.alpha;
                         gate_reason = decision.reason;
-                        if decision.alpha > 0.0 {
+                        blend_alpha_yaw = decision.alpha_yaw;
+                        gate_reason_yaw = decision.reason_yaw;
+                        if decision.alpha > 0.0 || decision.alpha_yaw > 0.0 {
                             blend_applied = true;
-                            blend_motion_delta(odom_delta, icp_delta, decision.alpha, &icp_params_scan)
+                            blend_motion_delta(
+                                odom_delta,
+                                icp_delta,
+                                decision.alpha,
+                                decision.alpha_yaw,
+                                &icp_params_scan,
+                            )
                         } else {
                             odom_delta
                         }
                     } else {
                         gate_reason = "missing_icp_delta";
+                        gate_reason_yaw = "missing_icp_delta";
                         odom_delta
                     };
                     applied_delta = Some(blended_delta);
                     st.corrected_pose = compose_pose_local(st.corrected_pose, blended_delta);
                 } else {
                     gate_reason = "syncing_to_odom";
+                    gate_reason_yaw = "syncing_to_odom";
                     st.corrected_pose = raw_pose;
                 }
                 st.corrected_pose
@@ -968,7 +1039,9 @@ fn main() -> Result<(), DynError> {
                     applied_delta,
                     blend_applied,
                     blend_alpha,
+                    blend_alpha_yaw,
                     gate_reason,
+                    gate_reason_yaw,
                 },
                 icp_params_scan.blend_alpha,
             );
@@ -1087,7 +1160,13 @@ mod tests {
             y: -1.0,
             yaw: 1.0,
         };
-        let blended = blend_motion_delta(odom, icp, DEFAULT_ICP_BLEND_ALPHA, &default_icp());
+        let blended = blend_motion_delta(
+            odom,
+            icp,
+            DEFAULT_ICP_BLEND_ALPHA,
+            DEFAULT_ICP_BLEND_ALPHA,
+            &default_icp(),
+        );
         assert!(blended.x > odom.x);
         assert!(blended.x < 0.2);
         assert!(blended.y.abs() < 0.1);
@@ -1211,7 +1290,9 @@ mod tests {
                 }),
                 blend_applied: true,
                 blend_alpha: DEFAULT_ICP_BLEND_ALPHA,
+                blend_alpha_yaw: DEFAULT_ICP_BLEND_ALPHA,
                 gate_reason: "accepted",
+                gate_reason_yaw: "accepted",
             },
             DEFAULT_ICP_BLEND_ALPHA,
         );
@@ -1224,6 +1305,59 @@ mod tests {
         assert!(text.contains("odom_dx=0.100"));
         assert!(text.contains("applied_dyaw=0.015"));
         assert!(text.contains("blend_alpha=0.350"));
+        assert!(text.contains("blend_alpha_yaw=0.350"));
         assert!(text.contains("gate_reason=accepted"));
+        assert!(text.contains("gate_reason_yaw=accepted"));
+    }
+
+    #[test]
+    fn compute_icp_blend_decision_yaw_only_during_in_place_rotation() {
+        // Robot is rotating in place: large yaw, near-zero translation.
+        // Both odom and ICP report this motion. With a looser yaw error threshold,
+        // alpha_yaw should be > 0 while alpha_xy stays 0 (low_motion on translation).
+        let mut params = default_icp();
+        params.full_weight_error_yaw = 0.020;
+        params.reject_error_yaw = 0.030;
+        // Translation motion is well below full_weight_translation_motion (0.05).
+        let odom = MotionDelta {
+            x: 0.001,
+            y: 0.0,
+            yaw: 0.12,
+        };
+        let icp = MotionDelta {
+            x: 0.0,
+            y: 0.0,
+            yaw: 0.12,
+        };
+        // ICP error 0.018 is above default reject (0.011) but below yaw reject (0.030).
+        let decision = compute_icp_blend_decision(odom, icp, true, 8, 0.018, &params);
+        assert_eq!(decision.alpha, 0.0, "XY must be rejected by high_error");
+        assert_eq!(decision.reason, "high_error");
+        assert!(
+            decision.alpha_yaw > 0.0,
+            "yaw must be admitted under looser reject_error_yaw"
+        );
+    }
+
+    #[test]
+    fn compute_icp_blend_decision_xy_low_motion_during_in_place_rotation() {
+        // Same in-place rotation regime but with default (equal) yaw thresholds.
+        // Even with default thresholds, the split motion gate should reject XY for
+        // low_motion (no translation) while yaw is still attenuated by motion ramp-up.
+        let params = default_icp();
+        let odom = MotionDelta {
+            x: 0.0,
+            y: 0.0,
+            yaw: 0.12,
+        };
+        let icp = MotionDelta {
+            x: 0.0,
+            y: 0.0,
+            yaw: 0.12,
+        };
+        let decision = compute_icp_blend_decision(odom, icp, true, 6, 0.006, &params);
+        assert_eq!(decision.alpha, 0.0);
+        assert_eq!(decision.reason, "low_motion");
+        assert!(decision.alpha_yaw > 0.0);
     }
 }

--- a/ros2_nodes/slam_node/src/main.rs
+++ b/ros2_nodes/slam_node/src/main.rs
@@ -384,6 +384,120 @@ fn translation_magnitude(delta: MotionDelta) -> f64 {
     delta.x.hypot(delta.y)
 }
 
+/// Rotate-and-translate a 2×N point cloud from body frame at `pose` into the world frame.
+///
+/// Each column is a 2D point `(x, y)` in `pose`'s body frame. Returns a fresh
+/// `2×N` matrix of the same points expressed in the world frame.
+#[allow(dead_code)] // wired into the scan callback in scan-to-map Phase 2.
+fn transform_scan_to_world(scan_body: &DMatrix<f64>, pose: Pose2D) -> DMatrix<f64> {
+    if scan_body.nrows() < 2 || scan_body.ncols() == 0 {
+        return DMatrix::zeros(scan_body.nrows().max(2), scan_body.ncols());
+    }
+    let cos_yaw = pose.yaw.cos();
+    let sin_yaw = pose.yaw.sin();
+    let mut out = DMatrix::zeros(2, scan_body.ncols());
+    for c in 0..scan_body.ncols() {
+        let bx = scan_body[(0, c)];
+        let by = scan_body[(1, c)];
+        out[(0, c)] = cos_yaw * bx - sin_yaw * by + pose.x;
+        out[(1, c)] = sin_yaw * bx + cos_yaw * by + pose.y;
+    }
+    out
+}
+
+/// Apply a world-frame rigid residual (2D rotation + translation) on top of a predicted pose.
+///
+/// Interpreted as: rotate the predicted position about the world origin by
+/// `residual.yaw`, then translate by `(residual.x, residual.y)`, and add
+/// `residual.yaw` to the predicted yaw. This is the inverse mapping of how
+/// scan-to-map ICP returns its residual (it rotates *points* in world frame).
+#[allow(dead_code)] // consumed by the scan-to-map blending seam in Phase 2.
+fn apply_world_residual(predicted: Pose2D, residual_world: MotionDelta) -> Pose2D {
+    let cos_yaw = residual_world.yaw.cos();
+    let sin_yaw = residual_world.yaw.sin();
+    Pose2D {
+        x: cos_yaw * predicted.x - sin_yaw * predicted.y + residual_world.x,
+        y: sin_yaw * predicted.x + cos_yaw * predicted.y + residual_world.y,
+        yaw: normalize_angle(predicted.yaw + residual_world.yaw),
+    }
+}
+
+/// Bound on the local submap used by scan-to-map ICP.
+///
+/// `max_points` caps point count so ICP cost stays predictable; `max_radius_m`
+/// is the L2 radius around `anchor` outside of which points are pruned, so the
+/// submap stays a *local* reference as the robot drives.
+#[allow(dead_code)] // populated by Phase 2 submap state plumbing.
+#[derive(Clone, Copy, Debug)]
+struct SubmapBudget {
+    max_points: usize,
+    max_radius_m: f64,
+}
+
+/// Append a new world-frame scan into the submap and prune to the budget.
+///
+/// Returns the merged + pruned submap. Pruning rule: drop any point whose L2
+/// distance from `(anchor.x, anchor.y)` exceeds `budget.max_radius_m`; then,
+/// if the result still exceeds `budget.max_points`, keep only the most
+/// recently appended `budget.max_points` columns (newest-first).
+#[allow(dead_code)] // submap maintenance is hooked up in Phase 2.
+fn append_and_prune(
+    existing: Option<DMatrix<f64>>,
+    new_world: &DMatrix<f64>,
+    anchor: Pose2D,
+    budget: SubmapBudget,
+) -> DMatrix<f64> {
+    let new_cols = if new_world.nrows() >= 2 {
+        new_world.ncols()
+    } else {
+        0
+    };
+    let existing_cols = match existing.as_ref() {
+        Some(m) if m.nrows() >= 2 => m.ncols(),
+        _ => 0,
+    };
+    let total = existing_cols + new_cols;
+    if total == 0 {
+        return DMatrix::zeros(2, 0);
+    }
+
+    let mut combined = DMatrix::zeros(2, total);
+    if let Some(m) = existing.as_ref() {
+        for c in 0..existing_cols {
+            combined[(0, c)] = m[(0, c)];
+            combined[(1, c)] = m[(1, c)];
+        }
+    }
+    for c in 0..new_cols {
+        combined[(0, existing_cols + c)] = new_world[(0, c)];
+        combined[(1, existing_cols + c)] = new_world[(1, c)];
+    }
+
+    // Radius prune around anchor.
+    let r2 = budget.max_radius_m * budget.max_radius_m;
+    let mut keep_idx: Vec<usize> = Vec::with_capacity(combined.ncols());
+    for c in 0..combined.ncols() {
+        let dx = combined[(0, c)] - anchor.x;
+        let dy = combined[(1, c)] - anchor.y;
+        if dx * dx + dy * dy <= r2 {
+            keep_idx.push(c);
+        }
+    }
+
+    // Cap to max_points by keeping the newest tail of survivors.
+    if budget.max_points > 0 && keep_idx.len() > budget.max_points {
+        let drop = keep_idx.len() - budget.max_points;
+        keep_idx.drain(0..drop);
+    }
+
+    let mut out = DMatrix::zeros(2, keep_idx.len());
+    for (j, &i) in keep_idx.iter().enumerate() {
+        out[(0, j)] = combined[(0, i)];
+        out[(1, j)] = combined[(1, i)];
+    }
+    out
+}
+
 fn ramp_weight(value: f64, full_weight_limit: f64, reject_limit: f64) -> f64 {
     if value <= full_weight_limit {
         1.0
@@ -1062,10 +1176,11 @@ fn main() -> Result<(), DynError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        blend_motion_delta, compose_pose_local, compute_icp_blend_decision,
-        format_slam_diagnostics, normalize_angle, odom_measurement_from_msg,
-        relative_motion_local, subsample_points_for_icp, IcpGatingParams, MotionDelta, Pose2D,
-        ScanDiagnostics, DEFAULT_BASE_FRAME_ID, DEFAULT_ICP_BLEND_ALPHA, DEFAULT_ODOM_FRAME_ID,
+        append_and_prune, apply_world_residual, blend_motion_delta, compose_pose_local,
+        compute_icp_blend_decision, format_slam_diagnostics, normalize_angle,
+        odom_measurement_from_msg, relative_motion_local, subsample_points_for_icp,
+        transform_scan_to_world, IcpGatingParams, MotionDelta, Pose2D, ScanDiagnostics,
+        SubmapBudget, DEFAULT_BASE_FRAME_ID, DEFAULT_ICP_BLEND_ALPHA, DEFAULT_ODOM_FRAME_ID,
     };
     use nalgebra::DMatrix;
     use safe_drive::msg::common_interfaces::nav_msgs;
@@ -1337,6 +1452,236 @@ mod tests {
             decision.alpha_yaw > 0.0,
             "yaw must be admitted under looser reject_error_yaw"
         );
+    }
+
+    #[test]
+    fn transform_scan_to_world_at_origin_is_identity() {
+        let scan = DMatrix::from_row_slice(2, 3, &[1.0, 0.0, -1.0, 0.0, 1.0, 0.0]);
+        let world = transform_scan_to_world(
+            &scan,
+            Pose2D {
+                x: 0.0,
+                y: 0.0,
+                yaw: 0.0,
+            },
+        );
+        assert_eq!(world.ncols(), 3);
+        for c in 0..3 {
+            assert!((world[(0, c)] - scan[(0, c)]).abs() < 1e-12);
+            assert!((world[(1, c)] - scan[(1, c)]).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn transform_scan_to_world_applies_translation_and_rotation() {
+        // Single body point at (+1, 0). Pose at (10, 20) facing +y (yaw=pi/2).
+        // After rotation, body +x becomes world +y; then translate to (10, 21).
+        let scan = DMatrix::from_row_slice(2, 1, &[1.0, 0.0]);
+        let world = transform_scan_to_world(
+            &scan,
+            Pose2D {
+                x: 10.0,
+                y: 20.0,
+                yaw: std::f64::consts::FRAC_PI_2,
+            },
+        );
+        assert!((world[(0, 0)] - 10.0).abs() < 1e-9);
+        assert!((world[(1, 0)] - 21.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn transform_scan_to_world_handles_empty_scan() {
+        let empty = DMatrix::zeros(2, 0);
+        let world = transform_scan_to_world(
+            &empty,
+            Pose2D {
+                x: 0.0,
+                y: 0.0,
+                yaw: 1.2,
+            },
+        );
+        assert_eq!(world.ncols(), 0);
+    }
+
+    #[test]
+    fn apply_world_residual_zero_is_identity() {
+        let predicted = Pose2D {
+            x: 1.0,
+            y: 2.0,
+            yaw: 0.3,
+        };
+        let out = apply_world_residual(
+            predicted,
+            MotionDelta {
+                x: 0.0,
+                y: 0.0,
+                yaw: 0.0,
+            },
+        );
+        assert!((out.x - 1.0).abs() < 1e-12);
+        assert!((out.y - 2.0).abs() < 1e-12);
+        assert!((out.yaw - 0.3).abs() < 1e-12);
+    }
+
+    #[test]
+    fn apply_world_residual_pure_translation_shifts_position_only() {
+        let predicted = Pose2D {
+            x: 1.0,
+            y: 2.0,
+            yaw: 0.3,
+        };
+        let out = apply_world_residual(
+            predicted,
+            MotionDelta {
+                x: 0.1,
+                y: -0.2,
+                yaw: 0.0,
+            },
+        );
+        assert!((out.x - 1.1).abs() < 1e-9);
+        assert!((out.y - 1.8).abs() < 1e-9);
+        assert!((out.yaw - 0.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn apply_world_residual_pure_rotation_rotates_position_about_origin() {
+        // Predicted pose at (1, 0). Residual is rotate by pi/2 about world origin.
+        // Expected new position: (0, 1). Yaw shifts from 0 to pi/2.
+        let predicted = Pose2D {
+            x: 1.0,
+            y: 0.0,
+            yaw: 0.0,
+        };
+        let out = apply_world_residual(
+            predicted,
+            MotionDelta {
+                x: 0.0,
+                y: 0.0,
+                yaw: std::f64::consts::FRAC_PI_2,
+            },
+        );
+        assert!(out.x.abs() < 1e-9);
+        assert!((out.y - 1.0).abs() < 1e-9);
+        assert!((out.yaw - std::f64::consts::FRAC_PI_2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn append_and_prune_into_empty_keeps_points_within_radius() {
+        let new_world = DMatrix::from_row_slice(2, 3, &[
+            0.0, 0.5, 5.0, //
+            0.0, 0.0, 0.0,
+        ]);
+        let anchor = Pose2D {
+            x: 0.0,
+            y: 0.0,
+            yaw: 0.0,
+        };
+        let out = append_and_prune(
+            None,
+            &new_world,
+            anchor,
+            SubmapBudget {
+                max_points: 0,
+                max_radius_m: 1.0,
+            },
+        );
+        // (0,0) and (0.5,0) survive, (5,0) is pruned.
+        assert_eq!(out.ncols(), 2);
+        assert!((out[(0, 0)] - 0.0).abs() < 1e-12);
+        assert!((out[(0, 1)] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn append_and_prune_concatenates_existing_and_new() {
+        let existing = DMatrix::from_row_slice(2, 2, &[0.1, 0.2, 0.0, 0.0]);
+        let new_world = DMatrix::from_row_slice(2, 2, &[0.3, 0.4, 0.0, 0.0]);
+        let out = append_and_prune(
+            Some(existing),
+            &new_world,
+            Pose2D {
+                x: 0.0,
+                y: 0.0,
+                yaw: 0.0,
+            },
+            SubmapBudget {
+                max_points: 0,
+                max_radius_m: 10.0,
+            },
+        );
+        assert_eq!(out.ncols(), 4);
+        // Insertion order is preserved: existing first, then new.
+        assert!((out[(0, 0)] - 0.1).abs() < 1e-12);
+        assert!((out[(0, 1)] - 0.2).abs() < 1e-12);
+        assert!((out[(0, 2)] - 0.3).abs() < 1e-12);
+        assert!((out[(0, 3)] - 0.4).abs() < 1e-12);
+    }
+
+    #[test]
+    fn append_and_prune_caps_to_max_points_keeping_newest_tail() {
+        let existing = DMatrix::from_row_slice(2, 3, &[0.10, 0.11, 0.12, 0.0, 0.0, 0.0]);
+        let new_world = DMatrix::from_row_slice(2, 2, &[0.20, 0.21, 0.0, 0.0]);
+        let out = append_and_prune(
+            Some(existing),
+            &new_world,
+            Pose2D {
+                x: 0.0,
+                y: 0.0,
+                yaw: 0.0,
+            },
+            SubmapBudget {
+                max_points: 3,
+                max_radius_m: 10.0,
+            },
+        );
+        // 5 total points, all within radius, cap to 3 keeping the 3 newest:
+        // drop existing[0]=0.10 and existing[1]=0.11; keep 0.12, 0.20, 0.21.
+        assert_eq!(out.ncols(), 3);
+        assert!((out[(0, 0)] - 0.12).abs() < 1e-12);
+        assert!((out[(0, 1)] - 0.20).abs() < 1e-12);
+        assert!((out[(0, 2)] - 0.21).abs() < 1e-12);
+    }
+
+    #[test]
+    fn append_and_prune_uses_anchor_for_radius_check() {
+        let new_world = DMatrix::from_row_slice(2, 3, &[
+            9.0, 10.0, 11.0, //
+            10.0, 10.0, 10.0,
+        ]);
+        let anchor = Pose2D {
+            x: 10.0,
+            y: 10.0,
+            yaw: 0.0,
+        };
+        let out = append_and_prune(
+            None,
+            &new_world,
+            anchor,
+            SubmapBudget {
+                max_points: 0,
+                max_radius_m: 1.5,
+            },
+        );
+        // All three are within 1.5 m of anchor (10,10): (9,10), (10,10), (11,10).
+        assert_eq!(out.ncols(), 3);
+    }
+
+    #[test]
+    fn append_and_prune_empty_inputs_return_empty_matrix() {
+        let empty = DMatrix::zeros(2, 0);
+        let out = append_and_prune(
+            None,
+            &empty,
+            Pose2D {
+                x: 0.0,
+                y: 0.0,
+                yaw: 0.0,
+            },
+            SubmapBudget {
+                max_points: 10,
+                max_radius_m: 1.0,
+            },
+        );
+        assert_eq!(out.ncols(), 0);
     }
 
     #[test]

--- a/ros2_nodes/slam_node/src/main.rs
+++ b/ros2_nodes/slam_node/src/main.rs
@@ -111,6 +111,36 @@ struct SlamState {
     previous_scan: Option<DMatrix<f64>>,
     previous_raw_odom_at_scan: Option<Pose2D>,
     last_icp_log_at: Option<Instant>,
+    /// Accumulated local point cloud in the corrected world frame. Only
+    /// populated when `SLAM_ICP_MODE=scan_to_map`.
+    local_submap_world: Option<DMatrix<f64>>,
+    /// Number of scans appended into `local_submap_world` since startup;
+    /// gates the bootstrap before scan-to-map ICP is allowed to run.
+    local_submap_scan_count: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum IcpMode {
+    ScanToScan,
+    ScanToMap,
+}
+
+impl IcpMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            IcpMode::ScanToScan => "scan_to_scan",
+            IcpMode::ScanToMap => "scan_to_map",
+        }
+    }
+}
+
+/// Submap tuning loaded from env at startup. Holds capacity bounds plus the
+/// bootstrap-scan count that gates scan-to-map ICP off until the submap has
+/// enough material to match against.
+#[derive(Clone, Copy, Debug)]
+struct SubmapParams {
+    budget: SubmapBudget,
+    bootstrap_scans: usize,
 }
 
 #[derive(Clone, Copy)]
@@ -133,6 +163,11 @@ struct ScanDiagnostics {
     blend_alpha_yaw: f64,
     gate_reason: &'static str,
     gate_reason_yaw: &'static str,
+    /// Which ICP target was matched against on this scan. Always reported so
+    /// downstream summarizers can split rows by mode without parsing env.
+    icp_mode: &'static str,
+    /// Submap point count after this scan was processed. 0 under scan_to_scan.
+    submap_points: usize,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -213,6 +248,45 @@ fn icp_point_stride_from_env() -> usize {
         .and_then(|raw| raw.trim().parse::<usize>().ok())
         .unwrap_or(1);
     s.clamp(1, 16)
+}
+
+/// Read `SLAM_ICP_MODE`. Default is scan-to-scan so the existing smoke and
+/// matrix paths behave identically when the flag is unset.
+fn icp_mode_from_env() -> IcpMode {
+    match env::var("SLAM_ICP_MODE").ok().as_deref() {
+        Some(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+            "scan_to_map" | "scan-to-map" | "scantomap" => IcpMode::ScanToMap,
+            _ => IcpMode::ScanToScan,
+        },
+        None => IcpMode::ScanToScan,
+    }
+}
+
+const DEFAULT_SUBMAP_MAX_POINTS: usize = 6_400;
+const DEFAULT_SUBMAP_RADIUS_M: f64 = 3.0;
+const DEFAULT_SUBMAP_BOOTSTRAP_SCANS: usize = 3;
+
+fn submap_params_from_env() -> SubmapParams {
+    let max_points = env::var("SLAM_SUBMAP_MAX_POINTS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_SUBMAP_MAX_POINTS);
+    let max_radius_m = env::var("SLAM_SUBMAP_RADIUS_M")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<f64>().ok())
+        .filter(|v| v.is_finite() && *v > 0.0)
+        .unwrap_or(DEFAULT_SUBMAP_RADIUS_M);
+    let bootstrap_scans = env::var("SLAM_SUBMAP_BOOTSTRAP_SCANS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_SUBMAP_BOOTSTRAP_SCANS);
+    SubmapParams {
+        budget: SubmapBudget {
+            max_points,
+            max_radius_m,
+        },
+        bootstrap_scans,
+    }
 }
 
 fn copy_stamp(
@@ -388,7 +462,6 @@ fn translation_magnitude(delta: MotionDelta) -> f64 {
 ///
 /// Each column is a 2D point `(x, y)` in `pose`'s body frame. Returns a fresh
 /// `2×N` matrix of the same points expressed in the world frame.
-#[allow(dead_code)] // wired into the scan callback in scan-to-map Phase 2.
 fn transform_scan_to_world(scan_body: &DMatrix<f64>, pose: Pose2D) -> DMatrix<f64> {
     if scan_body.nrows() < 2 || scan_body.ncols() == 0 {
         return DMatrix::zeros(scan_body.nrows().max(2), scan_body.ncols());
@@ -411,7 +484,6 @@ fn transform_scan_to_world(scan_body: &DMatrix<f64>, pose: Pose2D) -> DMatrix<f6
 /// `residual.yaw`, then translate by `(residual.x, residual.y)`, and add
 /// `residual.yaw` to the predicted yaw. This is the inverse mapping of how
 /// scan-to-map ICP returns its residual (it rotates *points* in world frame).
-#[allow(dead_code)] // consumed by the scan-to-map blending seam in Phase 2.
 fn apply_world_residual(predicted: Pose2D, residual_world: MotionDelta) -> Pose2D {
     let cos_yaw = residual_world.yaw.cos();
     let sin_yaw = residual_world.yaw.sin();
@@ -427,7 +499,6 @@ fn apply_world_residual(predicted: Pose2D, residual_world: MotionDelta) -> Pose2
 /// `max_points` caps point count so ICP cost stays predictable; `max_radius_m`
 /// is the L2 radius around `anchor` outside of which points are pruned, so the
 /// submap stays a *local* reference as the robot drives.
-#[allow(dead_code)] // populated by Phase 2 submap state plumbing.
 #[derive(Clone, Copy, Debug)]
 struct SubmapBudget {
     max_points: usize,
@@ -747,6 +818,8 @@ fn format_slam_diagnostics(
         format!("raw_frame={}", raw_frame_id),
         format!("corrected_mode={}", corrected_mode),
         format!("scan_points={}", diagnostics.scan_points),
+        format!("icp_mode={}", diagnostics.icp_mode),
+        format!("submap_points={}", diagnostics.submap_points),
         format!("icp_converged={}", diagnostics.icp_converged),
         format!("icp_iterations={}", diagnostics.icp_iterations),
         format!("icp_error_mean={:.4}", diagnostics.icp_final_error),
@@ -908,6 +981,8 @@ fn main() -> Result<(), DynError> {
         previous_scan: None,
         previous_raw_odom_at_scan: None,
         last_icp_log_at: None,
+        local_submap_world: None,
+        local_submap_scan_count: 0,
     }));
 
     let logger = Logger::new("slam_node");
@@ -931,6 +1006,18 @@ fn main() -> Result<(), DynError> {
             icp_params.max_yaw_correction,
             icp_params.full_weight_translation_motion,
             icp_params.full_weight_yaw_motion
+        );
+    }
+    let icp_mode = icp_mode_from_env();
+    let submap_params = submap_params_from_env();
+    if use_corrected_frame {
+        pr_info!(
+            logger,
+            "ICP mode={} (submap max_points={} radius_m={:.2} bootstrap_scans={})",
+            icp_mode.as_str(),
+            submap_params.budget.max_points,
+            submap_params.budget.max_radius_m,
+            submap_params.bootstrap_scans
         );
     }
     let icp_point_stride = icp_point_stride_from_env();
@@ -957,6 +1044,8 @@ fn main() -> Result<(), DynError> {
     let state_scan = state.clone();
     let icp_params_scan = icp_params;
     let icp_stride_scan = icp_point_stride;
+    let icp_mode_scan = icp_mode;
+    let submap_params_scan = submap_params;
     let pub_scan = map_pub;
     let pub_pose = corrected_pose_pub;
     let pub_odom = corrected_odom_pub;
@@ -990,6 +1079,9 @@ fn main() -> Result<(), DynError> {
             let raw_odom = st.raw_odom.clone();
             let raw_pose = raw_odom.pose;
             let had_previous_scan = st.previous_scan.is_some();
+            let odom_delta = st
+                .previous_raw_odom_at_scan
+                .map(|previous_raw_odom| relative_motion_local(previous_raw_odom, raw_pose));
             let mut icp_converged = false;
             let mut icp_iterations = 0;
             let mut icp_final_error = f64::NAN;
@@ -998,9 +1090,37 @@ fn main() -> Result<(), DynError> {
             let mut icp_error_p90 = f64::NAN;
             let mut icp_inlier_ratio_5cm = f64::NAN;
             let mut icp_relative_error_reduction = f64::NAN;
-            let mut icp_delta = None;
-            if let Some(previous) = st.previous_scan.as_ref() {
-                let icp_result = icp_matching(previous, &current_scan);
+            let mut icp_delta: Option<MotionDelta> = None;
+            let prev_corrected = st.corrected_pose;
+            let icp_result_opt = match icp_mode_scan {
+                IcpMode::ScanToScan => st
+                    .previous_scan
+                    .as_ref()
+                    .map(|previous| icp_matching(previous, &current_scan)),
+                IcpMode::ScanToMap => {
+                    // Need the submap warmed up plus an odom delta to seed the prediction.
+                    let bootstrap_done = st.corrected_initialized
+                        && st.local_submap_scan_count >= submap_params_scan.bootstrap_scans;
+                    match (st.local_submap_world.as_ref(), odom_delta, bootstrap_done) {
+                        (Some(submap), Some(od), true) => {
+                            let predicted = compose_pose_local(prev_corrected, od);
+                            let current_world = transform_scan_to_world(&current_scan, predicted);
+                            let result = icp_matching(submap, &current_world);
+                            if let Some(residual_world) = icp_motion_delta(&result) {
+                                let corrected_candidate =
+                                    apply_world_residual(predicted, residual_world);
+                                icp_delta = Some(relative_motion_local(
+                                    prev_corrected,
+                                    corrected_candidate,
+                                ));
+                            }
+                            Some(result)
+                        }
+                        _ => None,
+                    }
+                }
+            };
+            if let Some(icp_result) = icp_result_opt {
                 icp_converged = icp_result.converged;
                 icp_iterations = icp_result.iterations;
                 icp_final_error = icp_result.final_error_mean;
@@ -1009,7 +1129,11 @@ fn main() -> Result<(), DynError> {
                 icp_error_p90 = icp_result.final_error_p90;
                 icp_inlier_ratio_5cm = icp_result.inlier_ratio_5cm;
                 icp_relative_error_reduction = icp_result.relative_error_reduction;
-                icp_delta = icp_motion_delta(&icp_result);
+                // For scan-to-scan, derive the per-scan body delta directly. For
+                // scan-to-map, icp_delta is already set above from the world residual.
+                if matches!(icp_mode_scan, IcpMode::ScanToScan) {
+                    icp_delta = icp_motion_delta(&icp_result);
+                }
                 let now = Instant::now();
                 if !icp_result.converged {
                     pr_warn!(
@@ -1031,10 +1155,6 @@ fn main() -> Result<(), DynError> {
                     st.last_icp_log_at = Some(now);
                 }
             }
-
-            let odom_delta = st
-                .previous_raw_odom_at_scan
-                .map(|previous_raw_odom| relative_motion_local(previous_raw_odom, raw_pose));
             let mut applied_delta = None;
             let mut blend_applied = false;
             let mut blend_alpha = 0.0;
@@ -1102,6 +1222,25 @@ fn main() -> Result<(), DynError> {
                 msg.angle_increment as f64,
             );
 
+            // Maintain the local submap *after* the corrected pose has been updated for
+            // this scan, so the appended points reflect the just-corrected pose.
+            if matches!(icp_mode_scan, IcpMode::ScanToMap) && st.corrected_initialized {
+                let anchor = st.corrected_pose;
+                let scan_world_corrected = transform_scan_to_world(&current_scan, anchor);
+                let new_submap = append_and_prune(
+                    st.local_submap_world.take(),
+                    &scan_world_corrected,
+                    anchor,
+                    submap_params_scan.budget,
+                );
+                st.local_submap_world = Some(new_submap);
+                st.local_submap_scan_count = st.local_submap_scan_count.saturating_add(1);
+            }
+            let submap_points = st
+                .local_submap_world
+                .as_ref()
+                .map_or(0, |m| m.ncols());
+
             let frame_id = if use_corrected_frame {
                 corrected_frame_id.clone()
             } else {
@@ -1156,6 +1295,8 @@ fn main() -> Result<(), DynError> {
                     blend_alpha_yaw,
                     gate_reason,
                     gate_reason_yaw,
+                    icp_mode: icp_mode_scan.as_str(),
+                    submap_points,
                 },
                 icp_params_scan.blend_alpha,
             );
@@ -1408,10 +1549,14 @@ mod tests {
                 blend_alpha_yaw: DEFAULT_ICP_BLEND_ALPHA,
                 gate_reason: "accepted",
                 gate_reason_yaw: "accepted",
+                icp_mode: "scan_to_scan",
+                submap_points: 0,
             },
             DEFAULT_ICP_BLEND_ALPHA,
         );
         assert!(text.contains("status=icp_ok"));
+        assert!(text.contains("icp_mode=scan_to_scan"));
+        assert!(text.contains("submap_points=0"));
         assert!(text.contains("icp_error_mean=0.006"));
         assert!(text.contains("icp_error_p90=0.010"));
         assert!(text.contains("icp_inlier_ratio_5cm=0.950"));

--- a/ros2_nodes/slam_node/src/main.rs
+++ b/ros2_nodes/slam_node/src/main.rs
@@ -114,6 +114,11 @@ struct ScanDiagnostics {
     icp_converged: bool,
     icp_iterations: usize,
     icp_final_error: f64,
+    icp_initial_error: f64,
+    icp_error_median: f64,
+    icp_error_p90: f64,
+    icp_inlier_ratio_5cm: f64,
+    icp_relative_error_reduction: f64,
     odom_delta: Option<MotionDelta>,
     icp_delta: Option<MotionDelta>,
     applied_delta: Option<MotionDelta>,
@@ -574,6 +579,14 @@ fn format_slam_diagnostics(
         format!("icp_converged={}", diagnostics.icp_converged),
         format!("icp_iterations={}", diagnostics.icp_iterations),
         format!("icp_error_mean={:.4}", diagnostics.icp_final_error),
+        format!("icp_initial_error_mean={:.4}", diagnostics.icp_initial_error),
+        format!("icp_error_median={:.4}", diagnostics.icp_error_median),
+        format!("icp_error_p90={:.4}", diagnostics.icp_error_p90),
+        format!("icp_inlier_ratio_5cm={:.3}", diagnostics.icp_inlier_ratio_5cm),
+        format!(
+            "icp_relative_error_reduction={:.3}",
+            diagnostics.icp_relative_error_reduction
+        ),
         format!("blend_applied={}", diagnostics.blend_applied),
         format!("blend_alpha={:.3}", diagnostics.blend_alpha),
         format!("gate_reason={}", diagnostics.gate_reason),
@@ -807,12 +820,22 @@ fn main() -> Result<(), DynError> {
             let mut icp_converged = false;
             let mut icp_iterations = 0;
             let mut icp_final_error = f64::NAN;
+            let mut icp_initial_error = f64::NAN;
+            let mut icp_error_median = f64::NAN;
+            let mut icp_error_p90 = f64::NAN;
+            let mut icp_inlier_ratio_5cm = f64::NAN;
+            let mut icp_relative_error_reduction = f64::NAN;
             let mut icp_delta = None;
             if let Some(previous) = st.previous_scan.as_ref() {
                 let icp_result = icp_matching(previous, &current_scan);
                 icp_converged = icp_result.converged;
                 icp_iterations = icp_result.iterations;
                 icp_final_error = icp_result.final_error_mean;
+                icp_initial_error = icp_result.initial_error_mean;
+                icp_error_median = icp_result.final_error_median;
+                icp_error_p90 = icp_result.final_error_p90;
+                icp_inlier_ratio_5cm = icp_result.inlier_ratio_5cm;
+                icp_relative_error_reduction = icp_result.relative_error_reduction;
                 icp_delta = icp_motion_delta(&icp_result);
                 let now = Instant::now();
                 if !icp_result.converged {
@@ -935,6 +958,11 @@ fn main() -> Result<(), DynError> {
                     icp_converged,
                     icp_iterations,
                     icp_final_error,
+                    icp_initial_error,
+                    icp_error_median,
+                    icp_error_p90,
+                    icp_inlier_ratio_5cm,
+                    icp_relative_error_reduction,
                     odom_delta,
                     icp_delta,
                     applied_delta,
@@ -1161,6 +1189,11 @@ mod tests {
                 icp_converged: true,
                 icp_iterations: 7,
                 icp_final_error: 0.006,
+                icp_initial_error: 0.040,
+                icp_error_median: 0.005,
+                icp_error_p90: 0.010,
+                icp_inlier_ratio_5cm: 0.950,
+                icp_relative_error_reduction: 0.850,
                 odom_delta: Some(MotionDelta {
                     x: 0.1,
                     y: 0.0,
@@ -1184,6 +1217,9 @@ mod tests {
         );
         assert!(text.contains("status=icp_ok"));
         assert!(text.contains("icp_error_mean=0.006"));
+        assert!(text.contains("icp_error_p90=0.010"));
+        assert!(text.contains("icp_inlier_ratio_5cm=0.950"));
+        assert!(text.contains("icp_relative_error_reduction=0.850"));
         assert!(text.contains("scan_points=42"));
         assert!(text.contains("odom_dx=0.100"));
         assert!(text.contains("applied_dyaw=0.015"));

--- a/scripts/summarize_slam_revaluation.py
+++ b/scripts/summarize_slam_revaluation.py
@@ -64,6 +64,8 @@ class ProfileSummary:
     completed: int = 0
     better_xy: int = 0
     improvements: list[float] = field(default_factory=list)
+    icp_error_p90_values: list[float] = field(default_factory=list)
+    icp_inlier_ratio_values: list[float] = field(default_factory=list)
     gate_counts: Counter = field(default_factory=Counter)
     status_counts: Counter = field(default_factory=Counter)
 
@@ -72,6 +74,12 @@ class ProfileSummary:
         self.completed += int(parse_bool(row.get("mission_completed", "")))
         self.better_xy += int(parse_bool(row.get("slam_better_xy", "")))
         self.improvements.append(parse_float(row.get("improvement_xy", "")))
+        if row.get("icp_error_p90"):
+            self.icp_error_p90_values.append(parse_float(row.get("icp_error_p90", "")))
+        if row.get("icp_inlier_ratio_5cm"):
+            self.icp_inlier_ratio_values.append(
+                parse_float(row.get("icp_inlier_ratio_5cm", ""))
+            )
         self.gate_counts.update(parse_counts(row.get("gate_reason_counts", "")))
         self.status_counts.update(parse_counts(row.get("diagnostics_status_counts", "")))
 
@@ -88,6 +96,18 @@ class ProfileSummary:
     @property
     def max_improvement(self) -> float:
         return max(self.improvements) if self.improvements else 0.0
+
+    @property
+    def avg_icp_error_p90(self) -> float:
+        if not self.icp_error_p90_values:
+            return 0.0
+        return sum(self.icp_error_p90_values) / len(self.icp_error_p90_values)
+
+    @property
+    def avg_icp_inlier_ratio(self) -> float:
+        if not self.icp_inlier_ratio_values:
+            return 0.0
+        return sum(self.icp_inlier_ratio_values) / len(self.icp_inlier_ratio_values)
 
 
 def load_rows(paths: list[Path]) -> list[dict[str, str]]:
@@ -143,9 +163,9 @@ def print_profile_summary(rows: list[dict[str, str]]) -> None:
     print("Profile summary")
     print(
         f"{'odom_profile':<24} {'profile':<18} {'completed':>11} {'better_xy':>10} "
-        f"{'avg_xy':>9} {'min_xy':>9} {'max_xy':>9} gate_counts"
+        f"{'avg_xy':>9} {'min_xy':>9} {'max_xy':>9} {'icp_p90':>9} {'inlier':>8} gate_counts"
     )
-    print("-" * 122)
+    print("-" * 141)
     for (odom_profile, profile), summary in sorted(
         summaries.items(), key=profile_sort_key
     ):
@@ -157,6 +177,8 @@ def print_profile_summary(rows: list[dict[str, str]]) -> None:
             f"{summary.avg_improvement:>9.4f} "
             f"{summary.min_improvement:>9.4f} "
             f"{summary.max_improvement:>9.4f} "
+            f"{summary.avg_icp_error_p90:>9.4f} "
+            f"{summary.avg_icp_inlier_ratio:>8.3f} "
             f"{format_counts(summary.gate_counts)}"
         )
 


### PR DESCRIPTION
## Summary

This branch consolidates the 2026-05 corrected-SLAM tuning sprint plus the first two phases of the scan-to-map ICP redesign. All new behavior is opt-in via env flags; smoke / synthetic / matrix paths are byte-identical to main when no flag is set.

### Split-gate ICP and tuning findings
- Per-axis gate: `compute_icp_blend_decision` + `blend_motion_delta` now run XY and yaw independently with their own `SLAM_ICP_REJECT_ERROR*` / `SLAM_ICP_BLEND_ALPHA*` thresholds.
- New profiles `yaw_loose_018` and `yaw_loose_018_low_alpha` produce the first biased-odom XY wins of the sprint:
  - `yaw_loose_018 × yaw_drift_3deg_per_m`: 3/4 scenarios beat raw XY (+2.0 mm avg), yaw regresses -21 mrad.
  - `yaw_loose_018 × yaw_drift_1deg_per_m`: **4/4 scenarios beat raw XY** (+2.7 mm avg), yaw essentially flat (-1 mrad). XY win does NOT scale linearly with drift.
  - `yaw_loose_018_low_alpha`: trades XY win for yaw safety (-5 mrad at 3°/m).
- `loose_error*` / `very_loose_error` retired from the tuning matrix (strictly worse on every comparison).
- `rich_geometry_turns` positive-control scenario added.
- Mission-window diagnostics capture fix in `run_navigation_smoke_test.sh` (prior reports were stationary-only).
- Matrix script writes a partial CSV/JSONL row tagged `exit_code=killed` when SIGTERM'd mid-scenario (CI step timeout, ^C, etc.).

### Scan-to-map ICP foundation (Phase 1 + 2 of multi-week redesign)
- Design doc: `docs/scan_to_map_icp_design.md` — rationale, data structures, 5-phase rollout plan.
- Phase 1 helpers (pure, unit-tested): `transform_scan_to_world`, `apply_world_residual`, `append_and_prune` + `SubmapBudget`.
- Phase 2 plumbing: `SLAM_ICP_MODE=scan_to_scan|scan_to_map` switch (default scan-to-scan), submap state in `SlamState`, scan-callback branch, `icp_mode` + `submap_points` fields on `/slam_diagnostics`.

### Other
- Synthetic SLAM ICP positive-control smoke (`run_slam_icp_acceptance_test.sh`).
- Biased odom revaluation profiles (xy_scale, yaw_drift, turn_yaw_scale).
- Sliced matrix runs via `SLAM_REVALUATION_START_INDEX` / `MAX_RUNS` for CI step-timeout fit.

## Test plan
- [x] `cargo test` slam_node bins: 25/25 pass (includes 8 new helper tests)
- [x] `cargo build --manifest-path ros2_nodes/slam_node/Cargo.toml` clean
- [x] Default `SLAM_ICP_MODE` is scan-to-scan; existing smoke and matrix behavior unchanged
- [x] Matrix sliced sweep (indices 88-95) verified end-to-end on CI (run 26077863455)
- [ ] CI on this PR: build → test → headless examples → clippy → rustdoc → fmt → cargo-deny
- [ ] ROS2 Smoke workflow on the PR