### PR TITLE
Add EuRoC visual feature frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         cargo run -p rust_robotics --example headless_mission_recovery --features "planning,localization,control"
         cargo run -p rust_robotics --example headless_factor_graph_stack --no-default-features --features slam
         cargo run -p rust_robotics --example headless_euroc_vio --no-default-features --features slam
+        cargo test -p rust_robotics --example generate_euroc_feature_tracks --no-default-features --features slam
 
   package-check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A streaming EuRoC visual frontend with Shi-Tomasi detection, pyramidal
+  Lucas-Kanade tracking, forward/backward checks, IMU-seeded triangulation,
+  protected sidecar output, and a PNG CLI.
+
 ## [0.2.0] - 2026-07-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,7 +2000,7 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
- "png",
+ "png 0.18.1",
  "tiff",
 ]
 
@@ -3065,6 +3065,19 @@ dependencies = [
 
 [[package]]
 name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
@@ -3401,6 +3414,7 @@ dependencies = [
  "eyre",
  "gnuplot",
  "nalgebra",
+ "png 0.17.16",
  "rand",
  "rand_distr",
  "rust_robotics_control",

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ cargo run -p rust_robotics --example render_hierarchical_mapf_replanning_svg --n
 cargo run -p rust_robotics --example benchmark_hierarchical_mapf_scale --no-default-features --features planning
 cargo run -p rust_robotics --example headless_navigation_loop --features "planning,localization,control"
 cargo run -p rust_robotics --example headless_mission_recovery --features "planning,localization,control"
+cargo run --release -p rust_robotics --example generate_euroc_feature_tracks --no-default-features --features slam -- /datasets/EuRoC/MH_01_easy
 cargo run -p rust_robotics --example headless_euroc_vio --no-default-features --features slam
 cargo run -p rust_robotics --example render_euroc_vio_svg --no-default-features --features slam
 cargo run -p rust_robotics --example benchmark_conformal_sipp --no-default-features --features planning
@@ -737,17 +738,23 @@ cargo run --release -p rust_robotics --example benchmark_large_pose_graph \
 <img src="./docs/assets/euroc-vio-pipeline.svg" width="1000px" alt="EuRoC IMU, bundle adjustment, and SE3 pose graph pipeline">
 
 The SLAM crate loads official EuRoC MAV and KITTI odometry directory layouts
-without imposing an image decoder. EuRoC replay accepts a compact pre-extracted
-feature sidecar, preintegrates IMU samples, jointly optimizes cameras and
-landmarks with Schur elimination, then fuses metric IMU edges and the visual
-closure in an SE(3) pose graph.
+without imposing an image decoder on the library. A companion CLI decodes
+EuRoC PNGs, tracks Shi-Tomasi corners with forward/backward pyramidal
+Lucas-Kanade, and triangulates them from the IMU-predicted metric trajectory.
+The replay then jointly optimizes cameras and landmarks with Schur elimination
+and fuses metric IMU edges with the visual closure in an SE(3) pose graph.
 
 - [Dataset and sidecar guide](./docs/datasets.md)
 - [loader source](./crates/rust_robotics_slam/src/dataset.rs)
+- [visual frontend source](./crates/rust_robotics_slam/src/visual_frontend.rs)
 - [VIO pipeline source](./crates/rust_robotics_slam/src/vio_pipeline.rs)
 - [MathematicalRobotics numerical parity](./docs/mathematical-robotics-parity.md)
 
 ```bash
+cargo run --release -p rust_robotics \
+  --example generate_euroc_feature_tracks \
+  --no-default-features --features slam -- /datasets/EuRoC/MH_01_easy
+
 cargo run -p rust_robotics --example headless_euroc_vio \
   --no-default-features --features slam
 ```

--- a/crates/rust_robotics/Cargo.toml
+++ b/crates/rust_robotics/Cargo.toml
@@ -47,6 +47,7 @@ gnuplot = { workspace = true }
 nalgebra = { workspace = true, features = ["std"] }
 rand = { workspace = true }
 rand_distr = { workspace = true }
+png = "0.17"
 
 # === Headless examples (require domain features but not viz) ===
 
@@ -238,6 +239,11 @@ required-features = ["slam"]
 [[example]]
 name = "headless_euroc_vio"
 path = "examples/headless_euroc_vio.rs"
+required-features = ["slam"]
+
+[[example]]
+name = "generate_euroc_feature_tracks"
+path = "examples/generate_euroc_feature_tracks.rs"
 required-features = ["slam"]
 
 [[example]]

--- a/crates/rust_robotics/examples/generate_euroc_feature_tracks.rs
+++ b/crates/rust_robotics/examples/generate_euroc_feature_tracks.rs
@@ -1,0 +1,275 @@
+//! Generate a VIO feature sidecar directly from EuRoC cam0 PNG images.
+//!
+//! ```text
+//! cargo run --release -p rust_robotics --example generate_euroc_feature_tracks \
+//!   --no-default-features --features slam -- /datasets/EuRoC/MH_01_easy
+//! ```
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+
+use nalgebra::Vector3;
+use rust_robotics::slam::dataset::EurocDataset;
+use rust_robotics::slam::imu_preintegration::ImuNoise;
+use rust_robotics::slam::vio_pipeline::euroc_imu_camera_trajectory;
+use rust_robotics::slam::visual_frontend::{
+    triangulate_tracks, FeatureFrontendConfig, FeatureTracker, GrayImage, TriangulationConfig,
+};
+
+type CliResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Debug)]
+struct Arguments {
+    sequence: PathBuf,
+    output: Option<PathBuf>,
+    overwrite: bool,
+    max_features: usize,
+}
+
+#[derive(Debug)]
+struct GenerationSummary {
+    frames: usize,
+    accepted_matches: usize,
+    persistent_tracks: usize,
+    triangulated_landmarks: usize,
+    observations: usize,
+    output: PathBuf,
+}
+
+fn parse_arguments() -> CliResult<Arguments> {
+    let mut values = std::env::args_os().skip(1);
+    let sequence = values.next().map(PathBuf::from).ok_or(
+        "usage: generate_euroc_feature_tracks SEQUENCE [--output DIR] [--force] \
+         [--max-features N]",
+    )?;
+    let mut output = None;
+    let mut overwrite = false;
+    let mut max_features = FeatureFrontendConfig::default().max_features;
+    while let Some(argument) = values.next() {
+        match argument.to_str() {
+            Some("--output") => {
+                output = Some(PathBuf::from(
+                    values.next().ok_or("--output requires a directory")?,
+                ));
+            }
+            Some("--force") => overwrite = true,
+            Some("--max-features") => {
+                max_features = values
+                    .next()
+                    .and_then(|value| value.to_str().and_then(|value| value.parse().ok()))
+                    .ok_or("--max-features requires a positive integer")?;
+                if max_features == 0 {
+                    return Err("--max-features must be positive".into());
+                }
+            }
+            _ => {
+                return Err(format!("unrecognized argument: {}", argument.to_string_lossy()).into())
+            }
+        }
+    }
+    Ok(Arguments {
+        sequence,
+        output,
+        overwrite,
+        max_features,
+    })
+}
+
+fn decode_png(path: &Path) -> CliResult<GrayImage> {
+    let mut decoder = png::Decoder::new(BufReader::new(File::open(path)?));
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info()?;
+    let mut buffer = vec![0; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut buffer)?;
+    let bytes = &buffer[..info.buffer_size()];
+    let pixels = match info.color_type {
+        png::ColorType::Grayscale => bytes.to_vec(),
+        png::ColorType::GrayscaleAlpha => bytes.chunks_exact(2).map(|pixel| pixel[0]).collect(),
+        png::ColorType::Rgb => bytes
+            .chunks_exact(3)
+            .map(|pixel| rgb_to_gray(pixel[0], pixel[1], pixel[2]))
+            .collect(),
+        png::ColorType::Rgba => bytes
+            .chunks_exact(4)
+            .map(|pixel| rgb_to_gray(pixel[0], pixel[1], pixel[2]))
+            .collect(),
+        png::ColorType::Indexed => {
+            return Err("indexed PNG remained after decoder expansion".into());
+        }
+    };
+    Ok(GrayImage::new(
+        info.width as usize,
+        info.height as usize,
+        pixels,
+    )?)
+}
+
+fn rgb_to_gray(red: u8, green: u8, blue: u8) -> u8 {
+    ((77 * red as u16 + 150 * green as u16 + 29 * blue as u16) >> 8) as u8
+}
+
+fn generate(arguments: &Arguments) -> CliResult<GenerationSummary> {
+    let dataset = EurocDataset::load(&arguments.sequence)?;
+    let output = arguments
+        .output
+        .clone()
+        .unwrap_or_else(|| dataset.root.join("rust_robotics"));
+    let config = FeatureFrontendConfig {
+        max_features: arguments.max_features,
+        ..FeatureFrontendConfig::default()
+    };
+    let mut tracker = FeatureTracker::new(config)?;
+    for (index, frame) in dataset.camera_frames.iter().enumerate() {
+        tracker.process(decode_png(&frame.image_path)?)?;
+        if (index + 1) % 100 == 0 || index + 1 == dataset.camera_frames.len() {
+            eprintln!(
+                "tracked {}/{} frames",
+                index + 1,
+                dataset.camera_frames.len()
+            );
+        }
+    }
+    let accepted_matches = tracker.accepted_matches();
+    let image_tracks = tracker.finish();
+    let camera_trajectory =
+        euroc_imu_camera_trajectory(&dataset, Vector3::new(0.0, 0.0, -9.81), ImuNoise::default())?;
+    let timestamps = dataset
+        .camera_frames
+        .iter()
+        .map(|frame| frame.timestamp_ns)
+        .collect::<Vec<_>>();
+    let tracks = triangulate_tracks(
+        &image_tracks,
+        &timestamps,
+        &camera_trajectory,
+        dataset.camera.intrinsics,
+        TriangulationConfig::default(),
+    )?;
+    dataset.write_feature_tracks(&tracks, &output, arguments.overwrite)?;
+    Ok(GenerationSummary {
+        frames: dataset.camera_frames.len(),
+        accepted_matches,
+        persistent_tracks: image_tracks.len(),
+        triangulated_landmarks: tracks.landmarks.len(),
+        observations: tracks.observations.len(),
+        output,
+    })
+}
+
+fn main() -> CliResult<()> {
+    let arguments = parse_arguments()?;
+    let summary = generate(&arguments)?;
+    println!("EuRoC visual frontend: {}", arguments.sequence.display());
+    println!("  frames={}", summary.frames);
+    println!("  accepted_matches={}", summary.accepted_matches);
+    println!("  persistent_tracks={}", summary.persistent_tracks);
+    println!(
+        "  triangulated_landmarks={}",
+        summary.triangulated_landmarks
+    );
+    println!("  observations={}", summary.observations);
+    println!("  output={}", summary.output.display());
+    println!("  status=ok");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::BufWriter;
+
+    use super::*;
+
+    fn write_png(path: &Path, shift: usize) {
+        let width = 96;
+        let height = 72;
+        let mut pixels = vec![20; width * height];
+        for &(x, y) in &[(22, 18), (46, 20), (74, 22), (28, 48), (62, 50)] {
+            let x = x - shift;
+            for row in y - 3..=y + 3 {
+                for column in x - 3..=x + 3 {
+                    pixels[row * width + column] = if (row + column) % 2 == 0 { 240 } else { 80 };
+                }
+            }
+        }
+        let mut encoder = png::Encoder::new(
+            BufWriter::new(File::create(path).unwrap()),
+            width as u32,
+            height as u32,
+        );
+        encoder.set_color(png::ColorType::Grayscale);
+        encoder.set_depth(png::BitDepth::Eight);
+        encoder
+            .write_header()
+            .unwrap()
+            .write_image_data(&pixels)
+            .unwrap();
+    }
+
+    #[test]
+    fn png_cli_pipeline_writes_a_reloadable_sidecar() {
+        let root = std::env::temp_dir().join(format!(
+            "rust_robotics_euroc_frontend_{}",
+            std::process::id()
+        ));
+        if root.exists() {
+            fs::remove_dir_all(&root).unwrap();
+        }
+        let mav0 = root.join("mav0");
+        let camera = mav0.join("cam0");
+        fs::create_dir_all(camera.join("data")).unwrap();
+        fs::create_dir_all(mav0.join("imu0")).unwrap();
+        fs::create_dir_all(mav0.join("state_groundtruth_estimate0")).unwrap();
+        fs::write(
+            camera.join("data.csv"),
+            "#timestamp,filename\n1000000000,0.png\n1100000000,1.png\n1200000000,2.png\n",
+        )
+        .unwrap();
+        fs::write(
+            camera.join("sensor.yaml"),
+            "sensor_type: camera\nT_BS:\n  data: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]\nresolution: [96, 72]\nintrinsics: [80, 80, 48, 36]\n",
+        )
+        .unwrap();
+        fs::write(
+            mav0.join("imu0/data.csv"),
+            "#timestamp,wx,wy,wz,ax,ay,az\n1000000000,0,0,0,0,0,9.81\n1050000000,0,0,0,0,0,9.81\n1100000000,0,0,0,0,0,9.81\n1150000000,0,0,0,0,0,9.81\n1200000000,0,0,0,0,0,9.81\n",
+        )
+        .unwrap();
+        fs::write(
+            mav0.join("state_groundtruth_estimate0/data.csv"),
+            "#timestamp,p_x,p_y,p_z,q_w,q_x,q_y,q_z,v_x,v_y,v_z,bw_x,bw_y,bw_z,ba_x,ba_y,ba_z\n1000000000,0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,0\n",
+        )
+        .unwrap();
+        write_png(&camera.join("data/0.png"), 0);
+        write_png(&camera.join("data/1.png"), 2);
+        write_png(&camera.join("data/2.png"), 4);
+
+        let output = root.join("generated");
+        let summary = generate(&Arguments {
+            sequence: root.clone(),
+            output: Some(output.clone()),
+            overwrite: false,
+            max_features: 80,
+        })
+        .unwrap();
+        assert_eq!(summary.frames, 3);
+        assert!(summary.triangulated_landmarks >= 3);
+        let mut dataset = EurocDataset::load(&root).unwrap();
+        dataset.root = mav0;
+        fs::create_dir_all(dataset.root.join("rust_robotics")).unwrap();
+        fs::copy(
+            output.join("landmarks.csv"),
+            dataset.root.join("rust_robotics/landmarks.csv"),
+        )
+        .unwrap();
+        fs::copy(
+            output.join("observations.csv"),
+            dataset.root.join("rust_robotics/observations.csv"),
+        )
+        .unwrap();
+        let reloaded = dataset.load_feature_tracks().unwrap();
+        assert_eq!(reloaded.landmarks.len(), summary.triangulated_landmarks);
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/rust_robotics_slam/README.md
+++ b/crates/rust_robotics_slam/README.md
@@ -18,13 +18,19 @@ world-from-local SE(3) matrices; tangent vectors are translation-first. SE(3)
 pose graph and IMU factors use analytic Jacobians checked against finite
 differences.
 
-`dataset` loads standard EuRoC MAV and KITTI odometry layouts. `vio_pipeline`
-connects timestamped EuRoC IMU samples, optional pre-extracted visual tracks,
-Schur bundle adjustment, and block-sparse SE(3) pose-graph fusion. See the
-[dataset guide](../../docs/datasets.md) and pinned
+`dataset` loads standard EuRoC MAV and KITTI odometry layouts.
+`visual_frontend` provides decoder-independent Shi-Tomasi detection,
+pyramidal Lucas-Kanade tracking, forward/backward validation and metric
+triangulation. `vio_pipeline` connects timestamped EuRoC IMU samples,
+generated visual tracks, Schur bundle adjustment, and block-sparse SE(3)
+pose-graph fusion. See the [dataset guide](../../docs/datasets.md) and pinned
 [MathematicalRobotics parity report](../../docs/mathematical-robotics-parity.md).
 
 ```bash
+cargo run --release -p rust_robotics \
+  --example generate_euroc_feature_tracks \
+  --no-default-features --features slam -- /datasets/EuRoC/MH_01_easy
+
 cargo run -p rust_robotics --example headless_euroc_vio \
   --no-default-features --features slam
 ```

--- a/crates/rust_robotics_slam/src/dataset.rs
+++ b/crates/rust_robotics_slam/src/dataset.rs
@@ -169,19 +169,53 @@ impl EurocDataset {
                 })
             })
             .collect::<DatasetResult<Vec<_>>>()?;
