### PR TITLE
Improve adoption and release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Exact workspace version to release (for example 0.2.0)"
+        required: true
+        type: string
+      publish:
+        description: "Publish crates and create the GitHub Release"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: rust-robotics-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: crates-io
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Verify requested version
+      shell: bash
+      run: |
+        actual="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
+        test "$actual" = "${{ inputs.version }}" || {
+          echo "requested ${{ inputs.version }}, but workspace version is $actual" >&2
+          exit 1
+        }
+        test "$GITHUB_REF_NAME" = "main" || {
+          echo "releases must run from main (selected: $GITHUB_REF_NAME)" >&2
+          exit 1
+        }
+
+    - name: Run release preflight
+      run: bash scripts/publish_workspace.sh --check
+
+    - name: Publish workspace crates
+      if: inputs.publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: bash scripts/publish_workspace.sh --publish
+
+    - name: Create tag and GitHub Release
+      if: inputs.publish
+      env:
+        GH_TOKEN: ${{ github.token }}
+        VERSION: ${{ inputs.version }}
+      shell: bash
+      run: |
+        tag="v${VERSION}"
+        if git rev-parse "$tag" >/dev/null 2>&1; then
+          test "$(git rev-list -n 1 "$tag")" = "$GITHUB_SHA" || {
+            echo "$tag already points to a different commit" >&2
+            exit 1
+          }
+        else
+          git tag "$tag" "$GITHUB_SHA"
+          git push origin "$tag"
+        fi
+        gh release view "$tag" >/dev/null 2>&1 || \
+          gh release create "$tag" --verify-tag --generate-notes --title "$tag"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-06-17
+## [0.2.0] - 2026-07-15
 
 ### Added
 - **`no_std` localization stack.** `rust_robotics_core` and
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   EKF-SLAM, FastSLAM 1.0, and ICP scan matching (landmarks, particles, aligned scans).
 - Playground **ADMM Formation** tab: receding-horizon consensus ADMM with four
   agents, stiff vs smoothed overlay, noise slider, and jerk/tracking metrics.
