### PR TITLE
Port MathematicalRobotics IMU stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A streaming EuRoC visual frontend with Shi-Tomasi detection, pyramidal
   Lucas-Kanade tracking, forward/backward checks, IMU-seeded triangulation,
   protected sidecar output, and a PNG CLI.
+- MathematicalRobotics-compatible IMU extrinsic/lever-arm transforms,
+  navigation-state and bias factor families, EuRoC `imu0` `T_BS` ingestion,
+  and visual-pose-constrained state/bias refinement in the VIO pipeline.
 
 ## [0.2.0] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Every animation above is rendered by the library itself — regenerate them all 
   robust nonlinear least squares, pose graphs, IMU preintegration, and bundle
   adjustment share one tested mathematical foundation.
 - **Real dataset ingestion** — standard EuRoC MAV and KITTI odometry layouts,
-  plus a connected IMU → bundle-adjustment → SE(3) replay pipeline.
+  plus lever-arm-corrected IMU input and a connected
+  IMU → bundle-adjustment → state/bias refinement → SE(3) replay pipeline.
 
 ## Embedded / no_std
 
@@ -742,12 +743,15 @@ without imposing an image decoder on the library. A companion CLI decodes
 EuRoC PNGs, tracks Shi-Tomasi corners with forward/backward pyramidal
 Lucas-Kanade, and triangulates them from the IMU-predicted metric trajectory.
 The replay then jointly optimizes cameras and landmarks with Schur elimination
-and fuses metric IMU edges with the visual closure in an SE(3) pose graph.
+then refines navigation states and time-varying IMU biases before fusing metric
+IMU edges with the visual closure in an SE(3) pose graph. EuRoC `imu0` `T_BS`
+extrinsics include centripetal and tangential lever-arm correction.
 
 - [Dataset and sidecar guide](./docs/datasets.md)
 - [loader source](./crates/rust_robotics_slam/src/dataset.rs)
 - [visual frontend source](./crates/rust_robotics_slam/src/visual_frontend.rs)
 - [VIO pipeline source](./crates/rust_robotics_slam/src/vio_pipeline.rs)
+- [MathematicalRobotics porting matrix](./docs/mathematical-robotics-porting.md)
 - [MathematicalRobotics numerical parity](./docs/mathematical-robotics-parity.md)
 
 ```bash

--- a/crates/rust_robotics_slam/README.md
+++ b/crates/rust_robotics_slam/README.md
@@ -16,15 +16,19 @@ information-weighted factors, manifold retractions, and
 Huber/Pseudo-Huber/Cauchy losses. Camera poses and 3D pose graphs use
 world-from-local SE(3) matrices; tangent vectors are translation-first. SE(3)
 pose graph and IMU factors use analytic Jacobians checked against finite
-differences.
+differences. IMU support includes body-from-sensor extrinsics with lever-arm
+acceleration, navigation-state/bias priors, bias random walks,
+position/velocity factors, and relative navigation-state factors.
 
 `dataset` loads standard EuRoC MAV and KITTI odometry layouts.
 `visual_frontend` provides decoder-independent Shi-Tomasi detection,
 pyramidal Lucas-Kanade tracking, forward/backward validation and metric
 triangulation. `vio_pipeline` connects timestamped EuRoC IMU samples,
-generated visual tracks, Schur bundle adjustment, and block-sparse SE(3)
-pose-graph fusion. See the [dataset guide](../../docs/datasets.md) and pinned
-[MathematicalRobotics parity report](../../docs/mathematical-robotics-parity.md).
+generated visual tracks, Schur bundle adjustment, joint navigation-state/bias
+refinement, and block-sparse SE(3) pose-graph fusion. See the
+[dataset guide](../../docs/datasets.md) and pinned
+[MathematicalRobotics porting matrix](../../docs/mathematical-robotics-porting.md)
+and [parity report](../../docs/mathematical-robotics-parity.md).
 
 ```bash
 cargo run --release -p rust_robotics \

