### PR TITLE
Add documentation comment to error module

### DIFF
--- a/crates/rust_robotics_core/src/lib.rs
+++ b/crates/rust_robotics_core/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 //! Core types, traits, and error definitions for the RustRobotics workspace.
 
+/// Error types and definitions for the RustRobotics workspace.
 pub mod error;
 pub mod experiments;
 pub mod traits;


### PR DESCRIPTION
## Problem Background
The public `error` module in `rust_robotics_core` lacks documentation comments, which reduces code readability and maintainability. This is particularly important in a large robotics repository with 100+ algorithms, as clear documentation helps contributors understand the codebase.

## Changes Made
Added a documentation comment to the `pub mod error;` declaration in `crates/rust_robotics_core/src/lib.rs`. The comment reads: `/// Error types and definitions for the RustRobotics workspace.`

## Verification
- The change is purely additive (documentation only) and does not alter the module's functionality or public API.
- Verified by ensuring the code compiles successfully with `cargo build` and that no existing tests are broken.
- Documentation comments follow Rust conventions and will be picked up by `cargo doc` for better tooling support.