+- Reproducible playground links: the selected tab is shareable, and grid-planner
+  links preserve the planner, start/goal cells, and complete obstacle map.
+- Guarded release workflow for dependency-ordered workspace publishing,
+  crates.io propagation checks, tagging, and GitHub Release creation.
 
 ### Fixed
 - `RRTPlanner::planning()` now records the search tree so `get_tree()` exposes

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ RustRobotics is a library-first Rust workspace for robotics algorithms, inspired
 [PythonRobotics](https://github.com/AtsushiSakai/PythonRobotics) and extended with
 benchmarks, ROS2/Gazebo demos, and a visual showcase.
 
+<p align="center">
+  <a href="https://rsasaki0109.github.io/rust_robotics/playground/"><b>Run in your browser</b></a>
+  ·
+  <a href="#quick-start"><b>Use the Rust crate</b></a>
+  ·
+  <a href="#embedded--no_std"><b>Run on a microcontroller</b></a>
+  ·
+  <a href="https://rsasaki0109.github.io/rust_robotics/"><b>Browse the gallery</b></a>
+</p>
+
 <table>
   <tr>
     <td align="center"><a href="#rapidly-exploring-random-trees-rrt"><img src="./media/gallery/rrt.gif" width="260" alt="RRT tree growth"/></a><br/><b>RRT</b></td>
@@ -67,7 +77,18 @@ Open the visual gallery: <https://rsasaki0109.github.io/rust_robotics/>
 
 ## Quick Start
 
-Run a headless planner demo with no GUI dependencies:
+Try the interactive planners, localization, SLAM, and multi-agent formation
+demo with no installation:
+
+<https://rsasaki0109.github.io/rust_robotics/playground/>
+
+Add the latest published umbrella crate:
+
+```bash
+cargo add rust_robotics --features planning
+```
+
+Then run a headless planner demo from this repository with no GUI dependencies:
 
 ```bash
 git clone https://github.com/rsasaki0109/rust_robotics.git
@@ -94,15 +115,13 @@ cargo test --workspace --lib --tests
 
 ## Use As A Library
 
-Add the umbrella crate from crates.io (or the Git repository until the first
-release is indexed):
+Add the latest published umbrella crate from crates.io:
 
-```toml
-[dependencies]
-rust_robotics = "0.1"
+```bash
+cargo add rust_robotics --features "planning,localization,control"
 ```
 
-If you need unreleased changes before crates.io propagation finishes:
+If you need changes that have not reached crates.io yet:
 
 ```toml
 [dependencies]

--- a/crates/rust_robotics_playground/Cargo.toml
+++ b/crates/rust_robotics_playground/Cargo.toml
@@ -29,7 +29,7 @@ eframe = { version = "0.31", default-features = false, features = ["default_font
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1"
 getrandom = { version = "0.3", features = ["wasm_js"] }
-web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Element"] }
+web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Element", "History", "Location"] }
 wasm-bindgen = "0.2"
 
 [features]

--- a/crates/rust_robotics_playground/README.md
+++ b/crates/rust_robotics_playground/README.md
@@ -28,6 +28,14 @@ RUSTFLAGS='--cfg getrandom_backend="wasm_js"' trunk build --release --public-url
 
 Live demo: https://rsasaki0109.github.io/rust_robotics/playground/
 
+## Reproducible links
+
+Use **Copy share link** in the header to copy a URL for the active demo. Grid
+planner links preserve the selected planner, start and goal cells, and the full
+obstacle map, so another visitor opens the same planning problem. For example,
+`?tab=grid&planner=theta&start=2,12&goal=29,12&map=...` opens a reproducible
+Theta* scenario. The other tabs currently preserve the selected demo tab.
+
 ## Tabs
 
 - **Grid Planners** — A\*, Dijkstra, JPS, Theta\* with click-to-edit obstacles.

--- a/crates/rust_robotics_playground/src/app.rs
+++ b/crates/rust_robotics_playground/src/app.rs
@@ -19,16 +19,24 @@ pub struct PlaygroundApp {
     localization_demo: LocalizationDemo,
     slam_demo: SlamDemo,
     admm_demo: AdmmFormationDemo,
+    share_status: Option<&'static str>,
 }
 
 impl PlaygroundApp {
     pub fn new(_ctx: &eframe::CreationContext<'_>) -> Self {
+        let query = crate::share::current_query();
+        let tab = crate::share::value(&query, "tab")
+            .and_then(PlaygroundTab::from_slug)
+            .unwrap_or(PlaygroundTab::GridPlanners);
+        let mut grid_demo = GridPlannerDemo::default();
+        grid_demo.apply_share_query(&query);
         Self {
-            tab: PlaygroundTab::GridPlanners,
-            grid_demo: GridPlannerDemo::default(),
+            tab,
+            grid_demo,
             localization_demo: LocalizationDemo::default(),
             slam_demo: SlamDemo::default(),
             admm_demo: AdmmFormationDemo::default(),
+            share_status: None,
         }
     }
 
@@ -38,6 +46,13 @@ impl PlaygroundApp {
             PlaygroundTab::Localization => "Localization",
             PlaygroundTab::Slam => "SLAM",
             PlaygroundTab::AdmmFormation => "ADMM Formation",
+        }
+    }
+
+    fn share_query(&self) -> String {
+        match self.tab {
+            PlaygroundTab::GridPlanners => self.grid_demo.share_query(),
+            tab => format!("tab={}", tab.slug()),
         }
     }
 
@@ -59,6 +74,27 @@ impl PlaygroundApp {
     }
 }
 
+impl PlaygroundTab {
+    fn slug(self) -> &'static str {
+        match self {
+            Self::GridPlanners => "grid",
+            Self::Localization => "localization",
+            Self::Slam => "slam",
+            Self::AdmmFormation => "admm",
+        }
+    }
+
+    fn from_slug(value: &str) -> Option<Self> {
+        match value {
+            "grid" => Some(Self::GridPlanners),
+            "localization" => Some(Self::Localization),
+            "slam" => Some(Self::Slam),
+            "admm" => Some(Self::AdmmFormation),
+            _ => None,
+        }
+    }
+}
+
 impl eframe::App for PlaygroundApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::TopBottomPanel::top("header").show(ctx, |ui| {
@@ -76,7 +112,17 @@ impl eframe::App for PlaygroundApp {
                         .clicked()
                     {
                         self.tab = tab;
+                        self.share_status = None;
                     }
+                }
+                ui.separator();
+                if ui.button("Copy share link").clicked() {
+                    let url = crate::share::share_url(&self.share_query());
+                    ctx.copy_text(url);
+                    self.share_status = Some("Copied!");
+                }
+                if let Some(status) = self.share_status {
+                    ui.label(status);
                 }
             });
             ui.label(Self::tab_hint(self.tab));

--- a/crates/rust_robotics_playground/src/grid_planners.rs
+++ b/crates/rust_robotics_playground/src/grid_planners.rs
@@ -34,6 +34,25 @@ impl PlannerKind {
             Self::ThetaStar => "Theta*",
         }
     }
+
+    fn slug(self) -> &'static str {
+        match self {
+            Self::AStar => "astar",
+            Self::Dijkstra => "dijkstra",
+            Self::Jps => "jps",
+            Self::ThetaStar => "theta",
+        }
+    }
+
+    fn from_slug(value: &str) -> Option<Self> {
+        match value {
+            "astar" => Some(Self::AStar),
+            "dijkstra" => Some(Self::Dijkstra),
+            "jps" => Some(Self::Jps),
+            "theta" => Some(Self::ThetaStar),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -89,6 +108,87 @@ impl Default for GridPlannerDemo {
 }
 
 impl GridPlannerDemo {
+    pub(crate) fn apply_share_query(&mut self, query: &str) {
+        if let Some(planner) =
+            crate::share::value(query, "planner").and_then(PlannerKind::from_slug)
+        {
+            self.planner = planner;
+        }
+        if let Some(map) = crate::share::value(query, "map").and_then(Self::decode_map) {
+            self.obstacles = map;
+        }
+        if let Some(start) = crate::share::value(query, "start").and_then(Self::decode_point) {
+            if !self.obstacles[start.0][start.1] {
+                self.start = start;
+            }
+        }
+        if let Some(goal) = crate::share::value(query, "goal").and_then(Self::decode_point) {
+            if !self.obstacles[goal.0][goal.1] {
+                self.goal = goal;
+            }
+        }
+        self.compare_results.clear();
+        self.replan();
+    }
+
+    pub(crate) fn share_query(&self) -> String {
+        format!(
+            "tab=grid&planner={}&start={},{}&goal={},{}&map={}",
+            self.planner.slug(),
+            self.start.0,
+            self.start.1,
+            self.goal.0,
+            self.goal.1,
+            self.encode_map()
+        )
+    }
+
+    fn decode_point(value: &str) -> Option<(usize, usize)> {
+        let (x, y) = value.split_once(',')?;
+        let point = (x.parse().ok()?, y.parse().ok()?);
+        (point.0 < GRID_W && point.1 < GRID_H).then_some(point)
+    }
+
+    fn encode_map(&self) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut encoded = String::with_capacity(GRID_W * GRID_H / 4);
+        for group in 0..(GRID_W * GRID_H / 4) {
+            let mut nibble = 0_u8;
+            for bit in 0..4 {
+                let index = group * 4 + bit;
+                let x = index % GRID_W;
+                let y = index / GRID_W;
+                if self.obstacles[x][y] {
+                    nibble |= 1 << bit;
+                }
+            }
+            encoded.push(HEX[nibble as usize] as char);
+        }
+        encoded
+    }
+
+    fn decode_map(value: &str) -> Option<Vec<Vec<bool>>> {
+        if value.len() != GRID_W * GRID_H / 4 {
+            return None;
+        }
+        let mut obstacles = vec![vec![false; GRID_H]; GRID_W];
+        for (group, digit) in value.bytes().enumerate() {
+            let nibble = match digit {
+                b'0'..=b'9' => digit - b'0',
+                b'a'..=b'f' => digit - b'a' + 10,
+                b'A'..=b'F' => digit - b'A' + 10,
+                _ => return None,
+            };
+            for bit in 0..4 {
+                let index = group * 4 + bit;
+                let x = index % GRID_W;
+                let y = index / GRID_W;
+                obstacles[x][y] = nibble & (1 << bit) != 0;
+            }
+        }
+        Some(obstacles)
+    }
+
     fn set_border_obstacles(&mut self) {
         for x in 0..GRID_W {
             self.obstacles[x][0] = true;
@@ -479,5 +579,33 @@ impl GridPlannerDemo {
         let response = ui.allocate_rect(rect, Sense::click_and_drag());
         self.handle_pointer(rect, cell, &response);
         self.draw_grid(ui, rect, cell);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GridPlannerDemo, PlannerKind};
+
+    #[test]
+    fn shared_grid_state_round_trips() {
+        let original = GridPlannerDemo::default();
+        let query = original.share_query();
+        let mut restored = GridPlannerDemo::default();
+        restored.clear_interior();
+        restored.apply_share_query(&query);
+
+        assert_eq!(restored.planner, PlannerKind::AStar);
+        assert_eq!(restored.start, original.start);
+        assert_eq!(restored.goal, original.goal);
+        assert_eq!(restored.obstacles, original.obstacles);
+    }
+
+    #[test]
+    fn malformed_shared_state_is_ignored() {
+        let mut demo = GridPlannerDemo::default();
+        let original_map = demo.obstacles.clone();
+        demo.apply_share_query("planner=unknown&start=99,99&map=xyz");
+        assert_eq!(demo.planner, PlannerKind::AStar);
+        assert_eq!(demo.obstacles, original_map);
     }
 }

--- a/crates/rust_robotics_playground/src/main.rs
+++ b/crates/rust_robotics_playground/src/main.rs
@@ -4,6 +4,7 @@ mod admm_formation;
 mod app;
 mod grid_planners;
 mod localization;
+mod share;
 mod slam;
 
 use app::PlaygroundApp;

--- a/crates/rust_robotics_playground/src/share.rs
+++ b/crates/rust_robotics_playground/src/share.rs
@@ -1,0 +1,64 @@
+//! Small, dependency-free helpers for reproducible playground links.
+
+pub const LIVE_PLAYGROUND_URL: &str = "https://rsasaki0109.github.io/rust_robotics/playground/";
+
+pub fn value<'a>(query: &'a str, key: &str) -> Option<&'a str> {
+    query
+        .trim_start_matches('?')
+        .split('&')
+        .filter_map(|pair| pair.split_once('='))
+        .find_map(|(candidate, value)| (candidate == key).then_some(value))
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn current_query() -> String {
+    web_sys::window()
+        .and_then(|window| window.location().search().ok())
+        .unwrap_or_default()
+        .trim_start_matches('?')
+        .to_owned()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn current_query() -> String {
+    String::new()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn share_url(query: &str) -> String {
+    let Some(window) = web_sys::window() else {
+        return format!("{LIVE_PLAYGROUND_URL}?{query}");
+    };
+    let location = window.location();
+    let base = match (location.origin(), location.pathname()) {
+        (Ok(origin), Ok(pathname)) => format!("{origin}{pathname}"),
+        _ => LIVE_PLAYGROUND_URL.to_owned(),
+    };
+    let relative = format!("?{query}");
+    if let Ok(history) = window.history() {
+        let _ = history.replace_state_with_url(
+            &wasm_bindgen::JsValue::NULL,
+            "RustRobotics Playground",
+            Some(&relative),
+        );
+    }
+    format!("{base}{relative}")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn share_url(query: &str) -> String {
+    format!("{LIVE_PLAYGROUND_URL}?{query}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::value;
+
+    #[test]
+    fn reads_exact_query_keys() {
+        let query = "tab=grid&planner=theta&map=0f";
+        assert_eq!(value(query, "tab"), Some("grid"));
+        assert_eq!(value(query, "planner"), Some("theta"));
+        assert_eq!(value(query, "plan"), None);
+    }
+}

--- a/docs/crates_io_release.md
+++ b/docs/crates_io_release.md
@@ -18,6 +18,22 @@ dependency order and wait for the crates.io index to update between layers.
 
 ## Preflight
 
+The preferred path is the manually triggered `Release` GitHub Actions
+workflow. Run it once with `publish=false`; after the preflight succeeds, run
+the same version with `publish=true`. The publishing run requires a
+`CARGO_REGISTRY_TOKEN` secret in the protected `crates-io` environment. It
+publishes in dependency order, waits for crates.io propagation, and then
+creates the matching tag and GitHub Release. Re-running it is safe: versions
+already visible on crates.io are skipped.
+
+For a local preflight, run:
+
+```bash
+bash scripts/publish_workspace.sh --check
+```
+
+The commands below document the manual fallback.
+
 ```bash
 cargo fmt --all -- --check
 cargo check -p rust_robotics --all-features
@@ -99,8 +115,9 @@ retry after the crates.io index catches up.
 git tag v0.2.0
 git push origin v0.2.0
 gh release create v0.2.0 --title "v0.2.0" \
-  --notes "no_std localization stack, pure-Rust GIF gallery, RRT get_tree fix. See CHANGELOG.md."
+  --generate-notes
 ```
 
-Then update the root README library section from the Git dependency to the
-published version.
+Then verify that `cargo add rust_robotics` resolves the published version and
+that docs.rs has built it. The root README intentionally uses `cargo add`
+instead of hard-coding a version, so no post-release version edit is required.

--- a/plan.md
+++ b/plan.md
@@ -1203,3 +1203,13 @@ noted.
   research depth; resource split and deprioritization list recorded.
 - Workspace at `0.2.0` on `main` (PR #35 merged); crates.io publish + public
   announcement remain the top gate before further feature work.
+
+2026-07-15:
+
+- Added a guarded, manually triggered release workflow plus a dependency-ordered,
+  restart-safe publish script. The local `--check` preflight packages every
+  publishable `0.2.0` crate without publishing anything.
+- Promoted browser, crate, embedded, and gallery entry points to the top of the
+  README and removed the stale hard-coded `0.1` dependency instruction.
+- Added reproducible Playground links. Grid-planner URLs preserve the planner,
+  start/goal, and full obstacle map; native tests and a release Trunk build pass.

--- a/scripts/publish_workspace.sh
+++ b/scripts/publish_workspace.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:---check}"
+case "$mode" in
+  --check|--publish) ;;
+  *) echo "usage: $0 [--check|--publish]" >&2; exit 2 ;;
+esac
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+cargo_bin="${CARGO:-cargo}"
+if ! command -v "$cargo_bin" >/dev/null 2>&1; then
+  if [[ -x "$HOME/.cargo/bin/cargo.exe" ]]; then
+    cargo_bin="$HOME/.cargo/bin/cargo.exe"
+  else
+    echo "cargo was not found; set CARGO to its executable path" >&2
+    exit 1
+  fi
+fi
+
+version="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
+if [[ -z "$version" ]]; then
+  echo "could not read workspace.package.version" >&2
+  exit 1
+fi
+
+packages=(
+  rust_robotics_core
+  rust_robotics_planning
+  rust_robotics_localization
+  rust_robotics_control
+  rust_robotics_mapping
+  rust_robotics_viz
+  rust_robotics_slam
+  rust_robotics
+)
+
+wait_for_version() {
+  local package="$1"
+  local attempts=30
+  for ((i = 1; i <= attempts; i++)); do
+    if curl --fail --silent --show-error "https://crates.io/api/v1/crates/${package}/${version}" >/dev/null; then
+      echo "${package} ${version} is visible on crates.io"
+      return 0
+    fi
+    echo "waiting for ${package} ${version} to reach crates.io (${i}/${attempts})"
+    sleep 10
+  done
+  echo "timed out waiting for ${package} ${version}" >&2
+  return 1
+}
+
+echo "validating RustRobotics ${version}"
+"$cargo_bin" fmt --all -- --check
+"$cargo_bin" check -p rust_robotics --all-features
+"$cargo_bin" test -p rust_robotics --lib
+"$cargo_bin" package --manifest-path vendor/nearest_neighbor/Cargo.toml --allow-dirty
+"$cargo_bin" package -p rust_robotics_core --allow-dirty
+"$cargo_bin" package --workspace --no-verify --allow-dirty --exclude rust_robotics_playground
+
+if [[ "$mode" == "--check" ]]; then
+  echo "release preflight passed; no crates were published"
+  exit 0
+fi
+
+: "${CARGO_REGISTRY_TOKEN:?CARGO_REGISTRY_TOKEN is required for --publish}"
+
+for package in "${packages[@]}"; do
+  if curl --fail --silent "https://crates.io/api/v1/crates/${package}/${version}" >/dev/null; then
+    echo "skipping ${package} ${version}; already published"
+    continue
+  fi
+  "$cargo_bin" publish -p "$package"
+  wait_for_version "$package"
+done
+
+echo "all RustRobotics ${version} crates are published"


### PR DESCRIPTION
## What changed

- add a guarded manual release workflow and restart-safe, dependency-ordered crates.io publish script
- promote browser, crate, embedded, and gallery entry points in the README
- add reproducible Playground share links, including full grid-planner scenarios
- update the release checklist, changelog, and Phase 3 progress

## Why

The repository source is ready for v0.2.0, but the public release and first-visit adoption paths were still oriented around v0.1.0. These changes make the release repeatable and turn the existing WASM Playground into a shareable acquisition surface.

## Validation

- `bash scripts/publish_workspace.sh --check`
- `cargo test -p rust_robotics_playground` (3 passed)
- `cargo clippy -p rust_robotics_playground --all-targets -- -D warnings`
- `cargo check -p rust_robotics_playground --target wasm32-unknown-unknown`
- `trunk build index.html --release --public-url /rust_robotics/playground/`
- `cargo fmt --all -- --check`
- `git diff --check`