-        if landmarks
-            .iter()
-            .enumerate()
-            .any(|(index, landmark)| landmark.id != index)
-        {
-            return Err(DatasetError::InvalidData(
-                "feature landmark IDs must be contiguous and zero-based".into(),
-            ));
-        }
-        Ok(EurocFeatureTracks {
+        let tracks = EurocFeatureTracks {
             landmarks,
             observations,
-        })
+        };
+        validate_feature_tracks(&tracks, &self.camera_frames)?;
+        Ok(tracks)
+    }
+
+    /// Writes a generated feature sidecar. Existing files are preserved unless
+    /// `overwrite` is true.
+    pub fn write_feature_tracks(
+        &self,
+        tracks: &EurocFeatureTracks,
+        directory: impl AsRef<Path>,
+        overwrite: bool,
+    ) -> DatasetResult<()> {
+        validate_feature_tracks(tracks, &self.camera_frames)?;
+        let directory = directory.as_ref();
+        let landmarks_path = directory.join("landmarks.csv");
+        let observations_path = directory.join("observations.csv");
+        if !overwrite && (landmarks_path.exists() || observations_path.exists()) {
+            return Err(DatasetError::InvalidData(format!(
+                "feature sidecar already exists at {}; pass overwrite=true to replace it",
+                directory.display()
+            )));
+        }
+        fs::create_dir_all(directory)?;
+        let mut landmarks = String::from("#landmark_id,x,y,z\n");
+        for landmark in &tracks.landmarks {
+            landmarks.push_str(&format!(
+                "{},{:.17},{:.17},{:.17}\n",
+                landmark.id, landmark.position.x, landmark.position.y, landmark.position.z
+            ));
+        }
+        let mut observations = String::from("#timestamp_ns,landmark_id,u,v\n");
+        for observation in &tracks.observations {
+            observations.push_str(&format!(
+                "{},{},{:.17},{:.17}\n",
+                observation.timestamp_ns,
+                observation.landmark_id,
+                observation.pixel.x,
+                observation.pixel.y
+            ));
+        }
+        fs::write(landmarks_path, landmarks)?;
+        fs::write(observations_path, observations)?;
+        Ok(())
     }
 }
 