--- a/crates/rust_robotics_slam/src/dataset.rs
+++ b/crates/rust_robotics_slam/src/dataset.rs
@@ -72,6 +72,8 @@ pub struct EurocCameraCalibration {
 pub struct EurocDataset {
     pub root: PathBuf,
     pub imu: Vec<ImuSample>,
+    /// EuRoC `T_BS`: body-from-IMU transform.
+    pub imu_body_from_sensor: Matrix4<f64>,
     pub camera_frames: Vec<CameraFrame>,
     pub ground_truth: Vec<GroundTruthState>,
     pub camera: EurocCameraCalibration,
@@ -110,6 +112,12 @@ impl EurocDataset {
             root.to_path_buf()
         };
         let imu = parse_euroc_imu(&mav0.join("imu0/data.csv"))?;
+        let imu_calibration_path = mav0.join("imu0/sensor.yaml");
+        let imu_body_from_sensor = if imu_calibration_path.exists() {
+            parse_euroc_body_from_sensor_yaml(&imu_calibration_path)?
+        } else {
+            Matrix4::identity()
+        };
         let camera_frames =
             parse_image_index(&mav0.join("cam0/data.csv"), &mav0.join("cam0/data"))?;
         let ground_truth_path = mav0.join("state_groundtruth_estimate0/data.csv");
@@ -127,6 +135,7 @@ impl EurocDataset {
         Ok(Self {
             root: mav0,
             imu,
+            imu_body_from_sensor,
             camera_frames,
             ground_truth,
             camera,
@@ -446,8 +455,23 @@ fn parse_euroc_camera_yaml(path: &Path) -> DatasetResult<EurocCameraCalibration>
         .ok_or_else(|| DatasetError::InvalidData("missing EuRoC resolution".into()))?;
     let intrinsics = bracket_values::<f64>(intrinsics_line, "intrinsics:")?;
     let resolution = bracket_values::<usize>(resolution_line, "resolution:")?;
+    Ok(EurocCameraCalibration {
+        intrinsics: intrinsics.try_into().map_err(|_| {
+            DatasetError::InvalidData("EuRoC intrinsics must contain four values".into())
+        })?,
+        resolution: resolution.try_into().map_err(|_| {
+            DatasetError::InvalidData("EuRoC resolution must contain two values".into())
+        })?,
+        body_from_sensor: parse_euroc_body_from_sensor(&contents)?,
+    })
+}
+
+fn parse_euroc_body_from_sensor_yaml(path: &Path) -> DatasetResult<Matrix4<f64>> {
+    parse_euroc_body_from_sensor(&fs::read_to_string(path)?)
+}
+
+fn parse_euroc_body_from_sensor(contents: &str) -> DatasetResult<Matrix4<f64>> {
     let mut in_body_from_sensor = false;
-    let mut body_from_sensor = None;
     for line in contents.lines().map(str::trim) {
         if line == "T_BS:" {
             in_body_from_sensor = true;
@@ -458,20 +482,10 @@ fn parse_euroc_camera_yaml(path: &Path) -> DatasetResult<EurocCameraCalibration>
                     "EuRoC T_BS must contain 16 values".into(),
                 ));
             }
-            body_from_sensor = Some(Matrix4::from_row_slice(&values));
-            break;
+            return Ok(Matrix4::from_row_slice(&values));
         }
     }
-    Ok(EurocCameraCalibration {
-        intrinsics: intrinsics.try_into().map_err(|_| {
-            DatasetError::InvalidData("EuRoC intrinsics must contain four values".into())
-        })?,
-        resolution: resolution.try_into().map_err(|_| {
-            DatasetError::InvalidData("EuRoC resolution must contain two values".into())
-        })?,
-        body_from_sensor: body_from_sensor
-            .ok_or_else(|| DatasetError::InvalidData("missing EuRoC camera T_BS".into()))?,
-    })
+    Err(DatasetError::InvalidData("missing EuRoC T_BS".into()))
 }
 
 fn numeric_lines(path: &Path) -> DatasetResult<Vec<f64>> {
@@ -628,6 +642,7 @@ mod tests {
         assert_eq!(dataset.ground_truth.len(), 3);
         assert_eq!(dataset.camera.resolution, [752, 480]);
         assert_eq!(dataset.camera.body_from_sensor, Matrix4::identity());
+        assert_eq!(dataset.imu_body_from_sensor, Matrix4::identity());
         assert_eq!(dataset.imu_between(1_000_000_000, 1_010_000_000).len(), 2);
         assert!(dataset.camera_frames[0]
             .image_path
@@ -635,6 +650,19 @@ mod tests {
         let tracks = dataset.load_feature_tracks().unwrap();
         assert_eq!(tracks.landmarks.len(), 4);
         assert_eq!(tracks.observations.len(), 12);
+    }
+
+    #[test]
+    fn parses_euroc_imu_body_from_sensor_transform() {
+        let transform = parse_euroc_body_from_sensor(
+            "sensor_type: imu\nT_BS:\n  data: [0, -1, 0, 0.2, 1, 0, 0, -0.1, 0, 0, 1, 0.3, 0, 0, 0, 1]\n",
+        )
+        .unwrap();
+        assert_eq!(transform[(0, 1)], -1.0);
+        assert_eq!(transform[(1, 0)], 1.0);
+        assert_eq!(transform[(0, 3)], 0.2);
+        assert_eq!(transform[(1, 3)], -0.1);
+        assert_eq!(transform[(2, 3)], 0.3);
     }
 
     #[test]

--- a/crates/rust_robotics_slam/src/imu_preintegration.rs
+++ b/crates/rust_robotics_slam/src/imu_preintegration.rs
@@ -3,15 +3,90 @@
 //! Error states use `[rotation, position, velocity]`; biases use
 //! `[accelerometer, gyroscope]`.
 
-use nalgebra::{DMatrix, DVector, Matrix3, SMatrix, Vector3};
+use nalgebra::{DMatrix, DVector, Matrix3, Matrix4, SMatrix, Vector3};
 use rust_robotics_core::{skew, so3_exp, so3_left_jacobian, so3_left_jacobian_inverse, so3_log};
 use rust_robotics_optimization::{
-    Factor, FactorEvaluation, OptimizationError, OptimizationResult, Variable, VariableId,
+    solve, Factor, FactorEvaluation, OptimizationError, OptimizationResult, Problem, SolverConfig,
+    SolverSummary, Variable, VariableId,
 };
 
 pub type Matrix9 = SMatrix<f64, 9, 9>;
 pub type Matrix9x6 = SMatrix<f64, 9, 6>;
 pub type Matrix6 = SMatrix<f64, 6, 6>;
+
+/// One accelerometer/gyroscope sample expressed in an IMU sensor frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ImuMeasurement {
+    pub acceleration: Vector3<f64>,
+    pub angular_velocity: Vector3<f64>,
+}
+
+/// Rigid mounting transform from an IMU sensor frame to the navigation body frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ImuExtrinsics {
+    pub rotation_body_from_sensor: Matrix3<f64>,
+    pub translation_body_from_sensor: Vector3<f64>,
+}
+
+impl ImuExtrinsics {
+    pub fn identity() -> Self {
+        Self {
+            rotation_body_from_sensor: Matrix3::identity(),
+            translation_body_from_sensor: Vector3::zeros(),
+        }
+    }
+
+    /// Extracts the rotation and translation from a homogeneous body-from-sensor transform.
+    pub fn from_homogeneous(body_from_sensor: &Matrix4<f64>) -> OptimizationResult<Self> {
+        if !body_from_sensor.iter().all(|value| value.is_finite()) {
+            return Err(OptimizationError::InvalidParameter(
+                "IMU extrinsic transform must be finite".into(),
+            ));
+        }
+        let bottom_row = body_from_sensor.row(3);
+        if (bottom_row[0].abs() > 1.0e-12)
+            || (bottom_row[1].abs() > 1.0e-12)
+            || (bottom_row[2].abs() > 1.0e-12)
+            || ((bottom_row[3] - 1.0).abs() > 1.0e-12)
+        {
+            return Err(OptimizationError::InvalidParameter(
+                "IMU extrinsic transform must be homogeneous".into(),
+            ));
+        }
+        let rotation = body_from_sensor.fixed_view::<3, 3>(0, 0).into_owned();
+        let orthogonality_error = rotation.transpose() * rotation - Matrix3::identity();
+        if orthogonality_error.norm() > 1.0e-8 || (rotation.determinant() - 1.0).abs() > 1.0e-8 {
+            return Err(OptimizationError::InvalidParameter(
+                "IMU extrinsic rotation must be in SO(3)".into(),
+            ));
+        }
+        Ok(Self {
+            rotation_body_from_sensor: rotation,
+            translation_body_from_sensor: body_from_sensor.fixed_view::<3, 1>(0, 3).into_owned(),
+        })
+    }
+
+    /// Transforms a sensor-frame IMU sample to the body frame.
+    ///
+    /// The acceleration includes centripetal and tangential lever-arm terms,
+    /// matching MathematicalRobotics `transformIMU`.
+    pub fn transform(
+        &self,
+        measurement: ImuMeasurement,
+        angular_acceleration_sensor: Vector3<f64>,
+    ) -> ImuMeasurement {
+        let angular_velocity = self.rotation_body_from_sensor * measurement.angular_velocity;
+        let angular_acceleration = self.rotation_body_from_sensor * angular_acceleration_sensor;
+        let translation = self.translation_body_from_sensor;
+        let acceleration = self.rotation_body_from_sensor * measurement.acceleration
+            - skew(&angular_velocity) * skew(&angular_velocity) * translation
+            + skew(&translation) * angular_acceleration;
+        ImuMeasurement {
+            acceleration,
+            angular_velocity,
+        }
+    }
+}
 
 /// Accelerometer and gyroscope biases.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -163,6 +238,22 @@ impl PreintegratedImuMeasurement {
         Ok(())
     }
 
+    /// Transforms and integrates one sensor-frame IMU sample.
+    pub fn integrate_sensor_measurement(
+        &mut self,
+        measurement: ImuMeasurement,
+        angular_acceleration_sensor: Vector3<f64>,
+        extrinsics: &ImuExtrinsics,
+        dt: f64,
+    ) -> OptimizationResult<()> {
+        let body_measurement = extrinsics.transform(measurement, angular_acceleration_sensor);
+        self.integrate(
+            body_measurement.acceleration,
+            body_measurement.angular_velocity,
+            dt,
+        )
+    }
+
     /// Predicts the next navigation state, applying first-order bias correction.
     pub fn predict(&self, state: &NavState, bias: &ImuBias, gravity: Vector3<f64>) -> NavState {
         let (corrected_rotation, corrected_position, corrected_velocity) =
@@ -190,6 +281,24 @@ impl PreintegratedImuMeasurement {
     }
 }
 
+/// Relative rotation, position and velocity measurement between navigation states.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NavStateDelta {
+    pub rotation: Matrix3<f64>,
+    pub position: Vector3<f64>,
+    pub velocity: Vector3<f64>,
+}
+
+impl NavStateDelta {
+    pub fn identity() -> Self {
+        Self {
+            rotation: Matrix3::identity(),
+            position: Vector3::zeros(),
+            velocity: Vector3::zeros(),
+        }
+    }
+}
+
 /// Creates a 9-DOF manifold variable for a navigation state.
 pub fn nav_state_variable(state: &NavState) -> Variable {
     Variable::with_retraction(encode_nav_state(state), 9, retract_nav_state)
@@ -199,6 +308,274 @@ pub fn nav_state_variable(state: &NavState) -> Variable {
 /// Creates a Euclidean six-dimensional bias variable.
 pub fn imu_bias_variable(bias: &ImuBias) -> Variable {
     Variable::euclidean(bias.vector())
+}
+
+/// Prior factor for one six-dimensional accelerometer/gyroscope bias.
+pub struct BiasPriorFactor {
+    variables: [VariableId; 1],
+    measurement: ImuBias,
+    information: Matrix6,
+}
+
+impl BiasPriorFactor {
+    pub fn new(variable: VariableId, measurement: ImuBias, information: Matrix6) -> Self {
+        Self {
+            variables: [variable],
+            measurement,
+            information,
+        }
+    }
+}
+
+impl Factor for BiasPriorFactor {
+    fn variable_ids(&self) -> &[VariableId] {
+        &self.variables
+    }
+
+    fn evaluate(&self, values: &[&DVector<f64>]) -> OptimizationResult<FactorEvaluation> {
+        expect_dimensions(values, &[6], "bias prior")?;
+        Ok(FactorEvaluation {
+            residual: values[0] - self.measurement.vector(),
+            information: fixed_to_dynamic(&self.information),
+            jacobians: vec![DMatrix::identity(6, 6)],
+        })
+    }
+}
+
+/// Random-walk factor constraining two consecutive IMU biases.
+pub struct BiasBetweenFactor {
+    variables: [VariableId; 2],
+    information: Matrix6,
+}
+
+impl BiasBetweenFactor {
+    pub fn new(bias_i: VariableId, bias_j: VariableId, information: Matrix6) -> Self {
+        Self {
+            variables: [bias_i, bias_j],
+            information,
+        }
+    }
+}
+
+impl Factor for BiasBetweenFactor {
+    fn variable_ids(&self) -> &[VariableId] {
+        &self.variables
+    }
+
+    fn evaluate(&self, values: &[&DVector<f64>]) -> OptimizationResult<FactorEvaluation> {
+        expect_dimensions(values, &[6, 6], "bias between")?;
+        Ok(FactorEvaluation {
+            residual: values[0] - values[1],
+            information: fixed_to_dynamic(&self.information),
+            jacobians: vec![DMatrix::identity(6, 6), -DMatrix::identity(6, 6)],
+        })
+    }
+}
+
+/// Prior factor for a full navigation state.
+pub struct NavStatePriorFactor {
+    variables: [VariableId; 1],
+    measurement: NavState,
+    information: Matrix9,
+}
+
+impl NavStatePriorFactor {
+    pub fn new(variable: VariableId, measurement: NavState, information: Matrix9) -> Self {
+        Self {
+            variables: [variable],
+            measurement,
+            information,
+        }
+    }
+
+    fn residual(&self, value: &DVector<f64>) -> nalgebra::SVector<f64, 9> {
+        let state = decode_nav_state(value);
+        nav_state_local(&state, &self.measurement)
+    }
+}
+
+impl Factor for NavStatePriorFactor {
+    fn variable_ids(&self) -> &[VariableId] {
+        &self.variables
+    }
+
+    fn evaluate(&self, values: &[&DVector<f64>]) -> OptimizationResult<FactorEvaluation> {
+        expect_dimensions(values, &[9], "navigation-state prior")?;
+        let state = decode_nav_state(values[0]);
+        let residual = self.residual(values[0]);
+        let rotation_residual = Vector3::from(residual.fixed_rows::<3>(0));
+        let local_position = Vector3::from(residual.fixed_rows::<3>(3));
+        let local_velocity = Vector3::from(residual.fixed_rows::<3>(6));
+        let inverse_rotation = state.rotation.transpose();
+        let mut jacobian = DMatrix::zeros(9, 9);
+        jacobian
+            .view_mut((0, 0), (3, 3))
+            .copy_from(&(-so3_left_jacobian_inverse(&rotation_residual)));
+        jacobian
+            .view_mut((3, 0), (3, 3))
+            .copy_from(&skew(&local_position));
+        jacobian
+            .view_mut((3, 3), (3, 3))
+            .copy_from(&(-inverse_rotation));
+        jacobian
+            .view_mut((6, 0), (3, 3))
+            .copy_from(&skew(&local_velocity));
+        jacobian
+            .view_mut((6, 6), (3, 3))
+            .copy_from(&(-inverse_rotation));
+        Ok(FactorEvaluation {
+            residual: DVector::from_column_slice(residual.as_slice()),
+            information: fixed_to_dynamic(&self.information),
+            jacobians: vec![jacobian],
+        })
+    }
+}
+
+/// Constrains velocity to the finite difference between consecutive positions.
+pub struct PositionVelocityFactor {
+    variables: [VariableId; 2],
+    delta_time: f64,
+    information: Matrix3<f64>,
+}
+
+impl PositionVelocityFactor {
+    pub fn new(
+        state_i: VariableId,
+        state_j: VariableId,
+        delta_time: f64,
+        information: Matrix3<f64>,
+    ) -> OptimizationResult<Self> {
+        if !delta_time.is_finite() || delta_time <= 0.0 {
+            return Err(OptimizationError::InvalidParameter(
+                "position/velocity factor dt must be finite and positive".into(),
+            ));
+        }
+        Ok(Self {
+            variables: [state_i, state_j],
+            delta_time,
+            information,
+        })
+    }
+}
+
+impl Factor for PositionVelocityFactor {
+    fn variable_ids(&self) -> &[VariableId] {
+        &self.variables
+    }
+
+    fn evaluate(&self, values: &[&DVector<f64>]) -> OptimizationResult<FactorEvaluation> {
+        expect_dimensions(values, &[9, 9], "position/velocity")?;
+        let state_i = decode_nav_state(values[0]);
+        let state_j = decode_nav_state(values[1]);
+        let inverse_dt = self.delta_time.recip();
+        let residual = state_i.velocity - (state_j.position - state_i.position) * inverse_dt;
+        let mut jacobian_i = DMatrix::zeros(3, 9);
+        jacobian_i
+            .view_mut((0, 3), (3, 3))
+            .copy_from(&(Matrix3::identity() * inverse_dt));
+        jacobian_i
+            .view_mut((0, 6), (3, 3))
+            .copy_from(&Matrix3::identity());
+        let mut jacobian_j = DMatrix::zeros(3, 9);
+        jacobian_j
+            .view_mut((0, 3), (3, 3))
+            .copy_from(&(-Matrix3::identity() * inverse_dt));
+        Ok(FactorEvaluation {
+            residual: DVector::from_column_slice(residual.as_slice()),
+            information: fixed_to_dynamic(&self.information),
+            jacobians: vec![jacobian_i, jacobian_j],
+        })
+    }
+}
+
+/// Relative navigation-state factor, equivalent to MathematicalRobotics `NavitransEdge`.
+pub struct NavStateBetweenFactor {
+    variables: [VariableId; 2],
+    measurement: NavStateDelta,
+    information: Matrix9,
+}
+
+impl NavStateBetweenFactor {
+    pub fn new(
+        state_i: VariableId,
+        state_j: VariableId,
+        measurement: NavStateDelta,
+        information: Matrix9,
+    ) -> Self {
+        Self {
+            variables: [state_i, state_j],
+            measurement,
+            information,
+        }
+    }
+
+    fn residual(
+        &self,
+        value_i: &DVector<f64>,
+        value_j: &DVector<f64>,
+    ) -> nalgebra::SVector<f64, 9> {
+        let state_i = decode_nav_state(value_i);
+        let state_j = decode_nav_state(value_j);
+        let predicted = nav_state_delta(&state_i, &state_j);
+        let rotation_error = so3_log(&(self.measurement.rotation.transpose() * predicted.rotation));
+        nalgebra::SVector::<f64, 9>::from_iterator(
+            rotation_error
+                .iter()
+                .chain((predicted.position - self.measurement.position).iter())
+                .chain((predicted.velocity - self.measurement.velocity).iter())
+                .copied(),
+        )
+    }
+}
+
+impl Factor for NavStateBetweenFactor {
+    fn variable_ids(&self) -> &[VariableId] {
+        &self.variables
+    }
+
+    fn evaluate(&self, values: &[&DVector<f64>]) -> OptimizationResult<FactorEvaluation> {
+        expect_dimensions(values, &[9, 9], "navigation-state between")?;
+        let state_i = decode_nav_state(values[0]);
+        let state_j = decode_nav_state(values[1]);
+        let residual = self.residual(values[0], values[1]);
+        let local_position = state_i.rotation.transpose() * (state_j.position - state_i.position);
+        let local_velocity = state_i.rotation.transpose() * (state_j.velocity - state_i.velocity);
+        let rotation_residual = Vector3::from(residual.fixed_rows::<3>(0));
+        let inverse_rotation_i = state_i.rotation.transpose();
+        let mut jacobian_i = DMatrix::zeros(9, 9);
+        jacobian_i.view_mut((0, 0), (3, 3)).copy_from(
+            &(-so3_left_jacobian_inverse(&rotation_residual)
+                * self.measurement.rotation.transpose()),
+        );
+        jacobian_i
+            .view_mut((3, 0), (3, 3))
+            .copy_from(&skew(&local_position));
+        jacobian_i
+            .view_mut((3, 3), (3, 3))
+            .copy_from(&(-inverse_rotation_i));
+        jacobian_i
+            .view_mut((6, 0), (3, 3))
+            .copy_from(&skew(&local_velocity));
+        jacobian_i
+            .view_mut((6, 6), (3, 3))
+            .copy_from(&(-inverse_rotation_i));
+
+        let mut jacobian_j = DMatrix::zeros(9, 9);
+        jacobian_j
+            .view_mut((0, 0), (3, 3))
+            .copy_from(&so3_left_jacobian_inverse(&(-rotation_residual)));
+        jacobian_j
+            .view_mut((3, 3), (3, 3))
+            .copy_from(&inverse_rotation_i);
+        jacobian_j
+            .view_mut((6, 6), (3, 3))
+            .copy_from(&inverse_rotation_i);
+        Ok(FactorEvaluation {
+            residual: DVector::from_column_slice(residual.as_slice()),
+            information: fixed_to_dynamic(&self.information),
+            jacobians: vec![jacobian_i, jacobian_j],
+        })
+    }
 }
 
 /// IMU factor linking `(state_i, state_j, bias_i)`.
@@ -381,6 +758,167 @@ impl ImuFactor {
     }
 }
 
+/// Configuration for joint navigation-state and IMU-bias refinement.
+#[derive(Debug, Clone)]
+pub struct ImuTrajectoryConfig {
+    pub solver: SolverConfig,
+    pub nav_prior_information: Matrix9,
+    /// Optional information applied to every supplied initial navigation state.
+    ///
+    /// This lets visual pose estimates constrain the inertial trajectory. Zero
+    /// rows/columns can leave velocity or another component unconstrained.
+    pub nav_measurement_information: Option<Matrix9>,
+    pub bias_prior_information: Matrix6,
+    pub bias_between_information: Matrix6,
+}
+
+impl Default for ImuTrajectoryConfig {
+    fn default() -> Self {
+        Self {
+            solver: SolverConfig::default(),
+            nav_prior_information: Matrix9::identity() * 1.0e8,
+            nav_measurement_information: None,
+            bias_prior_information: Matrix6::identity() * 1.0e4,
+            bias_between_information: Matrix6::identity() * 1.0e3,
+        }
+    }
+}
+
+/// Refined navigation states, time-varying biases and solver diagnostics.
+#[derive(Debug, Clone)]
+pub struct ImuTrajectoryResult {
+    pub states: Vec<NavState>,
+    pub biases: Vec<ImuBias>,
+    pub summary: SolverSummary,
+}
+
+/// Jointly refines a navigation-state sequence and one bias per keyframe.
+///
+/// The first state and bias receive priors, each preintegrated interval adds an
+/// [`ImuFactor`], and consecutive biases receive a random-walk constraint.
+pub fn optimize_imu_trajectory(
+    initial_states: &[NavState],
+    initial_bias: ImuBias,
+    measurements: &[PreintegratedImuMeasurement],
+    gravity: Vector3<f64>,
+    config: &ImuTrajectoryConfig,
+) -> OptimizationResult<ImuTrajectoryResult> {
+    if initial_states.len() < 2 || measurements.len() + 1 != initial_states.len() {
+        return Err(OptimizationError::InvalidParameter(
+            "IMU trajectory requires N states and N-1 measurements".into(),
+        ));
+    }
+    let mut problem = Problem::new();
+    let state_ids = initial_states
+        .iter()
+        .map(|state| problem.add_variable(nav_state_variable(state)))
+        .collect::<Vec<_>>();
+    let bias_ids = initial_states
+        .iter()
+        .map(|_| problem.add_variable(imu_bias_variable(&initial_bias)))
+        .collect::<Vec<_>>();
+
+    problem.add_factor(NavStatePriorFactor::new(
+        state_ids[0],
+        initial_states[0].clone(),
+        config.nav_prior_information,
+    ))?;
+    problem.add_factor(BiasPriorFactor::new(
+        bias_ids[0],
+        initial_bias,
+        config.bias_prior_information,
+    ))?;
+    if let Some(information) = config.nav_measurement_information {
+        for (id, measurement) in state_ids.iter().zip(initial_states) {
+            problem.add_factor(NavStatePriorFactor::new(
+                *id,
+                measurement.clone(),
+                information,
+            ))?;
+        }
+    }
+    for (index, measurement) in measurements.iter().enumerate() {
+        problem.add_factor(ImuFactor::new(
+            state_ids[index],
+            state_ids[index + 1],
+            bias_ids[index],
+            measurement.clone(),
+            gravity,
+        ))?;
+        problem.add_factor(BiasBetweenFactor::new(
+            bias_ids[index],
+            bias_ids[index + 1],
+            config.bias_between_information,
+        ))?;
+    }
+
+    let summary = solve(&mut problem, &config.solver)?;
+    let states = state_ids
+        .iter()
+        .map(|id| {
+            problem
+                .variable(*id)
+                .map(|variable| decode_nav_state(variable.value()))
+        })
+        .collect::<OptimizationResult<Vec<_>>>()?;
+    let biases = bias_ids
+        .iter()
+        .map(|id| {
+            problem
+                .variable(*id)
+                .map(|variable| decode_bias(variable.value()))
+        })
+        .collect::<OptimizationResult<Vec<_>>>()?;
+    Ok(ImuTrajectoryResult {
+        states,
+        biases,
+        summary,
+    })
+}
+
+fn nav_state_delta(from: &NavState, to: &NavState) -> NavStateDelta {
+    let inverse_rotation = from.rotation.transpose();
+    NavStateDelta {
+        rotation: inverse_rotation * to.rotation,
+        position: inverse_rotation * (to.position - from.position),
+        velocity: inverse_rotation * (to.velocity - from.velocity),
+    }
+}
+
+fn nav_state_local(from: &NavState, to: &NavState) -> nalgebra::SVector<f64, 9> {
+    let delta = nav_state_delta(from, to);
+    let rotation = so3_log(&delta.rotation);
+    nalgebra::SVector::<f64, 9>::from_iterator(
+        rotation
+            .iter()
+            .chain(delta.position.iter())
+            .chain(delta.velocity.iter())
+            .copied(),
+    )
+}
+
+fn expect_dimensions(
+    values: &[&DVector<f64>],
+    dimensions: &[usize],
+    factor_name: &str,
+) -> OptimizationResult<()> {
+    if values.len() != dimensions.len()
+        || values
+            .iter()
+            .zip(dimensions)
+            .any(|(value, dimension)| value.len() != *dimension)
+    {
+        return Err(OptimizationError::InvalidFactor(format!(
+            "{factor_name} factor received invalid variable dimensions"
+        )));
+    }
+    Ok(())
+}
+
+fn fixed_to_dynamic<const N: usize>(matrix: &SMatrix<f64, N, N>) -> DMatrix<f64> {
+    DMatrix::from_column_slice(N, N, matrix.as_slice())
+}
+
 fn encode_nav_state(state: &NavState) -> DVector<f64> {
     let rotation = so3_log(&state.rotation);
     DVector::from_vec(vec![
@@ -434,6 +972,165 @@ mod tests {
     use rust_robotics_optimization::{Factor, Problem};
 
     use super::*;
+
+    fn numerical_factor_jacobian(
+        factor: &dyn Factor,
+        values: &[DVector<f64>],
+        variable: usize,
+        nav_state: bool,
+    ) -> DMatrix<f64> {
+        let residual_dimension = {
+            let refs = values.iter().collect::<Vec<_>>();
+            factor.evaluate(&refs).unwrap().residual.len()
+        };
+        let dimension = values[variable].len();
+        let epsilon = 1.0e-6;
+        let mut jacobian = DMatrix::zeros(residual_dimension, dimension);
+        for column in 0..dimension {
+            let mut increment = DVector::zeros(dimension);
+            increment[column] = epsilon;
+            let mut plus = values.to_vec();
+            let mut minus = values.to_vec();
+            plus[variable] = if nav_state {
+                retract_nav_state(&values[variable], &increment).unwrap()
+            } else {
+                &values[variable] + &increment
+            };
+            minus[variable] = if nav_state {
+                retract_nav_state(&values[variable], &(-&increment)).unwrap()
+            } else {
+                &values[variable] - &increment
+            };
+            let plus_refs = plus.iter().collect::<Vec<_>>();
+            let minus_refs = minus.iter().collect::<Vec<_>>();
+            let derivative = (factor.evaluate(&plus_refs).unwrap().residual
+                - factor.evaluate(&minus_refs).unwrap().residual)
+                / (2.0 * epsilon);
+            jacobian.set_column(column, &derivative);
+        }
+        jacobian
+    }
+
+    #[test]
+    fn imu_extrinsics_include_rotation_and_lever_arm_terms() {
+        let extrinsics = ImuExtrinsics {
+            rotation_body_from_sensor: so3_exp(&Vector3::new(0.1, -0.2, 0.3)),
+            translation_body_from_sensor: Vector3::new(0.4, -0.2, 0.1),
+        };
+        let measurement = ImuMeasurement {
+            acceleration: Vector3::new(0.3, -0.1, 9.7),
+            angular_velocity: Vector3::new(0.2, -0.3, 0.4),
+        };
+        let angular_acceleration = Vector3::new(0.05, 0.02, -0.04);
+        let transformed = extrinsics.transform(measurement, angular_acceleration);
+        let rotation = extrinsics.rotation_body_from_sensor;
+        let omega = rotation * measurement.angular_velocity;
+        let alpha = rotation * angular_acceleration;
+        let expected_acceleration = rotation * measurement.acceleration
+            - skew(&omega) * skew(&omega) * extrinsics.translation_body_from_sensor
+            + skew(&extrinsics.translation_body_from_sensor) * alpha;
+        assert!((transformed.acceleration - expected_acceleration).norm() < 1.0e-12);
+        assert!((transformed.angular_velocity - omega).norm() < 1.0e-12);
+
+        let identity = ImuExtrinsics::identity().transform(measurement, angular_acceleration);
+        assert_eq!(identity, measurement);
+    }
+
+    #[test]
+    fn specialized_factor_jacobians_match_finite_differences() {
+        let state_i = NavState {
+            rotation: so3_exp(&Vector3::new(0.2, -0.1, 0.3)),
+            position: Vector3::new(1.0, -2.0, 0.5),
+            velocity: Vector3::new(0.4, 0.1, -0.2),
+        };
+        let state_j = NavState {
+            rotation: so3_exp(&Vector3::new(-0.1, 0.3, 0.2)),
+            position: Vector3::new(1.3, -1.8, 0.7),
+            velocity: Vector3::new(0.2, 0.5, -0.1),
+        };
+        let measurement = NavState {
+            rotation: so3_exp(&Vector3::new(0.25, -0.05, 0.28)),
+            position: Vector3::new(0.9, -1.9, 0.55),
+            velocity: Vector3::new(0.35, 0.2, -0.15),
+        };
+        let value_i = encode_nav_state(&state_i);
+        let value_j = encode_nav_state(&state_j);
+
+        let prior = NavStatePriorFactor::new(VariableId(0), measurement, Matrix9::identity());
+        let prior_values = vec![value_i.clone()];
+        let prior_refs = prior_values.iter().collect::<Vec<_>>();
+        let prior_evaluation = prior.evaluate(&prior_refs).unwrap();
+        let prior_numerical = numerical_factor_jacobian(&prior, &prior_values, 0, true);
+        assert!(
+            (&prior_evaluation.jacobians[0] - prior_numerical).norm() < 1.0e-5,
+            "navigation prior analytic Jacobian disagrees with finite differences"
+        );
+
+        let between_measurement = NavStateDelta {
+            rotation: so3_exp(&Vector3::new(-0.2, 0.1, 0.15)),
+            position: Vector3::new(0.2, 0.1, -0.05),
+            velocity: Vector3::new(-0.1, 0.25, 0.08),
+        };
+        let between = NavStateBetweenFactor::new(
+            VariableId(0),
+            VariableId(1),
+            between_measurement,
+            Matrix9::identity(),
+        );
+        let between_values = vec![value_i.clone(), value_j.clone()];
+        let between_refs = between_values.iter().collect::<Vec<_>>();
+        let between_evaluation = between.evaluate(&between_refs).unwrap();
+        for variable in 0..2 {
+            let numerical = numerical_factor_jacobian(&between, &between_values, variable, true);
+            assert!(
+                (&between_evaluation.jacobians[variable] - numerical).norm() < 1.0e-5,
+                "navigation between analytic Jacobian {variable} disagrees with finite differences"
+            );
+        }
+
+        let position_velocity =
+            PositionVelocityFactor::new(VariableId(0), VariableId(1), 0.2, Matrix3::identity())
+                .unwrap();
+        let pv_evaluation = position_velocity.evaluate(&between_refs).unwrap();
+        for variable in 0..2 {
+            let numerical =
+                numerical_factor_jacobian(&position_velocity, &between_values, variable, true);
+            assert!(
+                (&pv_evaluation.jacobians[variable] - numerical).norm() < 1.0e-7,
+                "position/velocity analytic Jacobian {variable} disagrees with finite differences"
+            );
+        }
+    }
+
+    #[test]
+    fn bias_factors_match_mathematical_robotics_residuals() {
+        let bias_i = ImuBias {
+            accelerometer: Vector3::new(0.1, -0.2, 0.3),
+            gyroscope: Vector3::new(-0.01, 0.02, 0.03),
+        };
+        let bias_j = ImuBias {
+            accelerometer: Vector3::new(0.08, -0.18, 0.25),
+            gyroscope: Vector3::new(-0.02, 0.01, 0.04),
+        };
+        let prior = BiasPriorFactor::new(VariableId(0), bias_j, Matrix6::identity());
+        let prior_value = bias_i.vector();
+        let prior_evaluation = prior.evaluate(&[&prior_value]).unwrap();
+        assert!((prior_evaluation.residual - (bias_i.vector() - bias_j.vector())).norm() < 1.0e-12);
+
+        let between = BiasBetweenFactor::new(VariableId(0), VariableId(1), Matrix6::identity());
+        let value_i = bias_i.vector();
+        let value_j = bias_j.vector();
+        let evaluation = between.evaluate(&[&value_i, &value_j]).unwrap();
+        assert!((evaluation.residual - (bias_i.vector() - bias_j.vector())).norm() < 1.0e-12);
+        let values = vec![value_i, value_j];
+        for variable in 0..2 {
+            let numerical = numerical_factor_jacobian(&between, &values, variable, false);
+            assert!(
+                (&evaluation.jacobians[variable] - numerical).norm() < 1.0e-9,
+                "bias-between analytic Jacobian {variable} disagrees with finite differences"
+            );
+        }
+    }
 
     #[test]
     fn stationary_imu_prediction_cancels_gravity() {
@@ -493,5 +1190,86 @@ mod tests {
                 "analytic IMU Jacobian {variable} disagrees with finite differences"
             );
         }
+    }
+
+    #[test]
+    fn trajectory_optimizer_preserves_consistent_prediction() {
+        let bias = ImuBias {
+            accelerometer: Vector3::new(0.01, -0.02, 0.03),
+            gyroscope: Vector3::new(0.001, -0.002, 0.003),
+        };
+        let gravity = Vector3::new(0.0, 0.0, -9.81);
+        let initial = NavState::identity();
+        let mut measurement = PreintegratedImuMeasurement::new(bias, ImuNoise::default());
+        measurement
+            .integrate(
+                Vector3::new(0.1, -0.2, 9.9),
+                Vector3::new(0.02, 0.01, -0.03),
+                0.1,
+            )
+            .unwrap();
+        let predicted = measurement.predict(&initial, &bias, gravity);
+        let result = optimize_imu_trajectory(
+            &[initial.clone(), predicted.clone()],
+            bias,
+            &[measurement],
+            gravity,
+            &ImuTrajectoryConfig::default(),
+        )
+        .unwrap();
+        assert!(nav_state_local(&result.states[0], &initial).norm() < 1.0e-9);
+        assert!(nav_state_local(&result.states[1], &predicted).norm() < 1.0e-9);
+        assert!((result.biases[0].vector() - bias.vector()).norm() < 1.0e-9);
+        assert!((result.biases[1].vector() - bias.vector()).norm() < 1.0e-9);
+    }
+
+    #[test]
+    fn visual_state_priors_make_constant_accelerometer_bias_observable() {
+        let gravity = Vector3::new(0.0, 0.0, -9.81);
+        let true_bias = ImuBias {
+            accelerometer: Vector3::new(0.2, -0.1, 0.05),
+            gyroscope: Vector3::zeros(),
+        };
+        let linearization_bias = ImuBias::zero();
+        let initial = NavState::identity();
+        let mut states = vec![initial.clone()];
+        let mut measurements = Vec::new();
+        for _ in 0..4 {
+            let mut measurement =
+                PreintegratedImuMeasurement::new(linearization_bias, ImuNoise::default());
+            for _ in 0..10 {
+                measurement
+                    .integrate(
+                        Vector3::new(0.0, 0.0, 9.81) + true_bias.accelerometer,
+                        Vector3::zeros(),
+                        0.01,
+                    )
+                    .unwrap();
+            }
+            states.push(measurement.predict(states.last().unwrap(), &true_bias, gravity));
+            measurements.push(measurement);
+        }
+        let mut visual_information = Matrix9::zeros();
+        visual_information
+            .fixed_view_mut::<6, 6>(0, 0)
+            .copy_from(&(SMatrix::<f64, 6, 6>::identity() * 1.0e8));
+        let result = optimize_imu_trajectory(
+            &states,
+            linearization_bias,
+            &measurements,
+            gravity,
+            &ImuTrajectoryConfig {
+                nav_measurement_information: Some(visual_information),
+                bias_prior_information: Matrix6::identity() * 1.0e-6,
+                bias_between_information: Matrix6::identity() * 1.0e6,
+                ..ImuTrajectoryConfig::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            (result.biases[0].accelerometer - true_bias.accelerometer).norm() < 1.0e-4,
+            "estimated bias {:?}",
+            result.biases[0].accelerometer
+        );
     }
 }

--- a/crates/rust_robotics_slam/src/vio_pipeline.rs
+++ b/crates/rust_robotics_slam/src/vio_pipeline.rs
@@ -9,7 +9,10 @@ use crate::bundle_adjustment::{
     ReprojectionObservation,
 };
 use crate::dataset::{EurocDataset, EurocFeatureTracks, ImuSample};
-use crate::imu_preintegration::{ImuBias, ImuNoise, NavState, PreintegratedImuMeasurement};
+use crate::imu_preintegration::{
+    optimize_imu_trajectory, ImuBias, ImuExtrinsics, ImuMeasurement, ImuNoise, ImuTrajectoryConfig,
+    Matrix9, NavState, PreintegratedImuMeasurement,
+};
 use crate::pose_graph_optimization::PoseGraphConfig;
 use crate::pose_graph_optimization_3d::{
     optimize_pose_graph_3d, Edge3D, Pose3DNode, PoseGraphResult3D,
@@ -23,6 +26,8 @@ pub struct VioPipelineInput {
     pub initial_state: NavState,
     pub bias: ImuBias,
     pub gravity: Vector3<f64>,
+    /// Body-from-IMU extrinsic transform.
+    pub body_from_imu: Matrix4<f64>,
     /// Body-from-camera extrinsic transform.
     pub body_from_camera: Matrix4<f64>,
     pub landmarks: Vec<Vector3<f64>>,
@@ -34,6 +39,7 @@ pub struct VioPipelineInput {
 #[derive(Debug, Clone)]
 pub struct VioPipelineConfig {
     pub imu_noise: ImuNoise,
+    pub imu_trajectory: ImuTrajectoryConfig,
     pub bundle_adjustment: BundleAdjustmentConfig,
     pub pose_graph: PoseGraphConfig,
     pub imu_information: Matrix6,
@@ -42,8 +48,16 @@ pub struct VioPipelineConfig {
 
 impl Default for VioPipelineConfig {
     fn default() -> Self {
+        let mut nav_measurement_information = Matrix9::zeros();
+        nav_measurement_information
+            .fixed_view_mut::<6, 6>(0, 0)
+            .copy_from(&(nalgebra::SMatrix::<f64, 6, 6>::identity() * 50.0));
         Self {
             imu_noise: ImuNoise::default(),
+            imu_trajectory: ImuTrajectoryConfig {
+                nav_measurement_information: Some(nav_measurement_information),
+                ..ImuTrajectoryConfig::default()
+            },
             bundle_adjustment: BundleAdjustmentConfig::default(),
             pose_graph: PoseGraphConfig {
                 linear_solver: LinearSolver::BlockSparsePcg {
@@ -62,12 +76,14 @@ impl Default for VioPipelineConfig {
 #[derive(Debug, Clone)]
 pub struct VioPipelineResult {
     pub imu_states: Vec<NavState>,
+    pub imu_biases: Vec<ImuBias>,
     pub bundle_adjusted_cameras: Vec<Matrix4<f64>>,
     pub landmarks: Vec<Vector3<f64>>,
     pub trajectory: Vec<Matrix4<f64>>,
     pub pose_graph_iterations: usize,
     pub pose_graph_converged: bool,
     pub bundle_adjustment_iterations: usize,
+    pub imu_optimization_iterations: usize,
 }
 
 /// Converts a loaded EuRoC sequence and pre-extracted track sidecar into VIO
@@ -109,6 +125,7 @@ pub fn euroc_vio_input(
         initial_state,
         bias,
         gravity,
+        body_from_imu: dataset.imu_body_from_sensor,
         body_from_camera: dataset.camera.body_from_sensor,
         landmarks: tracks
             .landmarks
@@ -146,6 +163,7 @@ pub fn euroc_imu_camera_trajectory(
         initial_state,
         bias,
         gravity,
+        &dataset.imu_body_from_sensor,
         noise,
     )?;
     Ok(states
@@ -160,8 +178,8 @@ pub fn run_vio_pipeline(
     config: &VioPipelineConfig,
 ) -> OptimizationResult<VioPipelineResult> {
     validate_input(input)?;
-    let (imu_states, preintegrated) = initialize_from_imu(input, config)?;
-    let imu_cameras = imu_states
+    let (predicted_imu_states, preintegrated) = initialize_from_imu(input, config)?;
+    let imu_cameras = predicted_imu_states
         .iter()
         .map(|state| nav_state_pose(state) * input.body_from_camera)
         .collect::<Vec<_>>();
@@ -174,6 +192,28 @@ pub fn run_vio_pipeline(
         },
         &config.bundle_adjustment,
     )?;
+    let camera_from_body = se3_inverse(&input.body_from_camera);
+    let visual_nav_states = bundle_adjustment
+        .cameras
+        .iter()
+        .zip(&predicted_imu_states)
+        .map(|(world_from_camera, predicted)| {
+            let world_from_body = world_from_camera * camera_from_body;
+            NavState {
+                rotation: world_from_body.fixed_view::<3, 3>(0, 0).into_owned(),
+                position: world_from_body.fixed_view::<3, 1>(0, 3).into_owned(),
+                velocity: predicted.velocity,
+            }
+        })
+        .collect::<Vec<_>>();
+    let inertial = optimize_imu_trajectory(
+        &visual_nav_states,
+        input.bias,
+        &preintegrated,
+        input.gravity,
+        &config.imu_trajectory,
+    )?;
+    let imu_states = inertial.states;
 
     let graph = fuse_pose_graph(
         &bundle_adjustment.cameras,
@@ -184,12 +224,14 @@ pub fn run_vio_pipeline(
     );
     Ok(VioPipelineResult {
         imu_states,
+        imu_biases: inertial.biases,
         bundle_adjusted_cameras: bundle_adjustment.cameras,
         landmarks: bundle_adjustment.points,
         trajectory: graph.poses.iter().map(|pose| pose.transform).collect(),
         pose_graph_iterations: graph.iterations,
         pose_graph_converged: graph.converged,
         bundle_adjustment_iterations: bundle_adjustment.summary.iterations,
+        imu_optimization_iterations: inertial.summary.iterations,
     })
 }
 
@@ -206,6 +248,15 @@ fn validate_input(input: &VioPipelineInput) -> OptimizationResult<()> {
     {
         return Err(OptimizationError::InvalidParameter(
             "VIO keyframe timestamps must be strictly increasing".into(),
+        ));
+    }
+    if input
+        .imu_samples
+        .windows(2)
+        .any(|window| window[1].timestamp_ns <= window[0].timestamp_ns)
+    {
+        return Err(OptimizationError::InvalidParameter(
+            "VIO IMU timestamps must be strictly increasing".into(),
         ));
     }
     if input.imu_samples.is_empty() || input.landmarks.is_empty() {
@@ -234,6 +285,7 @@ fn initialize_from_imu(
         input.initial_state.clone(),
         input.bias,
         input.gravity,
+        &input.body_from_imu,
         config.imu_noise,
     )
 }
@@ -244,6 +296,7 @@ fn initialize_imu_sequence(
     initial_state: NavState,
     bias: ImuBias,
     gravity: Vector3<f64>,
+    body_from_imu: &Matrix4<f64>,
     noise: ImuNoise,
 ) -> OptimizationResult<(Vec<NavState>, Vec<PreintegratedImuMeasurement>)> {
     if timestamps_ns.len() < 2 {
@@ -253,8 +306,10 @@ fn initialize_imu_sequence(
     }
     let mut states = vec![initial_state];
     let mut measurements = Vec::with_capacity(timestamps_ns.len() - 1);
+    let extrinsics = ImuExtrinsics::from_homogeneous(body_from_imu)?;
     for interval in timestamps_ns.windows(2) {
-        let measurement = preintegrate_interval(samples, interval[0], interval[1], bias, noise)?;
+        let measurement =
+            preintegrate_interval(samples, interval[0], interval[1], bias, noise, &extrinsics)?;
         let next =
             measurement.predict(states.last().expect("initial state exists"), &bias, gravity);
         states.push(next);
@@ -292,6 +347,7 @@ fn preintegrate_interval(
     end_ns: i64,
     bias: ImuBias,
     noise: ImuNoise,
+    extrinsics: &ImuExtrinsics,
 ) -> OptimizationResult<PreintegratedImuMeasurement> {
     let mut measurement = PreintegratedImuMeasurement::new(bias, noise);
     let mut previous_ns = start_ns;
@@ -308,12 +364,37 @@ fn preintegrate_interval(
         .filter(|sample| sample.timestamp_ns > start_ns && sample.timestamp_ns < end_ns)
     {
         let dt = (sample.timestamp_ns - previous_ns) as f64 * 1.0e-9;
-        measurement.integrate(current.acceleration, current.angular_velocity, dt)?;
+        let angular_acceleration = (sample.angular_velocity - current.angular_velocity) / dt;
+        measurement.integrate_sensor_measurement(
+            ImuMeasurement {
+                acceleration: current.acceleration,
+                angular_velocity: current.angular_velocity,
+            },
+            angular_acceleration,
+            extrinsics,
+            dt,
+        )?;
         previous_ns = sample.timestamp_ns;
         current = sample;
     }
     let final_dt = (end_ns - previous_ns) as f64 * 1.0e-9;
-    measurement.integrate(current.acceleration, current.angular_velocity, final_dt)?;
+    let angular_acceleration = samples
+        .iter()
+        .find(|sample| sample.timestamp_ns >= end_ns && sample.timestamp_ns > current.timestamp_ns)
+        .map(|next| {
+            (next.angular_velocity - current.angular_velocity)
+                / ((next.timestamp_ns - current.timestamp_ns) as f64 * 1.0e-9)
+        })
+        .unwrap_or_else(Vector3::zeros);
+    measurement.integrate_sensor_measurement(
+        ImuMeasurement {
+            acceleration: current.acceleration,
+            angular_velocity: current.angular_velocity,
+        },
+        angular_acceleration,
+        extrinsics,
+        final_dt,
+    )?;
     Ok(measurement)
 }
 
@@ -430,6 +511,7 @@ mod tests {
             },
             bias: ImuBias::zero(),
             gravity: Vector3::new(0.0, 0.0, -9.81),
+            body_from_imu: Matrix4::identity(),
             body_from_camera: Matrix4::identity(),
             landmarks: truth_points
                 .iter()
@@ -441,6 +523,7 @@ mod tests {
         let result = run_vio_pipeline(&input, &VioPipelineConfig::default()).unwrap();
         assert!(result.pose_graph_converged);
         assert_eq!(result.trajectory.len(), truth_cameras.len());
+        assert_eq!(result.imu_biases.len(), truth_cameras.len());
         let terminal_error = pose_error(&result.trajectory[4], &truth_cameras[4]);
         assert!(terminal_error < 2.0e-2, "terminal error: {terminal_error}");
         let landmark_error = result

--- a/crates/rust_robotics_slam/tests/fixtures/euroc_mini/mav0/imu0/sensor.yaml
+++ b/crates/rust_robotics_slam/tests/fixtures/euroc_mini/mav0/imu0/sensor.yaml
@@ -1,0 +1,5 @@
+sensor_type: imu
+T_BS:
+  cols: 4
+  rows: 4
+  data: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]

--- a/crates/rust_robotics_slam/tests/mathematical_robotics_parity.rs
+++ b/crates/rust_robotics_slam/tests/mathematical_robotics_parity.rs
@@ -6,7 +6,7 @@ use nalgebra::{Matrix4, Vector2, Vector3};
 use rust_robotics_core::{se3_exp, se3_inverse, se3_log, Matrix6, Vector6};
 use rust_robotics_slam::bundle_adjustment::{reproject_world_point, CameraIntrinsics};
 use rust_robotics_slam::imu_preintegration::{
-    ImuBias, ImuNoise, NavState, PreintegratedImuMeasurement,
+    ImuBias, ImuExtrinsics, ImuMeasurement, ImuNoise, NavState, PreintegratedImuMeasurement,
 };
 use rust_robotics_slam::pose_graph_optimization::PoseGraphConfig;
 use rust_robotics_slam::pose_graph_optimization_3d::{optimize_pose_graph_3d, Edge3D, Pose3DNode};
@@ -99,6 +99,49 @@ fn imu_prediction_matches_mathr_preintegration() {
             ))
         .norm()
             < IMU_TOLERANCE
+    );
+}
+
+#[test]
+fn imu_extrinsic_transform_matches_mathr_kinematics() {
+    let body_from_sensor = Matrix4::from_row_slice(&[
+        0.9019840683889034,
+        -0.15288908060872075,
+        0.40379409282853806,
+        -0.6466681045654054,
+        0.231301825897598,
+        0.9607936273555614,
+        -0.15288908060872075,
+        0.7059522051667105,
+        -0.36458772018409946,
+        0.231301825897598,
+        0.9019840683889034,
+        2.2347636942319853,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]);
+    let transformed = ImuExtrinsics::from_homogeneous(&body_from_sensor)
+        .unwrap()
+        .transform(
+            ImuMeasurement {
+                acceleration: Vector3::new(0.3, -0.1, 9.7),
+                angular_velocity: Vector3::new(0.2, -0.3, 0.4),
+            },
+            Vector3::new(0.05, 0.02, -0.04),
+        );
+    assert!(
+        (transformed.acceleration
+            - Vector3::new(3.8885115178902527, -1.272134031029738, 9.21754932157626,))
+        .norm()
+            < TOLERANCE
+    );
+    assert!(
+        (transformed.angular_velocity
+            - Vector3::new(0.3877811749918122, -0.3031333552706371, 0.2184855355494621,))
+        .norm()
+            < TOLERANCE
     );
 }
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -17,14 +17,19 @@ MH_01_easy/
     │   ├── data.csv
     │   ├── data/*.png
     │   └── sensor.yaml
-    ├── imu0/data.csv
+    ├── imu0/
+    │   ├── data.csv
+    │   └── sensor.yaml
     └── state_groundtruth_estimate0/data.csv  # optional
 ```
 
 It validates increasing timestamps, parses camera intrinsics, resolution and
-`T_BS`, and exposes efficient IMU interval slices. Images remain paths so
-applications can choose their own decoder. RustRobotics includes a PNG-based
-sparse frontend CLI:
+the camera/IMU `T_BS` transforms, and exposes efficient IMU interval slices.
+IMU samples are transformed into the body frame before preintegration,
+including centripetal and tangential acceleration caused by a non-zero sensor
+lever arm. A missing legacy `imu0/sensor.yaml` falls back to an identity
+transform. Images remain paths so applications can choose their own decoder.
+RustRobotics includes a PNG-based sparse frontend CLI:
 
 ```bash
 cargo run --release -p rust_robotics \
@@ -68,9 +73,10 @@ The replay uses ground truth only for the initial state and acceptance report.
 Later ground-truth states are not optimizer inputs:
 
 ```text
-EuRoC IMU ──> bias-aware preintegration ──> metric initial trajectory
-feature tracks ───────────────────────────> camera/landmark BA (Schur)
-IMU relative edges + visual closure ─────> block-sparse SE(3) pose graph
+EuRoC IMU + T_BS ──> lever-arm correction ──> bias-aware preintegration
+feature tracks ─────────────────────────────> camera/landmark BA (Schur)
+BA poses + IMU factors ─────────────────────> navigation-state/bias refinement
+IMU relative edges + visual closure ────────> block-sparse SE(3) pose graph
 ```
 
 ## KITTI odometry

--- a/docs/mathematical-robotics-parity.md
+++ b/docs/mathematical-robotics-parity.md
@@ -5,6 +5,10 @@ against [scomup/MathematicalRobotics](https://github.com/scomup/MathematicalRobo
 at commit `79600010f0c86179905a6960e5fce2bb7cc85d77`.
 Both projects are MIT-licensed.
 
+See the [porting matrix](./mathematical-robotics-porting.md) for the complete
+module-by-module inventory. A module can be marked ported there without having
+a pinned numerical comparison in this report.
+
 The golden regression test is
 `crates/rust_robotics_slam/tests/mathematical_robotics_parity.rs`.
 
@@ -12,6 +16,7 @@ The golden regression test is
 |---|---|---:|
 | `se3_exp` / `se3_log` | `mathR/utilities/math_tools.py` | `2e-12` |
 | IMU integration and prediction | `mathR/imu_preintegration/preintegration.py` | `1e-6` |
+| IMU extrinsic/lever-arm transform | `mathR/kinematics/transfrom_imu.py` | `2e-12` |
 | pinhole reprojection | `mathR/slam/projection.py` | `2e-12` |
 | 12-node SE(3) loop closure optimum | `mathR/graph_optimization/demo_pose3d_graph.py` | `2e-4` |
 
@@ -26,6 +31,7 @@ cargo test -p rust_robotics_slam --test mathematical_robotics_parity
 
 Golden values were produced by checking out the pinned upstream commit,
 setting `PYTHONPATH` to that checkout, and evaluating the exact vectors listed
-in the test through its `expSE3`, `ImuIntegration`, `reproj_error`, and
-`GraphSolver` APIs. Changing the pinned commit or a test vector requires
-regenerating the values and documenting the numerical difference.
+in the test through its `expSE3`, `ImuIntegration`, `transformIMU`,
+`reproj_error`, and `GraphSolver` APIs. Changing the pinned commit or a test
+vector requires regenerating the values and documenting the numerical
+difference.

--- a/docs/mathematical-robotics-porting.md
+++ b/docs/mathematical-robotics-porting.md
@@ -1,0 +1,66 @@
+# MathematicalRobotics porting matrix
+
+This table tracks the RustRobotics counterpart of
+[scomup/MathematicalRobotics](https://github.com/scomup/MathematicalRobotics)
+at commit
+[`79600010f0c86179905a6960e5fce2bb7cc85d77`](https://github.com/scomup/MathematicalRobotics/tree/79600010f0c86179905a6960e5fce2bb7cc85d77).
+
+For this first-pass inventory, **ported** means that RustRobotics has an
+executable Rust implementation of the corresponding functionality. It does
+not require a line-by-line translation or a dedicated upstream parity test.
+The parity column records the smaller set that is also checked against pinned
+MathematicalRobotics numerical output.
+
+| Status | Meaning |
+|---|---|
+| ✅ Ported | Corresponding functionality is implemented in RustRobotics |
+| 🟡 Partial | The main functionality exists, but some APIs or variants in the grouped row are missing |
+| ⬜ Not ported | No corresponding Rust implementation was found |
+| ➖ Support | Demo GUI, plotting code, or bundled data rather than a core algorithm |
+
+## Summary
+
+| Ported | Partial | Not ported | Support |
+|---:|---:|---:|---:|
+| 19 | 3 | 3 | 2 |
+
+## Correspondence table
+
+| MathematicalRobotics source | Functionality | RustRobotics counterpart | Status | Pinned parity |
+|---|---|---|---|---|
+| [`filter/ekf.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/filter/ekf.py) | 2D odometry/GPS EKF | [`localization/ekf.rs`](../crates/rust_robotics_localization/src/ekf.rs) | ✅ Ported | — |
+| [`filter/particle_filter.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/filter/particle_filter.py) | 2D particle-filter localization | [`localization/particle_filter.rs`](../crates/rust_robotics_localization/src/particle_filter.rs) | ✅ Ported | — |
+| [`graph_optimization/graph_solver.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/graph_optimization/graph_solver.py) | Variables, factors, Hessian assembly, nonlinear solve | [`optimization/graph.rs`](../crates/rust_robotics_optimization/src/graph.rs), [`solver.rs`](../crates/rust_robotics_optimization/src/solver.rs), [`sparse.rs`](../crates/rust_robotics_optimization/src/sparse.rs) | ✅ Ported | SE(3) graph |
+| [`demo_pose2d_graph.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/graph_optimization/demo_pose2d_graph.py) | SE(2) prior/between factors and pose graph | [`pose_graph_optimization.rs`](../crates/rust_robotics_slam/src/pose_graph_optimization.rs) | ✅ Ported | — |
+| [`demo_pose3d_graph.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/graph_optimization/demo_pose3d_graph.py) | SE(3) prior/between factors and pose graph | [`pose_graph_optimization_3d.rs`](../crates/rust_robotics_slam/src/pose_graph_optimization_3d.rs) | ✅ Ported | ✅ 12-node loop |
+| [`demo_g2o_se2.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/graph_optimization/demo_g2o_se2.py), [`demo_g2o_se3.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/graph_optimization/demo_g2o_se3.py) | Solve imported SE(2)/SE(3) g2o graphs | [`g2o.rs`](../crates/rust_robotics_slam/src/g2o.rs), pose-graph modules above | ✅ Ported | — |
+| [`imls/imls.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/imls/imls.py) | PCA normals and 2D IMLS surface projection | [`mapping/imls.rs`](../crates/rust_robotics_mapping/src/imls.rs) | ✅ Ported | — |
+| [`imu_preintegration/preintegration.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/imu_preintegration/preintegration.py) | Navigation state, bias-aware IMU preintegration and prediction | [`imu_preintegration.rs`](../crates/rust_robotics_slam/src/imu_preintegration.rs) | ✅ Ported | ✅ Integration/prediction |
+| [`imu_preintegration/imu_factor.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/imu_preintegration/imu_factor.py) | IMU, navigation-state, bias, bias-change, position/velocity and transform factors | [`ImuFactor`, `NavStatePriorFactor`, `BiasPriorFactor`, `BiasBetweenFactor`, `PositionVelocityFactor`, `NavStateBetweenFactor`](../crates/rust_robotics_slam/src/imu_preintegration.rs) | ✅ Ported | Jacobians + IMU core |
+| [`kinematics/transfrom_velocity.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/kinematics/transfrom_velocity.py) | 2D/3D rigid-body velocity transforms | [`se2_adjoint`, `se3_adjoint`](../crates/rust_robotics_core/src/lie.rs) | ✅ Ported | — |
+| [`kinematics/transfrom_imu.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/kinematics/transfrom_imu.py) | IMU frame transform with centripetal and tangential lever-arm acceleration | [`ImuExtrinsics::transform`](../crates/rust_robotics_slam/src/imu_preintegration.rs) | ✅ Ported | ✅ Frame transform |
+| [`utilities/math_tools.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/utilities/math_tools.py) | Skew/unskew, SO(2), SE(2), SO(3), SE(3), inverses and Jacobians | [`core/lie.rs`](../crates/rust_robotics_core/src/lie.rs) | ✅ Ported | ✅ SE(3) exp/log |
+| [`utilities/math_tools.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/utilities/math_tools.py) | Numerical derivative and higher SO(3) differential helpers (`HSO3`, `dHinvSO3`, `dLogSO3`) | SO(3) left Jacobian and inverse in [`core/lie.rs`](../crates/rust_robotics_core/src/lie.rs); factor-specific finite-difference tests | 🟡 Partial | — |
+| [`optimization/gauss_newton.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/optimization/gauss_newton.py) | Gauss–Newton nonlinear least squares | [`optimization/solver.rs`](../crates/rust_robotics_optimization/src/solver.rs) | ✅ Ported | Through graph case |
+| [`utilities/robust_kernel.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/utilities/robust_kernel.py) | L2, L1, L4, Huber, Pseudo-Huber, Cauchy and Gaussian kernels | [`optimization/loss.rs`](../crates/rust_robotics_optimization/src/loss.rs): L2, Huber, Pseudo-Huber, Cauchy | 🟡 Partial | — |
+| [`robot_geometry/basic_geometry.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/robot_geometry/basic_geometry.py) | Line/plane estimation and point residuals | [`mapping/line_extraction.rs`](../crates/rust_robotics_mapping/src/line_extraction.rs), [`normal_vector_estimation.rs`](../crates/rust_robotics_mapping/src/normal_vector_estimation.rs), [`geometric_icp.rs`](../crates/rust_robotics_slam/src/geometric_icp.rs) | ✅ Ported | — |
+| [`demo_p2line_matching.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/robot_geometry/demo_p2line_matching.py) | Point-to-line ICP | [`point_to_line_icp_2d`](../crates/rust_robotics_slam/src/geometric_icp.rs) | ✅ Ported | — |
+| [`demo_p2plane_matching.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/robot_geometry/demo_p2plane_matching.py) | Point-to-plane ICP | [`point_to_plane_icp_3d`](../crates/rust_robotics_slam/src/geometric_icp.rs) | ✅ Ported | — |
+| [`demo_plane_cross_cube.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/robot_geometry/demo_plane_cross_cube.py) | Plane/cube intersection polygon | — | ⬜ Not ported | — |
+| [`slam/projection.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/slam/projection.py) | Pose/point transforms, pinhole projection and reprojection factors | [`bundle_adjustment.rs`](../crates/rust_robotics_slam/src/bundle_adjustment.rs), [`core/lie.rs`](../crates/rust_robotics_core/src/lie.rs) | ✅ Ported | ✅ Reprojection |
+| [`slam/demo_bundle_adjustment.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/slam/demo_bundle_adjustment.py) | Joint camera/landmark bundle adjustment | [`bundle_adjustment.rs`](../crates/rust_robotics_slam/src/bundle_adjustment.rs) | ✅ Ported | Projection core |
+| [`slam/load_ba_datasets.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/slam/load_ba_datasets.py) | BAL dataset loader | — | ⬜ Not ported | — |
+| [`utilities/math_tools.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/utilities/math_tools.py) | Quaternion/matrix conversion | `nalgebra::UnitQuaternion`, used by [`g2o.rs`](../crates/rust_robotics_slam/src/g2o.rs) and [`dataset.rs`](../crates/rust_robotics_slam/src/dataset.rs) | ✅ Ported | Round-trip tests |
+| [`utilities/pcd_io.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/utilities/pcd_io.py) | ASCII/binary PCD loader | — | ⬜ Not ported | — |
+| [`utilities/polygon.py`](https://github.com/scomup/MathematicalRobotics/blob/79600010f0c86179905a6960e5fce2bb7cc85d77/mathR/utilities/polygon.py) | Point-in-polygon and polygon boundary residual | Private point-in-polygon helper in [`grid_based_sweep_cpp.rs`](../crates/rust_robotics_planning/src/grid_based_sweep_cpp.rs); no reusable boundary-residual API | 🟡 Partial | — |
+| Plotting, Qt/OpenGL GUI and drawing helpers | Interactive visualization | Rust-native visualization and generated SVG/GIF examples exist, but exact GUIs are not port targets | ➖ Support | — |
+| Bundled BAL, g2o, PCD and NumPy samples | Demo/test input data | RustRobotics uses generated fixtures and EuRoC/KITTI loaders; upstream assets are not copied | ➖ Support | — |
+
+The pinned numerical checks and their tolerances are documented in the
+[MathematicalRobotics numerical parity report](./mathematical-robotics-parity.md).
+
+## Remaining port queue
+
+1. Add BAL and PCD readers.
+2. Add the remaining robust kernels and reusable polygon-boundary residual.
+3. Add plane/cube intersection if it is needed outside the original demo.


### PR DESCRIPTION
## Summary

- port MathematicalRobotics IMU extrinsic transforms with centripetal and tangential lever-arm correction
- add navigation-state, bias prior/random-walk, position/velocity, and relative navigation-state factors
- ingest EuRoC `imu0/sensor.yaml` `T_BS` and refine VIO navigation states plus time-varying biases from visual pose constraints
- add pinned MathematicalRobotics golden values, finite-difference Jacobian tests, bias observability coverage, and the porting matrix

## Impact

EuRoC and custom VIO inputs can now account for a displaced IMU and jointly refine one bias per keyframe instead of carrying one fixed bias through the entire sequence.

## Validation

- `cargo test -p rust_robotics_slam --all-targets`
- `cargo test --workspace --lib --tests --quiet`
- `cargo clippy -p rust_robotics_slam --all-targets -- -D warnings`
- `cargo doc -p rust_robotics_slam --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