@@ -537,6 +571,45 @@ fn ensure_strict_timestamps(
     Ok(())
 }
 
+fn validate_feature_tracks(
+    tracks: &EurocFeatureTracks,
+    camera_frames: &[CameraFrame],
+) -> DatasetResult<()> {
+    if tracks.landmarks.is_empty() || tracks.observations.is_empty() {
+        return Err(DatasetError::InvalidData(
+            "feature sidecar must contain landmarks and observations".into(),
+        ));
+    }
+    if tracks
+        .landmarks
+        .iter()
+        .enumerate()
+        .any(|(index, landmark)| landmark.id != index)
+    {
+        return Err(DatasetError::InvalidData(
+            "feature landmark IDs must be contiguous and zero-based".into(),
+        ));
+    }
+    if tracks.observations.iter().any(|observation| {
+        observation.landmark_id >= tracks.landmarks.len()
+            || !observation.pixel.iter().all(|value| value.is_finite())
+    }) {
+        return Err(DatasetError::InvalidData(
+            "feature observation is invalid or references a missing landmark".into(),
+        ));
+    }
+    if tracks.observations.iter().any(|observation| {
+        camera_frames
+            .binary_search_by_key(&observation.timestamp_ns, |frame| frame.timestamp_ns)
+            .is_err()
+    }) {
+        return Err(DatasetError::InvalidData(
+            "feature observation timestamp has no matching camera frame".into(),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -581,5 +654,26 @@ mod tests {
         let points = KittiOdometryDataset::read_velodyne(&scan_path).unwrap();
         fs::remove_file(scan_path).unwrap();
         assert_eq!(points, vec![[1.0, 2.0, 3.0, 0.5], [-1.0, 0.0, 4.0, 0.25]]);
+    }
+
+    #[test]
+    fn writes_feature_sidecar_without_silent_overwrite() {
+        let dataset = EurocDataset::load(fixture("euroc_mini")).unwrap();
+        let tracks = dataset.load_feature_tracks().unwrap();
+        let directory = std::env::temp_dir().join(format!(
+            "rust_robotics_feature_sidecar_{}",
+            std::process::id()
+        ));
+        if directory.exists() {
+            fs::remove_dir_all(&directory).unwrap();
+        }
+        dataset
+            .write_feature_tracks(&tracks, &directory, false)
+            .unwrap();
+        assert!(directory.join("landmarks.csv").is_file());
+        assert!(dataset
+            .write_feature_tracks(&tracks, &directory, false)
+            .is_err());
+        fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/crates/rust_robotics_slam/src/lib.rs
+++ b/crates/rust_robotics_slam/src/lib.rs
@@ -16,6 +16,7 @@ pub mod pose_graph_optimization;
 pub mod pose_graph_optimization_3d;
 pub mod robust_icp;
 pub mod vio_pipeline;
+pub mod visual_frontend;
 
 // Re-exports
 pub use ekf_slam::EKFSLAMState;

--- a/crates/rust_robotics_slam/src/vio_pipeline.rs
+++ b/crates/rust_robotics_slam/src/vio_pipeline.rs
@@ -78,9 +78,7 @@ pub fn euroc_vio_input(
     tracks: &EurocFeatureTracks,
     gravity: Vector3<f64>,
 ) -> OptimizationResult<VioPipelineInput> {
-    let first_truth = dataset.ground_truth.first().ok_or_else(|| {
-        OptimizationError::InvalidParameter("EuRoC VIO initialization needs ground truth".into())
-    })?;
+    let (initial_state, bias) = euroc_initial_conditions(dataset)?;
     let observations = tracks
         .observations
         .iter()
@@ -108,21 +106,8 @@ pub fn euroc_vio_input(
             .map(|frame| frame.timestamp_ns)
             .collect(),
         imu_samples: dataset.imu.clone(),
-        initial_state: NavState {
-            rotation: first_truth
-                .world_from_body
-                .fixed_view::<3, 3>(0, 0)
-                .into_owned(),
-            position: first_truth
-                .world_from_body
-                .fixed_view::<3, 1>(0, 3)
-                .into_owned(),
-            velocity: first_truth.velocity,
-        },
-        bias: ImuBias {
-            accelerometer: first_truth.accelerometer_bias,
-            gyroscope: first_truth.gyroscope_bias,
-        },
+        initial_state,
+        bias,
         gravity,
         body_from_camera: dataset.camera.body_from_sensor,
         landmarks: tracks
@@ -138,6 +123,35 @@ pub fn euroc_vio_input(
             cy: dataset.camera.intrinsics[3],
         },
     })
+}
+
+/// Produces the metric camera trajectory used to initialize visual tracks.
+///
+/// Only the first EuRoC ground-truth state supplies pose, velocity and biases;
+/// every later camera pose is predicted from the IMU.
+pub fn euroc_imu_camera_trajectory(
+    dataset: &EurocDataset,
+    gravity: Vector3<f64>,
+    noise: ImuNoise,
+) -> OptimizationResult<Vec<Matrix4<f64>>> {
+    let (initial_state, bias) = euroc_initial_conditions(dataset)?;
+    let timestamps = dataset
+        .camera_frames
+        .iter()
+        .map(|frame| frame.timestamp_ns)
+        .collect::<Vec<_>>();
+    let (states, _) = initialize_imu_sequence(
+        &timestamps,
+        &dataset.imu,
+        initial_state,
+        bias,
+        gravity,
+        noise,
+    )?;
+    Ok(states
+        .iter()
+        .map(|state| nav_state_pose(state) * dataset.camera.body_from_sensor)
+        .collect())
 }
 
 /// Runs IMU initialization, joint camera/landmark BA, then SE(3) graph fusion.
@@ -214,25 +228,62 @@ fn initialize_from_imu(
     input: &VioPipelineInput,
     config: &VioPipelineConfig,
 ) -> OptimizationResult<(Vec<NavState>, Vec<PreintegratedImuMeasurement>)> {
-    let mut states = vec![input.initial_state.clone()];
-    let mut measurements = Vec::with_capacity(input.keyframe_timestamps_ns.len() - 1);
-    for interval in input.keyframe_timestamps_ns.windows(2) {
-        let measurement = preintegrate_interval(
-            &input.imu_samples,
-            interval[0],
-            interval[1],
-            input.bias,
-            config.imu_noise,
-        )?;
-        let next = measurement.predict(
-            states.last().expect("initial state exists"),
-            &input.bias,
-            input.gravity,
-        );
+    initialize_imu_sequence(
+        &input.keyframe_timestamps_ns,
+        &input.imu_samples,
+        input.initial_state.clone(),
+        input.bias,
+        input.gravity,
+        config.imu_noise,
+    )
+}
+
+fn initialize_imu_sequence(
+    timestamps_ns: &[i64],
+    samples: &[ImuSample],
+    initial_state: NavState,
+    bias: ImuBias,
+    gravity: Vector3<f64>,
+    noise: ImuNoise,
+) -> OptimizationResult<(Vec<NavState>, Vec<PreintegratedImuMeasurement>)> {
+    if timestamps_ns.len() < 2 {
+        return Err(OptimizationError::InvalidParameter(
+            "IMU initialization requires at least two keyframes".into(),
+        ));
+    }
+    let mut states = vec![initial_state];
+    let mut measurements = Vec::with_capacity(timestamps_ns.len() - 1);
+    for interval in timestamps_ns.windows(2) {
+        let measurement = preintegrate_interval(samples, interval[0], interval[1], bias, noise)?;
+        let next =
+            measurement.predict(states.last().expect("initial state exists"), &bias, gravity);
         states.push(next);
         measurements.push(measurement);
     }
     Ok((states, measurements))
+}
+
+fn euroc_initial_conditions(dataset: &EurocDataset) -> OptimizationResult<(NavState, ImuBias)> {
+    let first_truth = dataset.ground_truth.first().ok_or_else(|| {
+        OptimizationError::InvalidParameter("EuRoC VIO initialization needs ground truth".into())
+    })?;
+    Ok((
+        NavState {
+            rotation: first_truth
+                .world_from_body
+                .fixed_view::<3, 3>(0, 0)
+                .into_owned(),
+            position: first_truth
+                .world_from_body
+                .fixed_view::<3, 1>(0, 3)
+                .into_owned(),
+            velocity: first_truth.velocity,
+        },
+        ImuBias {
+            accelerometer: first_truth.accelerometer_bias,
+            gyroscope: first_truth.gyroscope_bias,
+        },
+    ))
 }
 
 fn preintegrate_interval(

--- a/crates/rust_robotics_slam/src/visual_frontend.rs
+++ b/crates/rust_robotics_slam/src/visual_frontend.rs
@@ -1,0 +1,656 @@
+//! Decoder-independent sparse visual frontend for EuRoC-style sequences.
+//!
+//! Corners are distributed with non-maximum suppression, tracked with
+//! pyramidal Lucas-Kanade optical flow, checked in both directions, and
+//! triangulated from an IMU-predicted camera trajectory.
+
+use nalgebra::{Matrix3, Matrix4, Vector2, Vector3};
+use rust_robotics_optimization::{OptimizationError, OptimizationResult};
+
+use crate::dataset::{EurocFeatureTracks, FeatureTrackObservation, TrackedLandmark};
+
+/// Owned eight-bit grayscale image.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrayImage {
+    width: usize,
+    height: usize,
+    pixels: Vec<u8>,
+}
+
+impl GrayImage {
+    pub fn new(width: usize, height: usize, pixels: Vec<u8>) -> OptimizationResult<Self> {
+        if width < 8 || height < 8 || pixels.len() != width * height {
+            return Err(OptimizationError::InvalidParameter(
+                "gray image dimensions or pixel count are invalid".into(),
+            ));
+        }
+        Ok(Self {
+            width,
+            height,
+            pixels,
+        })
+    }
+
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    pub fn pixels(&self) -> &[u8] {
+        &self.pixels
+    }
+
+    fn sample(&self, point: Vector2<f64>) -> Option<f64> {
+        if point.x < 0.0
+            || point.y < 0.0
+            || point.x >= (self.width - 1) as f64
+            || point.y >= (self.height - 1) as f64
+        {
+            return None;
+        }
+        let x = point.x.floor() as usize;
+        let y = point.y.floor() as usize;
+        let dx = point.x - x as f64;
+        let dy = point.y - y as f64;
+        let at = |column: usize, row: usize| self.pixels[row * self.width + column] as f64;
+        Some(
+            at(x, y) * (1.0 - dx) * (1.0 - dy)
+                + at(x + 1, y) * dx * (1.0 - dy)
+                + at(x, y + 1) * (1.0 - dx) * dy
+                + at(x + 1, y + 1) * dx * dy,
+        )
+    }
+
+    fn half_size(&self) -> Self {
+        let width = self.width / 2;
+        let height = self.height / 2;
+        let mut pixels = vec![0; width * height];
+        for y in 0..height {
+            for x in 0..width {
+                let source = 2 * y * self.width + 2 * x;
+                let sum = self.pixels[source] as u16
+                    + self.pixels[source + 1] as u16
+                    + self.pixels[source + self.width] as u16
+                    + self.pixels[source + self.width + 1] as u16;
+                pixels[y * width + x] = (sum / 4) as u8;
+            }
+        }
+        Self {
+            width,
+            height,
+            pixels,
+        }
+    }
+}
+
+/// Sparse tracking parameters.
+#[derive(Debug, Clone, Copy)]
+pub struct FeatureFrontendConfig {
+    pub max_features: usize,
+    pub quality_level: f64,
+    pub min_distance: f64,
+    pub pyramid_levels: usize,
+    pub window_radius: usize,
+    pub max_iterations: usize,
+    pub convergence_epsilon: f64,
+    pub forward_backward_tolerance: f64,
+    pub max_patch_rms: f64,
+    pub min_track_length: usize,
+}
+
+impl Default for FeatureFrontendConfig {
+    fn default() -> Self {
+        Self {
+            max_features: 240,
+            quality_level: 0.01,
+            min_distance: 12.0,
+            pyramid_levels: 3,
+            window_radius: 3,
+            max_iterations: 12,
+            convergence_epsilon: 0.02,
+            forward_backward_tolerance: 1.0,
+            max_patch_rms: 30.0,
+            min_track_length: 3,
+        }
+    }
+}
+
+/// One 2D observation retained by the frontend.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ImageFeatureObservation {
+    pub frame: usize,
+    pub pixel: Vector2<f64>,
+}
+
+/// A feature identity followed across consecutive frames.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImageFeatureTrack {
+    pub id: usize,
+    pub observations: Vec<ImageFeatureObservation>,
+}
+
+/// Stateful streaming tracker. Only the previous image pyramid is retained.
+#[derive(Debug)]
+pub struct FeatureTracker {
+    config: FeatureFrontendConfig,
+    previous: Option<Vec<GrayImage>>,
+    tracks: Vec<ImageFeatureTrack>,
+    active: Vec<usize>,
+    frame_count: usize,
+    accepted_matches: usize,
+}
+
+impl FeatureTracker {
+    pub fn new(config: FeatureFrontendConfig) -> OptimizationResult<Self> {
+        validate_config(&config)?;
+        Ok(Self {
+            config,
+            previous: None,
+            tracks: Vec::new(),
+            active: Vec::new(),
+            frame_count: 0,
+            accepted_matches: 0,
+        })
+    }
+
+    /// Adds one image in timestamp order.
+    pub fn process(&mut self, image: GrayImage) -> OptimizationResult<()> {
+        let pyramid = image_pyramid(image, self.config.pyramid_levels);
+        if let Some(previous) = &self.previous {
+            let mut next_active = Vec::new();
+            for &track_index in &self.active {
+                let previous_pixel = self.tracks[track_index]
+                    .observations
+                    .last()
+                    .expect("active track has an observation")
+                    .pixel;
+                let Some(current_pixel) =
+                    track_pyramid(previous, &pyramid, previous_pixel, &self.config)
+                else {
+                    continue;
+                };
+                let Some(backward_pixel) =
+                    track_pyramid(&pyramid, previous, current_pixel, &self.config)
+                else {
+                    continue;
+                };
+                if (backward_pixel - previous_pixel).norm() > self.config.forward_backward_tolerance
+                {
+                    continue;
+                }
+                self.tracks[track_index]
+                    .observations
+                    .push(ImageFeatureObservation {
+                        frame: self.frame_count,
+                        pixel: current_pixel,
+                    });
+                next_active.push(track_index);
+                self.accepted_matches += 1;
+            }
+            self.active = next_active;
+        }
+
+        let occupied = self
+            .active
+            .iter()
+            .map(|&index| {
+                self.tracks[index]
+                    .observations
+                    .last()
+                    .expect("active track has an observation")
+                    .pixel
+            })
+            .collect::<Vec<_>>();
+        let capacity = self.config.max_features.saturating_sub(self.active.len());
+        let new_points = detect_corners(&pyramid[0], &occupied, capacity, &self.config);
+        for pixel in new_points {
+            let index = self.tracks.len();
+            self.tracks.push(ImageFeatureTrack {
+                id: index,
+                observations: vec![ImageFeatureObservation {
+                    frame: self.frame_count,
+                    pixel,
+                }],
+            });
+            self.active.push(index);
+        }
+        self.previous = Some(pyramid);
+        self.frame_count += 1;
+        Ok(())
+    }
+
+    pub fn frame_count(&self) -> usize {
+        self.frame_count
+    }
+
+    pub fn accepted_matches(&self) -> usize {
+        self.accepted_matches
+    }
+
+    pub fn finish(self) -> Vec<ImageFeatureTrack> {
+        self.tracks
+            .into_iter()
+            .filter(|track| track.observations.len() >= self.config.min_track_length)
+            .collect()
+    }
+}
+
+/// Landmark initialization parameters.
+#[derive(Debug, Clone, Copy)]
+pub struct TriangulationConfig {
+    pub min_parallax_radians: f64,
+    pub min_depth: f64,
+    pub max_reprojection_error: f64,
+}
+
+impl Default for TriangulationConfig {
+    fn default() -> Self {
+        Self {
+            min_parallax_radians: 0.005,
+            min_depth: 0.1,
+            max_reprojection_error: 8.0,
+        }
+    }
+}
+
+/// Triangulates 2D tracks and converts them to the VIO sidecar representation.
+pub fn triangulate_tracks(
+    tracks: &[ImageFeatureTrack],
+    timestamps_ns: &[i64],
+    world_from_camera: &[Matrix4<f64>],
+    intrinsics: [f64; 4],
+    config: TriangulationConfig,
+) -> OptimizationResult<EurocFeatureTracks> {
+    if timestamps_ns.len() != world_from_camera.len() || timestamps_ns.is_empty() {
+        return Err(OptimizationError::InvalidParameter(
+            "timestamps and camera trajectory must have the same nonzero length".into(),
+        ));
+    }
+    if config.min_parallax_radians <= 0.0
+        || config.min_depth <= 0.0
+        || config.max_reprojection_error <= 0.0
+    {
+        return Err(OptimizationError::InvalidParameter(
+            "triangulation thresholds must be positive".into(),
+        ));
+    }
+
+    let mut landmarks = Vec::new();
+    let mut observations = Vec::new();
+    for track in tracks {
+        if track
+            .observations
+            .iter()
+            .any(|observation| observation.frame >= world_from_camera.len())
+        {
+            return Err(OptimizationError::InvalidParameter(
+                "feature observation frame is out of range".into(),
+            ));
+        }
+        let Some(position) = triangulate_one(track, world_from_camera, intrinsics, config)? else {
+            continue;
+        };
+        let id = landmarks.len();
+        landmarks.push(TrackedLandmark { id, position });
+        observations.extend(
+            track
+                .observations
+                .iter()
+                .map(|observation| FeatureTrackObservation {
+                    timestamp_ns: timestamps_ns[observation.frame],
+                    landmark_id: id,
+                    pixel: observation.pixel,
+                }),
+        );
+    }
+    if landmarks.is_empty() {
+        return Err(OptimizationError::InvalidParameter(
+            "no feature track passed triangulation".into(),
+        ));
+    }
+    Ok(EurocFeatureTracks {
+        landmarks,
+        observations,
+    })
+}
+
+fn validate_config(config: &FeatureFrontendConfig) -> OptimizationResult<()> {
+    if config.max_features == 0
+        || !(0.0..=1.0).contains(&config.quality_level)
+        || config.quality_level == 0.0
+        || config.min_distance < 1.0
+        || config.pyramid_levels == 0
+        || config.window_radius < 2
+        || config.max_iterations == 0
+        || config.convergence_epsilon <= 0.0
+        || config.forward_backward_tolerance <= 0.0
+        || config.max_patch_rms <= 0.0
+        || config.min_track_length < 2
+    {
+        return Err(OptimizationError::InvalidParameter(
+            "invalid visual frontend configuration".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn image_pyramid(image: GrayImage, levels: usize) -> Vec<GrayImage> {
+    let mut pyramid = vec![image];
+    while pyramid.len() < levels {
+        let previous = pyramid.last().expect("base image exists");
+        if previous.width < 16 || previous.height < 16 {
+            break;
+        }
+        pyramid.push(previous.half_size());
+    }
+    pyramid
+}
+
+fn detect_corners(
+    image: &GrayImage,
+    occupied: &[Vector2<f64>],
+    capacity: usize,
+    config: &FeatureFrontendConfig,
+) -> Vec<Vector2<f64>> {
+    if capacity == 0 {
+        return Vec::new();
+    }
+    let margin = config.window_radius + 2;
+    let mut scores = vec![0.0; image.width * image.height];
+    let mut maximum: f64 = 0.0;
+    for y in margin..image.height - margin {
+        for x in margin..image.width - margin {
+            let mut xx = 0.0;
+            let mut xy = 0.0;
+            let mut yy = 0.0;
+            for row in y - 1..=y + 1 {
+                for column in x - 1..=x + 1 {
+                    let gx = image.pixels[row * image.width + column + 1] as f64
+                        - image.pixels[row * image.width + column - 1] as f64;
+                    let gy = image.pixels[(row + 1) * image.width + column] as f64
+                        - image.pixels[(row - 1) * image.width + column] as f64;
+                    xx += gx * gx;
+                    xy += gx * gy;
+                    yy += gy * gy;
+                }
+            }
+            let trace = xx + yy;
+            let score = 0.5 * (trace - ((xx - yy).powi(2) + 4.0 * xy * xy).sqrt());
+            maximum = maximum.max(score);
+            scores[y * image.width + x] = score;
+        }
+    }
+    let threshold = maximum * config.quality_level;
+    let mut candidates = Vec::new();
+    for y in margin + 1..image.height - margin - 1 {
+        for x in margin + 1..image.width - margin - 1 {
+            let score = scores[y * image.width + x];
+            if score < threshold || score <= 0.0 {
+                continue;
+            }
+            let is_local_maximum = (y - 1..=y + 1).all(|row| {
+                (x - 1..=x + 1).all(|column| {
+                    (row == y && column == x) || scores[row * image.width + column] <= score
+                })
+            });
+            if is_local_maximum {
+                candidates.push((score, Vector2::new(x as f64, y as f64)));
+            }
+        }
+    }
+    candidates.sort_by(|left, right| right.0.total_cmp(&left.0));
+
+    let minimum_squared = config.min_distance * config.min_distance;
+    let mut selected = occupied.to_vec();
+    let existing = selected.len();
+    for (_, point) in candidates {
+        if selected
+            .iter()
+            .all(|other| (point - other).norm_squared() >= minimum_squared)
+        {
+            selected.push(point);
+            if selected.len() - existing == capacity {
+                break;
+            }
+        }
+    }
+    selected.into_iter().skip(existing).collect()
+}
+
+fn track_pyramid(
+    source: &[GrayImage],
+    destination: &[GrayImage],
+    source_point: Vector2<f64>,
+    config: &FeatureFrontendConfig,
+) -> Option<Vector2<f64>> {
+    let levels = source.len().min(destination.len());
+    let mut destination_point = Vector2::zeros();
+    for level in (0..levels).rev() {
+        let scale = (1_usize << level) as f64;
+        let point = source_point / scale;
+        if level == levels - 1 {
+            destination_point = point;
+        } else {
+            destination_point *= 2.0;
+        }
+        destination_point = track_level(
+            &source[level],
+            &destination[level],
+            point,
+            destination_point,
+            config,
+        )?;
+    }
+    Some(destination_point)
+}
+
+fn track_level(
+    source: &GrayImage,
+    destination: &GrayImage,
+    source_point: Vector2<f64>,
+    mut destination_point: Vector2<f64>,
+    config: &FeatureFrontendConfig,
+) -> Option<Vector2<f64>> {
+    let radius = config.window_radius as isize;
+    let mut final_squared_error = 0.0;
+    let mut count = 0;
+    for _ in 0..config.max_iterations {
+        let mut hessian = Matrix3::<f64>::zeros();
+        let mut gradient = Vector2::<f64>::zeros();
+        final_squared_error = 0.0;
+        count = 0;
+        for dy in -radius..=radius {
+            for dx in -radius..=radius {
+                let offset = Vector2::new(dx as f64, dy as f64);
+                let reference = source.sample(source_point + offset)?;
+                let target_point = destination_point + offset;
+                let target = destination.sample(target_point)?;
+                let gx = 0.5
+                    * (destination.sample(target_point + Vector2::new(1.0, 0.0))?
+                        - destination.sample(target_point - Vector2::new(1.0, 0.0))?);
+                let gy = 0.5
+                    * (destination.sample(target_point + Vector2::new(0.0, 1.0))?
+                        - destination.sample(target_point - Vector2::new(0.0, 1.0))?);
+                let residual = target - reference;
+                hessian[(0, 0)] += gx * gx;
+                hessian[(0, 1)] += gx * gy;
+                hessian[(1, 0)] += gx * gy;
+                hessian[(1, 1)] += gy * gy;
+                gradient.x += gx * residual;
+                gradient.y += gy * residual;
+                final_squared_error += residual * residual;
+                count += 1;
+            }
+        }
+        let determinant = hessian[(0, 0)] * hessian[(1, 1)] - hessian[(0, 1)].powi(2);
+        if determinant < 1.0e-6 {
+            return None;
+        }
+        let delta = Vector2::<f64>::new(
+            (-hessian[(1, 1)] * gradient.x + hessian[(0, 1)] * gradient.y) / determinant,
+            (hessian[(1, 0)] * gradient.x - hessian[(0, 0)] * gradient.y) / determinant,
+        );
+        if !delta.iter().all(|value| value.is_finite()) || delta.norm() > 3.0 {
+            return None;
+        }
+        destination_point += delta;
+        if delta.norm() < config.convergence_epsilon {
+            break;
+        }
+    }
+    let rms = (final_squared_error / count as f64).sqrt();
+    (rms <= config.max_patch_rms).then_some(destination_point)
+}
+
+fn triangulate_one(
+    track: &ImageFeatureTrack,
+    poses: &[Matrix4<f64>],
+    intrinsics: [f64; 4],
+    config: TriangulationConfig,
+) -> OptimizationResult<Option<Vector3<f64>>> {
+    if track.observations.len() < 2 {
+        return Ok(None);
+    }
+    let [fx, fy, cx, cy] = intrinsics;
+    if fx <= 0.0 || fy <= 0.0 {
+        return Err(OptimizationError::InvalidParameter(
+            "camera focal lengths must be positive".into(),
+        ));
+    }
+    let mut rays = Vec::with_capacity(track.observations.len());
+    for observation in &track.observations {
+        let pose = &poses[observation.frame];
+        let origin = pose.fixed_view::<3, 1>(0, 3).into_owned();
+        let camera_ray = Vector3::new(
+            (observation.pixel.x - cx) / fx,
+            (observation.pixel.y - cy) / fy,
+            1.0,
+        )
+        .normalize();
+        let direction = pose.fixed_view::<3, 3>(0, 0) * camera_ray;
+        rays.push((origin, direction));
+    }
+    let maximum_parallax = rays
+        .iter()
+        .enumerate()
+        .flat_map(|(index, left)| rays[index + 1..].iter().map(move |right| (left, right)))
+        .map(|(left, right)| left.1.dot(&right.1).clamp(-1.0, 1.0).acos())
+        .fold(0.0_f64, f64::max);
+    if maximum_parallax < config.min_parallax_radians {
+        return Ok(None);
+    }
+
+    let mut normal = Matrix3::zeros();
+    let mut right_hand_side = Vector3::zeros();
+    for (origin, direction) in &rays {
+        let projection = Matrix3::identity() - direction * direction.transpose();
+        normal += projection;
+        right_hand_side += projection * origin;
+    }
+    let Some(position) = normal.lu().solve(&right_hand_side) else {
+        return Ok(None);
+    };
+    for (observation, pose) in track.observations.iter().zip(
+        track
+            .observations
+            .iter()
+            .map(|observation| &poses[observation.frame]),
+    ) {
+        let camera_from_world_rotation = pose.fixed_view::<3, 3>(0, 0).transpose();
+        let camera_point =
+            camera_from_world_rotation * (position - pose.fixed_view::<3, 1>(0, 3).into_owned());
+        if camera_point.z <= config.min_depth {
+            return Ok(None);
+        }
+        let projected = Vector2::new(
+            fx * camera_point.x / camera_point.z + cx,
+            fy * camera_point.y / camera_point.z + cy,
+        );
+        if (projected - observation.pixel).norm() > config.max_reprojection_error {
+            return Ok(None);
+        }
+    }
+    Ok(Some(position))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthetic_image(shift_x: usize) -> GrayImage {
+        let width = 96;
+        let height = 72;
+        let mut pixels = vec![20; width * height];
+        for &(x, y) in &[(18, 18), (42, 20), (70, 22), (24, 48), (58, 50)] {
+            let x = x + shift_x;
+            for row in y - 3..=y + 3 {
+                for column in x - 3..=x + 3 {
+                    pixels[row * width + column] = if (row + column) % 2 == 0 { 240 } else { 80 };
+                }
+            }
+        }
+        GrayImage::new(width, height, pixels).unwrap()
+    }
+
+    #[test]
+    fn pyramidal_tracker_follows_translation() {
+        let config = FeatureFrontendConfig {
+            min_distance: 8.0,
+            min_track_length: 3,
+            ..FeatureFrontendConfig::default()
+        };
+        let mut tracker = FeatureTracker::new(config).unwrap();
+        tracker.process(synthetic_image(0)).unwrap();
+        tracker.process(synthetic_image(2)).unwrap();
+        tracker.process(synthetic_image(4)).unwrap();
+        assert!(tracker.accepted_matches() >= 6);
+        let tracks = tracker.finish();
+        assert!(tracks.len() >= 3);
+        for track in tracks {
+            let displacement =
+                track.observations.last().unwrap().pixel - track.observations[0].pixel;
+            assert!((displacement.x - 4.0).abs() < 0.25);
+            assert!(displacement.y.abs() < 0.25);
+        }
+    }
+
+    #[test]
+    fn triangulation_recovers_known_point() {
+        let intrinsics = [200.0, 200.0, 48.0, 36.0];
+        let point = Vector3::new(0.2, -0.1, 4.0);
+        let mut poses = vec![Matrix4::identity(); 3];
+        poses[1][(0, 3)] = 0.2;
+        poses[2][(0, 3)] = 0.4;
+        let observations = poses
+            .iter()
+            .enumerate()
+            .map(|(frame, pose)| {
+                let camera_point = point - pose.fixed_view::<3, 1>(0, 3).into_owned();
+                ImageFeatureObservation {
+                    frame,
+                    pixel: Vector2::new(
+                        intrinsics[0] * camera_point.x / camera_point.z + intrinsics[2],
+                        intrinsics[1] * camera_point.y / camera_point.z + intrinsics[3],
+                    ),
+                }
+            })
+            .collect();
+        let result = triangulate_tracks(
+            &[ImageFeatureTrack {
+                id: 7,
+                observations,
+            }],
+            &[1, 2, 3],
+            &poses,
+            intrinsics,
+            TriangulationConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(result.landmarks[0].id, 0);
+        assert!((result.landmarks[0].position - point).norm() < 1.0e-10);
+        assert_eq!(result.observations.len(), 3);
+    }
+}

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -23,10 +23,26 @@ MH_01_easy/
 
 It validates increasing timestamps, parses camera intrinsics, resolution and
 `T_BS`, and exposes efficient IMU interval slices. Images remain paths so
-applications can choose their own decoder and feature frontend.
+applications can choose their own decoder. RustRobotics includes a PNG-based
+sparse frontend CLI:
 
-The offline VIO example consumes pre-extracted tracks from this optional
-sidecar:
+```bash
+cargo run --release -p rust_robotics \
+  --example generate_euroc_feature_tracks \
+  --no-default-features --features slam -- \
+  /datasets/EuRoC/MH_01_easy
+```
+
+The frontend distributes Shi-Tomasi corners, tracks them with pyramidal
+Lucas-Kanade optical flow, applies a forward/backward consistency check, and
+triangulates persistent tracks from the metric IMU-predicted camera
+trajectory. Only the first ground-truth state initializes pose, velocity and
+IMU biases. Existing sidecars are never replaced unless `--force` is passed.
+Use `--output DIR` to write elsewhere and `--max-features N` to adjust the
+per-frame cap.
+
+The offline VIO example consumes generated or externally extracted tracks
+from this optional sidecar:
 
 ```text
 mav0/rust_robotics/
@@ -35,15 +51,15 @@ mav0/rust_robotics/
 ```
 
 Landmark IDs must be contiguous and zero-based. Observation timestamps must
-match `cam0/data.csv`. A frontend can export this interchange format without
-coupling the SLAM crate to an image library.
+match `cam0/data.csv`. A different frontend can export the same interchange
+format without coupling the SLAM crate itself to an image library.
 
 ```bash
 # Checked-in miniature replay
 cargo run -p rust_robotics --example headless_euroc_vio \
   --no-default-features --features slam
 
-# Extracted sequence with a generated feature sidecar
+# Extracted sequence after running generate_euroc_feature_tracks
 cargo run --release -p rust_robotics --example headless_euroc_vio \
   --no-default-features --features slam -- /datasets/EuRoC/MH_01_easy
 ```


### PR DESCRIPTION
## What changed

- add a decoder-independent streaming Shi-Tomasi + pyramidal Lucas-Kanade frontend
- reject inconsistent tracks with forward/backward optical flow checks
- triangulate persistent tracks from the IMU-predicted metric camera trajectory
- add protected EuRoC sidecar CSV output and a PNG generation CLI
- add synthetic PNG end-to-end coverage and CI execution
- update dataset, crate, README, and changelog documentation

## Why

EuRoC VIO replay previously required a pre-generated feature sidecar. This
change generates that sidecar directly from `cam0` images while keeping image
decoding outside the SLAM library.

## Validation

- `cargo clippy --workspace --all-targets -- -W clippy::all -D warnings`
- `cargo test --workspace --lib --tests`
- PNG CLI end-to-end example test
- rustdoc with warnings denied
- SLAM `--no-default-features` tests
- workspace Wasm check
- `git diff --check`
